### PR TITLE
Follow-up: add stitched POI/climb coordinate regression coverage

### DIFF
--- a/tests/fixtures/climb.ts
+++ b/tests/fixtures/climb.ts
@@ -1,0 +1,25 @@
+import type { Climb } from "@/types";
+
+export function buildClimb(
+  id: string,
+  routeId: string,
+  startDistanceMeters: number,
+  endDistanceMeters: number,
+  overrides: Partial<Climb> = {},
+): Climb {
+  return {
+    id,
+    routeId,
+    name: id,
+    startDistanceMeters,
+    endDistanceMeters,
+    lengthMeters: endDistanceMeters - startDistanceMeters,
+    totalAscentMeters: 120,
+    startElevationMeters: 100,
+    endElevationMeters: 220,
+    averageGradientPercent: 7,
+    maxGradientPercent: 10,
+    difficultyScore: 100,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/collection.ts
+++ b/tests/fixtures/collection.ts
@@ -1,0 +1,56 @@
+import type { RoutePoint, StitchedCollection, StitchedSegmentInfo } from "@/types";
+
+export const stitchedSegmentsFixture: StitchedSegmentInfo[] = [
+  {
+    routeId: "r1",
+    routeName: "r1",
+    position: 0,
+    startPointIndex: 0,
+    endPointIndex: 1,
+    distanceOffsetMeters: 0,
+    segmentDistanceMeters: 1_000,
+    segmentAscentMeters: 100,
+    segmentDescentMeters: 0,
+  },
+  {
+    routeId: "r2",
+    routeName: "r2",
+    position: 1,
+    startPointIndex: 2,
+    endPointIndex: 3,
+    distanceOffsetMeters: 1_000,
+    segmentDistanceMeters: 2_000,
+    segmentAscentMeters: 200,
+    segmentDescentMeters: 100,
+  },
+];
+
+interface BuildStitchedCollectionOptions {
+  collectionId?: string;
+  points: RoutePoint[];
+  segments?: StitchedSegmentInfo[];
+  totalDistanceMeters?: number;
+  totalAscentMeters?: number;
+  totalDescentMeters?: number;
+  pointsByRouteId?: Record<string, RoutePoint[]>;
+}
+
+export function buildStitchedCollection({
+  collectionId = "c1",
+  points,
+  segments = stitchedSegmentsFixture,
+  totalDistanceMeters = points[points.length - 1]?.distanceFromStartMeters ?? 0,
+  totalAscentMeters = 300,
+  totalDescentMeters = 100,
+  pointsByRouteId = {},
+}: BuildStitchedCollectionOptions): StitchedCollection {
+  return {
+    collectionId,
+    points,
+    segments,
+    totalDistanceMeters,
+    totalAscentMeters,
+    totalDescentMeters,
+    pointsByRouteId,
+  };
+}

--- a/tests/fixtures/poi.ts
+++ b/tests/fixtures/poi.ts
@@ -1,0 +1,23 @@
+import type { POI } from "@/types";
+
+export function buildPoi(
+  id: string,
+  routeId: string,
+  distanceAlongRouteMeters: number,
+  overrides: Partial<POI> = {},
+): POI {
+  return {
+    id,
+    sourceId: id,
+    source: "osm",
+    name: id,
+    category: "water",
+    latitude: 0,
+    longitude: 0,
+    tags: {},
+    distanceFromRouteMeters: 0,
+    distanceAlongRouteMeters,
+    routeId,
+    ...overrides,
+  };
+}

--- a/tests/fixtures/route.ts
+++ b/tests/fixtures/route.ts
@@ -1,0 +1,11 @@
+import type { RoutePoint } from "@/types";
+
+export function buildRoutePoint(distanceFromStartMeters: number, idx: number): RoutePoint {
+  return {
+    latitude: 0,
+    longitude: idx,
+    elevationMeters: 100,
+    distanceFromStartMeters,
+    idx,
+  };
+}

--- a/tests/helpers/stitchedCollectionHarness.ts
+++ b/tests/helpers/stitchedCollectionHarness.ts
@@ -1,0 +1,39 @@
+import {
+  createCollectionStoreMockState,
+  resetCollectionStoreMockState,
+  type MockCollectionStoreState,
+} from "@/tests/mocks/collectionStore";
+import {
+  createPoiStoreMockState,
+  resetPoiStoreMockState,
+  type MockPoiStoreState,
+} from "@/tests/mocks/poiStore";
+import {
+  createRouteStoreMockState,
+  resetRouteStoreMockState,
+  type MockRouteStoreState,
+} from "@/tests/mocks/routeStore";
+
+export interface StitchedCollectionHarness {
+  routeState: MockRouteStoreState;
+  collectionState: MockCollectionStoreState;
+  poiState: MockPoiStoreState;
+  reset: () => void;
+}
+
+export function createStitchedCollectionHarness(): StitchedCollectionHarness {
+  const routeState = createRouteStoreMockState();
+  const collectionState = createCollectionStoreMockState();
+  const poiState = createPoiStoreMockState();
+
+  return {
+    routeState,
+    collectionState,
+    poiState,
+    reset: () => {
+      resetRouteStoreMockState(routeState);
+      resetCollectionStoreMockState(collectionState);
+      resetPoiStoreMockState(poiState);
+    },
+  };
+}

--- a/tests/mocks/collectionStore.ts
+++ b/tests/mocks/collectionStore.ts
@@ -1,0 +1,15 @@
+import type { StitchedCollection } from "@/types";
+
+export interface MockCollectionStoreState {
+  activeStitchedCollection: StitchedCollection | null;
+}
+
+export function createCollectionStoreMockState(): MockCollectionStoreState {
+  return {
+    activeStitchedCollection: null,
+  };
+}
+
+export function resetCollectionStoreMockState(state: MockCollectionStoreState): void {
+  state.activeStitchedCollection = null;
+}

--- a/tests/mocks/database.ts
+++ b/tests/mocks/database.ts
@@ -1,0 +1,7 @@
+import { vi } from "vitest";
+import type { getClimbsForRoute, updateClimbName } from "@/db/database";
+
+export const databaseMocks = {
+  getClimbsForRoute: vi.fn<typeof getClimbsForRoute>(),
+  updateClimbName: vi.fn<typeof updateClimbName>(),
+};

--- a/tests/mocks/etaCalculator.ts
+++ b/tests/mocks/etaCalculator.ts
@@ -1,0 +1,6 @@
+import { vi } from "vitest";
+import type { computeRouteETA } from "@/services/etaCalculator";
+
+export const etaCalculatorMocks = {
+  computeRouteETA: vi.fn<typeof computeRouteETA>(),
+};

--- a/tests/mocks/poiStore.ts
+++ b/tests/mocks/poiStore.ts
@@ -1,0 +1,15 @@
+import type { POI } from "@/types";
+
+export interface MockPoiStoreState {
+  pois: Record<string, POI[]>;
+}
+
+export function createPoiStoreMockState(): MockPoiStoreState {
+  return {
+    pois: {},
+  };
+}
+
+export function resetPoiStoreMockState(state: MockPoiStoreState): void {
+  state.pois = {};
+}

--- a/tests/mocks/reactNativeMmkv.ts
+++ b/tests/mocks/reactNativeMmkv.ts
@@ -1,0 +1,13 @@
+import { vi } from "vitest";
+
+export const reactNativeMmkvMocks = {
+  getString: vi.fn(() => null as string | null),
+  set: vi.fn(),
+};
+
+export function createMockMMKV() {
+  return {
+    getString: reactNativeMmkvMocks.getString,
+    set: reactNativeMmkvMocks.set,
+  };
+}

--- a/tests/mocks/routeStore.ts
+++ b/tests/mocks/routeStore.ts
@@ -1,0 +1,18 @@
+import type { RoutePoint, SnappedPosition } from "@/types";
+
+export interface MockRouteStoreState {
+  snappedPosition: Pick<SnappedPosition, "pointIndex"> | null;
+  visibleRoutePoints: Record<string, RoutePoint[]>;
+}
+
+export function createRouteStoreMockState(): MockRouteStoreState {
+  return {
+    snappedPosition: null,
+    visibleRoutePoints: {},
+  };
+}
+
+export function resetRouteStoreMockState(state: MockRouteStoreState): void {
+  state.snappedPosition = null;
+  state.visibleRoutePoints = {};
+}

--- a/tests/store/etaAndClimbCollectionBehavior.test.ts
+++ b/tests/store/etaAndClimbCollectionBehavior.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Climb, POI, RoutePoint, StitchedCollection, StitchedSegmentInfo } from "@/types";
+
+const {
+  mockComputeRouteETA,
+  mockRouteState,
+  mockCollectionState,
+  mockPoiState,
+  mockGetClimbsForRoute,
+  mockUpdateClimbName,
+} = vi.hoisted(() => ({
+  mockComputeRouteETA: vi.fn<(points: RoutePoint[]) => number[]>(),
+  mockRouteState: {
+    snappedPosition: null as { pointIndex: number } | null,
+    visibleRoutePoints: {} as Record<string, RoutePoint[]>,
+  },
+  mockCollectionState: {
+    activeStitchedCollection: null as StitchedCollection | null,
+  },
+  mockPoiState: {
+    pois: {} as Record<string, POI[]>,
+  },
+  mockGetClimbsForRoute: vi.fn(),
+  mockUpdateClimbName: vi.fn(),
+}));
+
+vi.mock("react-native-mmkv", () => ({
+  createMMKV: () => ({
+    getString: () => null,
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock("@/services/etaCalculator", async () => {
+  const actual = await vi.importActual<typeof import("@/services/etaCalculator")>(
+    "@/services/etaCalculator",
+  );
+  return {
+    ...actual,
+    computeRouteETA: mockComputeRouteETA,
+  };
+});
+
+vi.mock("@/store/routeStore", () => ({
+  useRouteStore: {
+    getState: () => mockRouteState,
+  },
+}));
+
+vi.mock("@/store/collectionStore", () => ({
+  useCollectionStore: {
+    getState: () => mockCollectionState,
+  },
+}));
+
+vi.mock("@/store/poiStore", () => ({
+  usePoiStore: {
+    getState: () => mockPoiState,
+  },
+}));
+
+vi.mock("@/db/database", () => ({
+  getClimbsForRoute: mockGetClimbsForRoute,
+  updateClimbName: mockUpdateClimbName,
+}));
+
+import { useEtaStore } from "@/store/etaStore";
+import { useClimbStore } from "@/store/climbStore";
+
+const point = (distanceFromStartMeters: number, idx: number): RoutePoint => ({
+  latitude: 0,
+  longitude: idx,
+  elevationMeters: 100,
+  distanceFromStartMeters,
+  idx,
+});
+
+const rawPoi = (id: string, routeId: string, distanceAlongRouteMeters: number): POI => ({
+  id,
+  sourceId: id,
+  source: "osm",
+  name: id,
+  category: "water",
+  latitude: 0,
+  longitude: 0,
+  tags: {},
+  distanceFromRouteMeters: 0,
+  distanceAlongRouteMeters,
+  routeId,
+});
+
+const climb = (
+  id: string,
+  routeId: string,
+  startDistanceMeters: number,
+  endDistanceMeters: number,
+): Climb => ({
+  id,
+  routeId,
+  name: id,
+  startDistanceMeters,
+  endDistanceMeters,
+  lengthMeters: endDistanceMeters - startDistanceMeters,
+  totalAscentMeters: 120,
+  startElevationMeters: 100,
+  endElevationMeters: 220,
+  averageGradientPercent: 7,
+  maxGradientPercent: 10,
+  difficultyScore: 100,
+});
+
+const segments: StitchedSegmentInfo[] = [
+  {
+    routeId: "r1",
+    routeName: "r1",
+    position: 0,
+    startPointIndex: 0,
+    endPointIndex: 1,
+    distanceOffsetMeters: 0,
+    segmentDistanceMeters: 1_000,
+    segmentAscentMeters: 100,
+    segmentDescentMeters: 0,
+  },
+  {
+    routeId: "r2",
+    routeName: "r2",
+    position: 1,
+    startPointIndex: 2,
+    endPointIndex: 3,
+    distanceOffsetMeters: 1_000,
+    segmentDistanceMeters: 2_000,
+    segmentAscentMeters: 200,
+    segmentDescentMeters: 100,
+  },
+];
+
+describe("stitched collection coordinate behavior", () => {
+  beforeEach(() => {
+    useEtaStore.setState({
+      cumulativeTime: null,
+      routeId: null,
+      cachedPoints: null,
+    });
+    useClimbStore.setState({
+      climbs: {},
+      selectedClimb: null,
+      currentClimbId: null,
+      isClimbZoomed: false,
+    });
+    mockRouteState.snappedPosition = null;
+    mockRouteState.visibleRoutePoints = {};
+    mockCollectionState.activeStitchedCollection = null;
+    mockPoiState.pois = {};
+    mockComputeRouteETA.mockReset();
+  });
+
+  it("applies segment offsets for POI ETA and supports segment 0 and later segments", () => {
+    const stitchedPoints = [point(0, 0), point(1_000, 1), point(2_000, 2), point(3_000, 3)];
+
+    useEtaStore.setState({
+      routeId: "c1",
+      cumulativeTime: [0, 100, 200, 300],
+      cachedPoints: stitchedPoints,
+    });
+
+    mockRouteState.snappedPosition = { pointIndex: 0 };
+    mockRouteState.visibleRoutePoints = { c1: stitchedPoints };
+    mockCollectionState.activeStitchedCollection = {
+      collectionId: "c1",
+      points: stitchedPoints,
+      segments,
+      totalDistanceMeters: 3_000,
+      totalAscentMeters: 300,
+      totalDescentMeters: 100,
+      pointsByRouteId: {},
+    };
+
+    const etaSegment0 = useEtaStore.getState().getETAToPOI(rawPoi("p0", "r1", 900));
+    const etaSegment1 = useEtaStore.getState().getETAToPOI(rawPoi("p1", "r2", 200));
+
+    expect(etaSegment0?.ridingTimeSeconds).toBe(90);
+    expect(etaSegment1?.ridingTimeSeconds).toBe(120);
+  });
+
+  it("uses canonical raw POI distance so pre-stitched POIs are not double-offset", () => {
+    const stitchedPoints = [point(0, 0), point(1_000, 1), point(2_000, 2), point(3_000, 3)];
+
+    useEtaStore.setState({
+      routeId: "c1",
+      cumulativeTime: [0, 100, 200, 300],
+      cachedPoints: stitchedPoints,
+    });
+
+    mockRouteState.snappedPosition = { pointIndex: 0 };
+    mockRouteState.visibleRoutePoints = { c1: stitchedPoints };
+    mockCollectionState.activeStitchedCollection = {
+      collectionId: "c1",
+      points: stitchedPoints,
+      segments,
+      totalDistanceMeters: 3_000,
+      totalAscentMeters: 300,
+      totalDescentMeters: 100,
+      pointsByRouteId: {},
+    };
+    mockPoiState.pois = {
+      r2: [rawPoi("poi-late", "r2", 200)],
+    };
+
+    const preStitched = rawPoi("poi-late", "r2", 1_200);
+    const eta = useEtaStore.getState().getETAToPOI(preStitched);
+
+    expect(eta?.ridingTimeSeconds).toBe(120);
+  });
+
+  it("recomputes ETA cache when collection variant swaps points array with same route id", () => {
+    const pointsA = [point(0, 0), point(1_000, 1)];
+    const pointsB = [point(0, 0), point(1_200, 1)];
+    mockComputeRouteETA.mockReturnValueOnce([0, 100]).mockReturnValueOnce([0, 140]);
+
+    useEtaStore.getState().computeETAForRoute("collection-1", pointsA);
+    useEtaStore.getState().computeETAForRoute("collection-1", pointsA);
+    useEtaStore.getState().computeETAForRoute("collection-1", pointsB);
+
+    expect(mockComputeRouteETA).toHaveBeenCalledTimes(2);
+    expect(useEtaStore.getState().cumulativeTime).toEqual([0, 140]);
+    expect(useEtaStore.getState().cachedPoints).toBe(pointsB);
+  });
+
+  it("offsets climb display coordinates for stitched segments and sorts by stitched distance", () => {
+    useClimbStore.setState({
+      climbs: {
+        r1: [climb("c1", "r1", 700, 900)],
+        r2: [climb("c2", "r2", 100, 400)],
+      },
+    });
+
+    const display = useClimbStore.getState().getClimbsForDisplay(["r1", "r2"], segments);
+
+    expect(display.map((c) => [c.id, c.startDistanceMeters, c.endDistanceMeters])).toEqual([
+      ["c1", 700, 900],
+      ["c2", 1_100, 1_400],
+    ]);
+  });
+});

--- a/tests/store/etaAndClimbCollectionBehavior.test.ts
+++ b/tests/store/etaAndClimbCollectionBehavior.test.ts
@@ -1,34 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Climb, POI, RoutePoint, StitchedCollection, StitchedSegmentInfo } from "@/types";
+import { buildClimb } from "@/tests/fixtures/climb";
+import { buildStitchedCollection, stitchedSegmentsFixture } from "@/tests/fixtures/collection";
+import { buildPoi } from "@/tests/fixtures/poi";
+import { buildRoutePoint } from "@/tests/fixtures/route";
+import { createStitchedCollectionHarness } from "@/tests/helpers/stitchedCollectionHarness";
+import { databaseMocks } from "@/tests/mocks/database";
+import { etaCalculatorMocks } from "@/tests/mocks/etaCalculator";
+import { createMockMMKV } from "@/tests/mocks/reactNativeMmkv";
 
-const {
-  mockComputeRouteETA,
-  mockRouteState,
-  mockCollectionState,
-  mockPoiState,
-  mockGetClimbsForRoute,
-  mockUpdateClimbName,
-} = vi.hoisted(() => ({
-  mockComputeRouteETA: vi.fn<(points: RoutePoint[]) => number[]>(),
-  mockRouteState: {
-    snappedPosition: null as { pointIndex: number } | null,
-    visibleRoutePoints: {} as Record<string, RoutePoint[]>,
-  },
-  mockCollectionState: {
-    activeStitchedCollection: null as StitchedCollection | null,
-  },
-  mockPoiState: {
-    pois: {} as Record<string, POI[]>,
-  },
-  mockGetClimbsForRoute: vi.fn(),
-  mockUpdateClimbName: vi.fn(),
-}));
+const stitchedHarness = createStitchedCollectionHarness();
 
 vi.mock("react-native-mmkv", () => ({
-  createMMKV: () => ({
-    getString: () => null,
-    set: vi.fn(),
-  }),
+  createMMKV: createMockMMKV,
 }));
 
 vi.mock("@/services/etaCalculator", async () => {
@@ -37,102 +20,35 @@ vi.mock("@/services/etaCalculator", async () => {
   );
   return {
     ...actual,
-    computeRouteETA: mockComputeRouteETA,
+    computeRouteETA: etaCalculatorMocks.computeRouteETA,
   };
 });
 
 vi.mock("@/store/routeStore", () => ({
   useRouteStore: {
-    getState: () => mockRouteState,
+    getState: () => stitchedHarness.routeState,
   },
 }));
 
 vi.mock("@/store/collectionStore", () => ({
   useCollectionStore: {
-    getState: () => mockCollectionState,
+    getState: () => stitchedHarness.collectionState,
   },
 }));
 
 vi.mock("@/store/poiStore", () => ({
   usePoiStore: {
-    getState: () => mockPoiState,
+    getState: () => stitchedHarness.poiState,
   },
 }));
 
 vi.mock("@/db/database", () => ({
-  getClimbsForRoute: mockGetClimbsForRoute,
-  updateClimbName: mockUpdateClimbName,
+  getClimbsForRoute: databaseMocks.getClimbsForRoute,
+  updateClimbName: databaseMocks.updateClimbName,
 }));
 
 import { useEtaStore } from "@/store/etaStore";
 import { useClimbStore } from "@/store/climbStore";
-
-const point = (distanceFromStartMeters: number, idx: number): RoutePoint => ({
-  latitude: 0,
-  longitude: idx,
-  elevationMeters: 100,
-  distanceFromStartMeters,
-  idx,
-});
-
-const rawPoi = (id: string, routeId: string, distanceAlongRouteMeters: number): POI => ({
-  id,
-  sourceId: id,
-  source: "osm",
-  name: id,
-  category: "water",
-  latitude: 0,
-  longitude: 0,
-  tags: {},
-  distanceFromRouteMeters: 0,
-  distanceAlongRouteMeters,
-  routeId,
-});
-
-const climb = (
-  id: string,
-  routeId: string,
-  startDistanceMeters: number,
-  endDistanceMeters: number,
-): Climb => ({
-  id,
-  routeId,
-  name: id,
-  startDistanceMeters,
-  endDistanceMeters,
-  lengthMeters: endDistanceMeters - startDistanceMeters,
-  totalAscentMeters: 120,
-  startElevationMeters: 100,
-  endElevationMeters: 220,
-  averageGradientPercent: 7,
-  maxGradientPercent: 10,
-  difficultyScore: 100,
-});
-
-const segments: StitchedSegmentInfo[] = [
-  {
-    routeId: "r1",
-    routeName: "r1",
-    position: 0,
-    startPointIndex: 0,
-    endPointIndex: 1,
-    distanceOffsetMeters: 0,
-    segmentDistanceMeters: 1_000,
-    segmentAscentMeters: 100,
-    segmentDescentMeters: 0,
-  },
-  {
-    routeId: "r2",
-    routeName: "r2",
-    position: 1,
-    startPointIndex: 2,
-    endPointIndex: 3,
-    distanceOffsetMeters: 1_000,
-    segmentDistanceMeters: 2_000,
-    segmentAscentMeters: 200,
-    segmentDescentMeters: 100,
-  },
-];
 
 describe("stitched collection coordinate behavior", () => {
   beforeEach(() => {
@@ -147,15 +63,19 @@ describe("stitched collection coordinate behavior", () => {
       currentClimbId: null,
       isClimbZoomed: false,
     });
-    mockRouteState.snappedPosition = null;
-    mockRouteState.visibleRoutePoints = {};
-    mockCollectionState.activeStitchedCollection = null;
-    mockPoiState.pois = {};
-    mockComputeRouteETA.mockReset();
+    stitchedHarness.reset();
+    etaCalculatorMocks.computeRouteETA.mockReset();
+    databaseMocks.getClimbsForRoute.mockReset();
+    databaseMocks.updateClimbName.mockReset();
   });
 
   it("applies segment offsets for POI ETA and supports segment 0 and later segments", () => {
-    const stitchedPoints = [point(0, 0), point(1_000, 1), point(2_000, 2), point(3_000, 3)];
+    const stitchedPoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+      buildRoutePoint(3_000, 3),
+    ];
 
     useEtaStore.setState({
       routeId: "c1",
@@ -163,27 +83,26 @@ describe("stitched collection coordinate behavior", () => {
       cachedPoints: stitchedPoints,
     });
 
-    mockRouteState.snappedPosition = { pointIndex: 0 };
-    mockRouteState.visibleRoutePoints = { c1: stitchedPoints };
-    mockCollectionState.activeStitchedCollection = {
-      collectionId: "c1",
+    stitchedHarness.routeState.snappedPosition = { pointIndex: 0 };
+    stitchedHarness.routeState.visibleRoutePoints = { c1: stitchedPoints };
+    stitchedHarness.collectionState.activeStitchedCollection = buildStitchedCollection({
       points: stitchedPoints,
-      segments,
-      totalDistanceMeters: 3_000,
-      totalAscentMeters: 300,
-      totalDescentMeters: 100,
-      pointsByRouteId: {},
-    };
+    });
 
-    const etaSegment0 = useEtaStore.getState().getETAToPOI(rawPoi("p0", "r1", 900));
-    const etaSegment1 = useEtaStore.getState().getETAToPOI(rawPoi("p1", "r2", 200));
+    const etaSegment0 = useEtaStore.getState().getETAToPOI(buildPoi("p0", "r1", 900));
+    const etaSegment1 = useEtaStore.getState().getETAToPOI(buildPoi("p1", "r2", 200));
 
     expect(etaSegment0?.ridingTimeSeconds).toBe(90);
     expect(etaSegment1?.ridingTimeSeconds).toBe(120);
   });
 
   it("uses canonical raw POI distance so pre-stitched POIs are not double-offset", () => {
-    const stitchedPoints = [point(0, 0), point(1_000, 1), point(2_000, 2), point(3_000, 3)];
+    const stitchedPoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+      buildRoutePoint(3_000, 3),
+    ];
 
     useEtaStore.setState({
       routeId: "c1",
@@ -191,37 +110,31 @@ describe("stitched collection coordinate behavior", () => {
       cachedPoints: stitchedPoints,
     });
 
-    mockRouteState.snappedPosition = { pointIndex: 0 };
-    mockRouteState.visibleRoutePoints = { c1: stitchedPoints };
-    mockCollectionState.activeStitchedCollection = {
-      collectionId: "c1",
+    stitchedHarness.routeState.snappedPosition = { pointIndex: 0 };
+    stitchedHarness.routeState.visibleRoutePoints = { c1: stitchedPoints };
+    stitchedHarness.collectionState.activeStitchedCollection = buildStitchedCollection({
       points: stitchedPoints,
-      segments,
-      totalDistanceMeters: 3_000,
-      totalAscentMeters: 300,
-      totalDescentMeters: 100,
-      pointsByRouteId: {},
-    };
-    mockPoiState.pois = {
-      r2: [rawPoi("poi-late", "r2", 200)],
+    });
+    stitchedHarness.poiState.pois = {
+      r2: [buildPoi("poi-late", "r2", 200)],
     };
 
-    const preStitched = rawPoi("poi-late", "r2", 1_200);
+    const preStitched = buildPoi("poi-late", "r2", 1_200);
     const eta = useEtaStore.getState().getETAToPOI(preStitched);
 
     expect(eta?.ridingTimeSeconds).toBe(120);
   });
 
   it("recomputes ETA cache when collection variant swaps points array with same route id", () => {
-    const pointsA = [point(0, 0), point(1_000, 1)];
-    const pointsB = [point(0, 0), point(1_200, 1)];
-    mockComputeRouteETA.mockReturnValueOnce([0, 100]).mockReturnValueOnce([0, 140]);
+    const pointsA = [buildRoutePoint(0, 0), buildRoutePoint(1_000, 1)];
+    const pointsB = [buildRoutePoint(0, 0), buildRoutePoint(1_200, 1)];
+    etaCalculatorMocks.computeRouteETA.mockReturnValueOnce([0, 100]).mockReturnValueOnce([0, 140]);
 
     useEtaStore.getState().computeETAForRoute("collection-1", pointsA);
     useEtaStore.getState().computeETAForRoute("collection-1", pointsA);
     useEtaStore.getState().computeETAForRoute("collection-1", pointsB);
 
-    expect(mockComputeRouteETA).toHaveBeenCalledTimes(2);
+    expect(etaCalculatorMocks.computeRouteETA).toHaveBeenCalledTimes(2);
     expect(useEtaStore.getState().cumulativeTime).toEqual([0, 140]);
     expect(useEtaStore.getState().cachedPoints).toBe(pointsB);
   });
@@ -229,12 +142,14 @@ describe("stitched collection coordinate behavior", () => {
   it("offsets climb display coordinates for stitched segments and sorts by stitched distance", () => {
     useClimbStore.setState({
       climbs: {
-        r1: [climb("c1", "r1", 700, 900)],
-        r2: [climb("c2", "r2", 100, 400)],
+        r1: [buildClimb("c1", "r1", 700, 900)],
+        r2: [buildClimb("c2", "r2", 100, 400)],
       },
     });
 
-    const display = useClimbStore.getState().getClimbsForDisplay(["r1", "r2"], segments);
+    const display = useClimbStore
+      .getState()
+      .getClimbsForDisplay(["r1", "r2"], stitchedSegmentsFixture);
 
     expect(display.map((c) => [c.id, c.startDistanceMeters, c.endDistanceMeters])).toEqual([
       ["c1", 700, 900],


### PR DESCRIPTION
### Motivation

- Prevent regressions caused by stitched collections where POIs and climbs are stored in per-route (raw) coordinates but displayed/ETAd against stitched (cumulative) coordinates. 
- Cover edge cases that previously produced subtle bugs: POIs in segment 0 vs later segments, callers passing pre-stitched POIs, and collection variant swaps that keep the same id but change the points array reference. 
- Ensure climb display offsets and sorting behave correctly when routes are stitched into a collection.

### Description

- Add a pure-logic test suite at `tests/store/etaAndClimbCollectionBehavior.test.ts` that exercises ETA and climb behavior for stitched collections. 
- Introduce deterministic mocks for `react-native-mmkv`, `@/services/etaCalculator` (override `computeRouteETA`), `@/store/routeStore`, `@/store/collectionStore`, `@/store/poiStore`, and `@/db/database` to keep tests Node-friendly and isolated. 
- Tests cover: POI ETA calculation with segment offsets for segment 0 and later segments, canonical raw POI lookup to avoid double-applying stitch offsets for pre-stitched POIs, recompute behavior when `computeETAForRoute` is called with the same collection id but a different points array reference, and climb display coordinate offsetting + sorting for stitched segments. 
- This PR is a follow-up regression coverage change and notes a dependency on #2.

### Testing

- Ran `npm test -- --run tests/store/etaAndClimbCollectionBehavior.test.ts` (initial run failed due to missing test runner). 
- Ran `npm install` to ensure dev/test dependencies were present. 
- Re-ran `npm test -- --run tests/store/etaAndClimbCollectionBehavior.test.ts` and the file passed: 1 test file, 4 tests — all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba80a4e6c8331b00d457916ddf527)