### PR TITLE
[codex] Unify displayed POI and climb distances

### DIFF
--- a/app/route/[id].tsx
+++ b/app/route/[id].tsx
@@ -12,6 +12,7 @@ import type { RouteWithPoints, Climb } from "@/types";
 import { useMapStyle } from "@/hooks/useMapStyle";
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import { computeElevationProgress, computeBounds } from "@/utils/geo";
+import { toDisplayClimbs, toDisplayPOIs } from "@/services/displayDistance";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import RouteLayer from "@/components/map/RouteLayer";
 import StatBox from "@/components/common/StatBox";
@@ -70,10 +71,12 @@ export default function RouteDetailScreen() {
 
   const chartPOIs = useMemo(() => {
     if (!id) return [];
-    return getStarredPOIs(id);
+    return toDisplayPOIs(getStarredPOIs(id));
     // starredPOIIds is a reactivity trigger: getStarredPOIs reads store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, getStarredPOIs, starredPOIIds]);
+
+  const chartClimbs = useMemo(() => toDisplayClimbs(routeClimbs), [routeClimbs]);
 
   const bounds = useMemo(() => {
     if (!route?.points.length) return null;
@@ -162,7 +165,7 @@ export default function RouteDetailScreen() {
             currentPointIndex={currentPointIndex}
             pois={chartPOIs}
             onPOIPress={setSelectedPOI}
-            climbs={routeClimbs}
+            climbs={chartClimbs}
           />
         </View>
 

--- a/components/climb/ClimbListItem.tsx
+++ b/components/climb/ClimbListItem.tsx
@@ -5,13 +5,13 @@ import { useSettingsStore } from "@/store/settingsStore";
 import { useEtaStore } from "@/store/etaStore";
 import { climbDifficultyColor } from "@/constants/climbHelpers";
 import { formatDistance, formatElevation, formatDuration, formatETA } from "@/utils/formatters";
-import type { Climb } from "@/types";
+import type { DisplayClimb } from "@/types";
 
 interface ClimbListItemProps {
-  climb: Climb;
+  climb: DisplayClimb;
   currentDistAlongRoute: number | null;
   isPast: boolean;
-  onPress: (climb: Climb) => void;
+  onPress: (climb: DisplayClimb) => void;
 }
 
 export default function ClimbListItem({
@@ -26,11 +26,11 @@ export default function ClimbListItem({
   const diffColor = climbDifficultyColor(climb.difficultyScore);
 
   const distAhead =
-    currentDistAlongRoute != null ? climb.startDistanceMeters - currentDistAlongRoute : null;
+    currentDistAlongRoute != null ? climb.effectiveDistanceMeters - currentDistAlongRoute : null;
 
   const etaResult = useMemo(
-    () => getETAToDistance(climb.startDistanceMeters),
-    [climb.startDistanceMeters, getETAToDistance],
+    () => getETAToDistance(climb.effectiveDistanceMeters),
+    [climb.effectiveDistanceMeters, getETAToDistance],
   );
 
   return (

--- a/components/elevation/ElevationProfile.tsx
+++ b/components/elevation/ElevationProfile.tsx
@@ -24,7 +24,7 @@ import { formatDistance, formatElevation } from "@/utils/formatters";
 import { getOpeningHoursStatus } from "@/services/openingHoursParser";
 import { categoryColor, categoryLetter, ohStatusColorKey } from "@/constants/poiHelpers";
 import { climbDifficultyColor } from "@/constants/climbHelpers";
-import type { RoutePoint, UnitSystem, POI, Climb } from "@/types";
+import type { RoutePoint, UnitSystem, DisplayPOI, DisplayClimb } from "@/types";
 
 interface SegmentBoundary {
   distanceMeters: number;
@@ -40,11 +40,11 @@ interface ElevationProfileProps {
   showLegend?: boolean;
   /** Offset added to X-axis labels so they show absolute route distance */
   distanceOffsetMeters?: number;
-  pois?: POI[];
-  onPOIPress?: (poi: POI) => void;
+  pois?: DisplayPOI[];
+  onPOIPress?: (poi: DisplayPOI) => void;
   /** Vertical boundary lines at segment junctions (for stitched collections) */
   segmentBoundaries?: SegmentBoundary[];
-  climbs?: Climb[];
+  climbs?: DisplayClimb[];
   /** Force fit-to-width — disables horizontal scrolling and the overview minimap */
   fitToWidth?: boolean;
 }
@@ -193,7 +193,7 @@ function buildLinePath(
 }
 
 interface POIMarkerPos {
-  poi: POI;
+  poi: DisplayPOI;
   x: number;
   y: number;
   color: string;
@@ -335,7 +335,7 @@ export default function ElevationProfile({
 
     const markers: POIMarkerPos[] = [];
     for (const poi of pois) {
-      const localDist = poi.distanceAlongRouteMeters - distanceOffsetMeters;
+      const localDist = poi.effectiveDistanceMeters - distanceOffsetMeters;
       if (localDist < 0 || localDist > totalMeters) continue;
 
       const x = xScale(localDist);
@@ -373,8 +373,8 @@ export default function ElevationProfile({
 
     const regions: { id: string; color: string; fillPath: string }[] = [];
     for (const climb of climbs) {
-      const localStart = climb.startDistanceMeters - distanceOffsetMeters;
-      const localEnd = climb.endDistanceMeters - distanceOffsetMeters;
+      const localStart = climb.effectiveStartDistanceMeters - distanceOffsetMeters;
+      const localEnd = climb.effectiveEndDistanceMeters - distanceOffsetMeters;
       const visStart = Math.max(0, localStart);
       const visEnd = Math.min(totalMeters, localEnd);
       if (visStart >= visEnd) continue;

--- a/components/map/ClimbHighlightLayer.tsx
+++ b/components/map/ClimbHighlightLayer.tsx
@@ -2,27 +2,21 @@ import React, { useMemo } from "react";
 import { ShapeSource, LineLayer } from "@rnmapbox/maps";
 import { gradientColor } from "@/theme/elevation";
 import { useThemeColors } from "@/theme";
-import type { Climb, RoutePoint } from "@/types";
+import type { DisplayClimb, RoutePoint } from "@/types";
 
 interface ClimbHighlightLayerProps {
-  climb: Climb;
+  climb: DisplayClimb;
   points: RoutePoint[];
-  /** Offset to add to climb distances (for collections) */
-  distanceOffset?: number;
 }
 
 /**
  * Renders a climb segment on the map with a smooth gradient-colored line.
  * Uses Mapbox lineGradient on a single LineString for seamless color blending.
  */
-export default function ClimbHighlightLayer({
-  climb,
-  points,
-  distanceOffset = 0,
-}: ClimbHighlightLayerProps) {
+export default function ClimbHighlightLayer({ climb, points }: ClimbHighlightLayerProps) {
   const colors = useThemeColors();
-  const climbStart = climb.startDistanceMeters + distanceOffset;
-  const climbEnd = climb.endDistanceMeters + distanceOffset;
+  const climbStart = climb.effectiveStartDistanceMeters;
+  const climbEnd = climb.effectiveEndDistanceMeters;
 
   const { geoJSON, gradientExpr } = useMemo(() => {
     if (points.length < 2) return { geoJSON: null, gradientExpr: null };

--- a/components/map/ClimbTabContent.tsx
+++ b/components/map/ClimbTabContent.tsx
@@ -24,7 +24,7 @@ import { formatDistance, formatElevation } from "@/utils/formatters";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import ClimbListItem from "@/components/climb/ClimbListItem";
 import { resolveActiveClimb } from "@/utils/climbSelect";
-import type { Climb, ActiveRouteData } from "@/types";
+import type { ActiveRouteData, DisplayClimb } from "@/types";
 
 interface ClimbTabContentProps {
   activeData: ActiveRouteData | null;
@@ -49,7 +49,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
 
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState("");
-  const [editingClimb, setEditingClimb] = useState<Climb | null>(null);
+  const [editingClimb, setEditingClimb] = useState<DisplayClimb | null>(null);
   const [graphHeight, setGraphHeight] = useState(0);
 
   const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
@@ -73,7 +73,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
 
   const distToStart = useMemo(() => {
     if (!climb || currentDist == null) return null;
-    return climb.startDistanceMeters - currentDist;
+    return climb.effectiveDistanceMeters - currentDist;
   }, [climb, currentDist]);
 
   const climbProfile = useMemo(() => {
@@ -81,12 +81,12 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
     const points = activeData.points;
     let startIdx = 0;
     for (let i = 0; i < points.length; i++) {
-      if (points[i].distanceFromStartMeters >= climb.startDistanceMeters) {
+      if (points[i].distanceFromStartMeters >= climb.effectiveStartDistanceMeters) {
         startIdx = Math.max(0, i - 1);
         break;
       }
     }
-    const sliceLength = climb.endDistanceMeters - points[startIdx].distanceFromStartMeters;
+    const sliceLength = climb.effectiveEndDistanceMeters - points[startIdx].distanceFromStartMeters;
     if (sliceLength <= 0) return null;
     const sliced = extractRouteSlice(points, startIdx, sliceLength);
     if (sliced.length < 2) return null;
@@ -123,13 +123,15 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
   const sortedClimbs = useMemo(
     () =>
       isExpanded
-        ? [...displayedClimbs].sort((a, b) => a.startDistanceMeters - b.startDistanceMeters)
+        ? [...displayedClimbs].sort(
+            (a, b) => a.effectiveStartDistanceMeters - b.effectiveStartDistanceMeters,
+          )
         : [],
     [isExpanded, displayedClimbs],
   );
 
   const handleClimbPress = useCallback(
-    (c: Climb) => {
+    (c: DisplayClimb) => {
       setSelectedClimb(c);
     },
     [setSelectedClimb],
@@ -259,7 +261,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
               <ClimbListItem
                 climb={item}
                 currentDistAlongRoute={currentDist}
-                isPast={currentDist != null && item.endDistanceMeters < currentDist}
+                isPast={currentDist != null && item.effectiveEndDistanceMeters < currentDist}
                 onPress={handleClimbPress}
               />
             )}

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -316,8 +316,8 @@ export default function MapScreen() {
   // Fly to highlighted climb bounds
   useEffect(() => {
     if (!highlightedClimb || !activeRoutePoints?.length) return;
-    const climbStart = highlightedClimb.startDistanceMeters;
-    const climbEnd = highlightedClimb.endDistanceMeters;
+    const climbStart = highlightedClimb.effectiveStartDistanceMeters;
+    const climbEnd = highlightedClimb.effectiveEndDistanceMeters;
 
     let minLat = 90,
       maxLat = -90,
@@ -376,7 +376,11 @@ export default function MapScreen() {
           );
         })}
         {activeRouteIds.length > 0 && (
-          <POILayer key={mapStyle.styleKey} routeIds={activeRouteIds} />
+          <POILayer
+            key={mapStyle.styleKey}
+            routeIds={activeRouteIds}
+            segments={activeData?.segments ?? null}
+          />
         )}
         {highlightedClimb && activeRoutePoints && (
           <ClimbHighlightLayer climb={highlightedClimb} points={activeRoutePoints} />

--- a/components/map/POILayer.tsx
+++ b/components/map/POILayer.tsx
@@ -4,15 +4,18 @@ import { usePoiStore } from "@/store/poiStore";
 import { useThemeColors } from "@/theme";
 import { POI_CATEGORIES } from "@/constants";
 import { haversineDistance } from "@/utils/geo";
-import type { POI } from "@/types";
+import { toDisplayPOIs } from "@/services/displayDistance";
+import { stitchPOIs } from "@/services/stitchingService";
+import type { DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
 
 const categoryColorMap = Object.fromEntries(POI_CATEGORIES.map((c) => [c.key, c.color]));
 
 interface POILayerProps {
   routeIds: string[];
+  segments: StitchedSegmentInfo[] | null;
 }
 
-export default function POILayer({ routeIds }: POILayerProps) {
+export default function POILayer({ routeIds, segments }: POILayerProps) {
   const getVisiblePOIs = usePoiStore((s) => s.getVisiblePOIs);
   const enabledCategories = usePoiStore((s) => s.enabledCategories);
   const starredPOIIds = usePoiStore((s) => s.starredPOIIds);
@@ -21,13 +24,21 @@ export default function POILayer({ routeIds }: POILayerProps) {
   const colors = useThemeColors();
 
   const visiblePOIs = useMemo(() => {
-    const combined: POI[] = [];
+    if (segments) {
+      const poisByRoute: Record<string, POI[]> = {};
+      for (const routeId of routeIds) {
+        poisByRoute[routeId] = getVisiblePOIs(routeId);
+      }
+      return stitchPOIs(segments, poisByRoute);
+    }
+
+    const combined: DisplayPOI[] = [];
     for (const routeId of routeIds) {
-      combined.push(...getVisiblePOIs(routeId));
+      combined.push(...toDisplayPOIs(getVisiblePOIs(routeId)));
     }
     return combined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeIds, allPois, enabledCategories, starredPOIIds]);
+  }, [routeIds, segments, allPois, enabledCategories, starredPOIIds]);
 
   const geoJSON = useMemo(
     (): GeoJSON.FeatureCollection => ({
@@ -57,7 +68,7 @@ export default function POILayer({ routeIds }: POILayerProps) {
 
       // When multiple features overlap, pick the one closest to the tap point
       const tapCoord = event?.coordinates;
-      let bestPoi: POI | undefined;
+      let bestPoi: DisplayPOI | undefined;
 
       if (tapCoord && features.length > 1) {
         let bestDist = Infinity;

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -15,16 +15,16 @@ import { useRouteStore } from "@/store/routeStore";
 import { usePoiStore } from "@/store/poiStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useEtaStore } from "@/store/etaStore";
-import { useActiveRouteData } from "@/hooks/useActiveRouteData";
 import { POI_CATEGORIES, POI_BEHIND_THRESHOLD_M } from "@/constants";
 import { POI_ICON_MAP } from "@/constants/poiIcons";
 import { ohStatusColorKey } from "@/constants/poiHelpers";
 import { formatDistance, formatDuration, formatETA } from "@/utils/formatters";
 import { getOpeningHoursStatus, isOpenAt, getDaySchedules } from "@/services/openingHoursParser";
 import { stitchPOIs } from "@/services/stitchingService";
+import { toDisplayPOIs } from "@/services/displayDistance";
 import POIFilterBar from "@/components/map/POIFilterBar";
 import POIListItem from "@/components/poi/POIListItem";
-import type { ActiveRouteData, POI } from "@/types";
+import type { ActiveRouteData, DisplayPOI, POI } from "@/types";
 
 interface POITabContentProps {
   activeData: ActiveRouteData | null;
@@ -54,37 +54,42 @@ export default function POITabContent({ activeData }: POITabContentProps) {
 
   const starredUpcoming = useMemo(() => {
     if (routeIds.length === 0) return [];
-    const allStarred: (POI & { effectiveDist: number; ridingTimeSeconds: number | null })[] = [];
+    const poisByRoute: Record<string, POI[]> = {};
     for (const routeId of routeIds) {
-      const pois = getStarredPOIs(routeId);
-      const offset = segments?.find((s) => s.routeId === routeId)?.distanceOffsetMeters ?? 0;
-      for (const poi of pois) {
-        const effDist = poi.distanceAlongRouteMeters + offset;
-        let ridingTime: number | null = null;
-        if (
-          currentIdx != null &&
-          cumulativeTime &&
-          routePoints &&
-          currentDist != null &&
-          effDist > currentDist
-        ) {
-          let poiIdx = currentIdx;
-          for (let i = currentIdx; i < routePoints.length; i++) {
-            if (routePoints[i].distanceFromStartMeters >= effDist) {
-              poiIdx = i;
-              break;
-            }
-            poiIdx = i;
-          }
-          const seconds = cumulativeTime[poiIdx] - cumulativeTime[currentIdx];
-          if (seconds > 0) ridingTime = seconds;
-        }
-        allStarred.push({ ...poi, effectiveDist: effDist, ridingTimeSeconds: ridingTime });
-      }
+      poisByRoute[routeId] = getStarredPOIs(routeId);
     }
-    allStarred.sort((a, b) => a.effectiveDist - b.effectiveDist);
+    const displayed = segments
+      ? stitchPOIs(segments, poisByRoute)
+      : routeIds.flatMap((routeId) => toDisplayPOIs(poisByRoute[routeId] ?? []));
+    const allStarred: (DisplayPOI & { ridingTimeSeconds: number | null })[] = [];
+    for (const poi of displayed) {
+      const effectiveDist = poi.effectiveDistanceMeters;
+      let ridingTime: number | null = null;
+      if (
+        currentIdx != null &&
+        cumulativeTime &&
+        routePoints &&
+        currentDist != null &&
+        effectiveDist > currentDist
+      ) {
+        let poiIdx = currentIdx;
+        for (let i = currentIdx; i < routePoints.length; i++) {
+          if (routePoints[i].distanceFromStartMeters >= effectiveDist) {
+            poiIdx = i;
+            break;
+          }
+          poiIdx = i;
+        }
+        const seconds = cumulativeTime[poiIdx] - cumulativeTime[currentIdx];
+        if (seconds > 0) ridingTime = seconds;
+      }
+      allStarred.push({ ...poi, ridingTimeSeconds: ridingTime });
+    }
+    allStarred.sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
     if (currentDist == null) return allStarred;
-    return allStarred.filter((p) => p.effectiveDist >= currentDist - POI_BEHIND_THRESHOLD_M);
+    return allStarred.filter(
+      (p) => p.effectiveDistanceMeters >= currentDist - POI_BEHIND_THRESHOLD_M,
+    );
     // starredPOIIds is a reactivity trigger: getStarredPOIs reads from store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -116,20 +121,18 @@ export default function POITabContent({ activeData }: POITabContentProps) {
       }
       return stitchPOIs(segments, poisByRoute);
     }
-    return routeIds.length > 0 ? getVisiblePOIs(routeIds[0]) : [];
+    return routeIds.length > 0 ? toDisplayPOIs(getVisiblePOIs(routeIds[0])) : [];
     // allPois/enabledCategories/starredPOIIds are reactivity triggers: getVisiblePOIs reads store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isExpanded, routeIds, segments, allPois, enabledCategories, starredPOIIds]);
 
   const sortedAllPOIs = useMemo(() => {
     if (currentDist == null) {
-      return [...visiblePOIs].sort(
-        (a, b) => a.distanceAlongRouteMeters - b.distanceAlongRouteMeters,
-      );
+      return [...visiblePOIs].sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
     }
     return visiblePOIs
-      .filter((p) => p.distanceAlongRouteMeters >= currentDist - POI_BEHIND_THRESHOLD_M)
-      .sort((a, b) => a.distanceAlongRouteMeters - b.distanceAlongRouteMeters);
+      .filter((p) => p.effectiveDistanceMeters >= currentDist - POI_BEHIND_THRESHOLD_M)
+      .sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
   }, [visiblePOIs, currentDist]);
 
   const filteredPOIs = useMemo(() => {
@@ -139,9 +142,8 @@ export default function POITabContent({ activeData }: POITabContentProps) {
   }, [sortedAllPOIs, searchQuery]);
 
   const handlePOIPress = useCallback(
-    (poi: POI) => {
-      const raw = usePoiStore.getState().pois[poi.routeId]?.find((p) => p.id === poi.id);
-      setSelectedPOI(raw ?? poi);
+    (poi: DisplayPOI) => {
+      setSelectedPOI(poi);
     },
     [setSelectedPOI],
   );
@@ -224,15 +226,9 @@ export default function POITabContent({ activeData }: POITabContentProps) {
             renderItem={({ item }) => (
               <CompactPOIRow
                 poi={item}
-                effectiveDist={item.effectiveDist}
                 currentDist={currentDist}
                 ridingTimeSeconds={item.ridingTimeSeconds}
-                onPress={() => {
-                  const raw = usePoiStore
-                    .getState()
-                    .pois[item.routeId]?.find((p) => p.id === item.id);
-                  setSelectedPOI(raw ?? item);
-                }}
+                onPress={() => setSelectedPOI(item)}
               />
             )}
             showsVerticalScrollIndicator={false}
@@ -253,13 +249,11 @@ export default function POITabContent({ activeData }: POITabContentProps) {
 
 function CompactPOIRow({
   poi,
-  effectiveDist,
   currentDist,
   ridingTimeSeconds,
   onPress,
 }: {
-  poi: POI;
-  effectiveDist: number;
+  poi: DisplayPOI;
   currentDist: number | null;
   ridingTimeSeconds: number | null;
   onPress: () => void;
@@ -269,7 +263,7 @@ function CompactPOIRow({
 
   const catMeta = POI_CATEGORIES.find((c) => c.key === poi.category);
   const IconComp = catMeta ? POI_ICON_MAP[catMeta.iconName] : null;
-  const distAhead = currentDist != null ? effectiveDist - currentDist : null;
+  const distAhead = currentDist != null ? poi.effectiveDistanceMeters - currentDist : null;
 
   const ohStatus = useMemo(() => {
     const tag = poi.tags?.opening_hours;
@@ -327,27 +321,21 @@ function CompactPOIRow({
   );
 }
 
-function InlinePOIDetail({ poi, onBack }: { poi: POI; onBack: () => void }) {
+function InlinePOIDetail({ poi, onBack }: { poi: DisplayPOI; onBack: () => void }) {
   const colors = useThemeColors();
   const units = useSettingsStore((s) => s.units);
   const snappedPosition = useRouteStore((s) => s.snappedPosition);
   const toggleStarred = usePoiStore((s) => s.toggleStarred);
   const isStarred = usePoiStore((s) => s.starredPOIIds.has(poi.id));
   const getETAToPOI = useEtaStore((s) => s.getETAToPOI);
-  const activeData = useActiveRouteData();
 
   const catMeta = POI_CATEGORIES.find((c) => c.key === poi.category);
   const IconComp = catMeta ? POI_ICON_MAP[catMeta.iconName] : null;
 
   const distAhead = useMemo(() => {
     if (!snappedPosition) return null;
-    let poiDist = poi.distanceAlongRouteMeters;
-    if (activeData?.segments) {
-      const seg = activeData.segments.find((s) => s.routeId === poi.routeId);
-      if (seg) poiDist += seg.distanceOffsetMeters;
-    }
-    return poiDist - snappedPosition.distanceAlongRouteMeters;
-  }, [poi, snappedPosition, activeData]);
+    return poi.effectiveDistanceMeters - snappedPosition.distanceAlongRouteMeters;
+  }, [poi.effectiveDistanceMeters, snappedPosition]);
 
   const etaResult = useMemo(() => getETAToPOI(poi), [poi, getETAToPOI]);
 

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -21,10 +21,10 @@ import { ohStatusColorKey } from "@/constants/poiHelpers";
 import { formatDistance, formatDuration, formatETA } from "@/utils/formatters";
 import { getOpeningHoursStatus, isOpenAt, getDaySchedules } from "@/services/openingHoursParser";
 import { stitchPOIs } from "@/services/stitchingService";
-import { toDisplayPOIs } from "@/services/displayDistance";
+import { toDisplayPOIForSegments, toDisplayPOIs } from "@/services/displayDistance";
 import POIFilterBar from "@/components/map/POIFilterBar";
 import POIListItem from "@/components/poi/POIListItem";
-import type { ActiveRouteData, DisplayPOI, POI } from "@/types";
+import type { ActiveRouteData, DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
 
 interface POITabContentProps {
   activeData: ActiveRouteData | null;
@@ -150,7 +150,9 @@ export default function POITabContent({ activeData }: POITabContentProps) {
 
   // Show inline detail when a POI is selected
   if (selectedPOI) {
-    return <InlinePOIDetail poi={selectedPOI} onBack={() => setSelectedPOI(null)} />;
+    return (
+      <InlinePOIDetail poi={selectedPOI} segments={segments} onBack={() => setSelectedPOI(null)} />
+    );
   }
 
   // Empty state — no POI data at all
@@ -321,7 +323,15 @@ function CompactPOIRow({
   );
 }
 
-function InlinePOIDetail({ poi, onBack }: { poi: DisplayPOI; onBack: () => void }) {
+function InlinePOIDetail({
+  poi,
+  segments,
+  onBack,
+}: {
+  poi: DisplayPOI;
+  segments: StitchedSegmentInfo[] | null;
+  onBack: () => void;
+}) {
   const colors = useThemeColors();
   const units = useSettingsStore((s) => s.units);
   const snappedPosition = useRouteStore((s) => s.snappedPosition);
@@ -331,13 +341,17 @@ function InlinePOIDetail({ poi, onBack }: { poi: DisplayPOI; onBack: () => void 
 
   const catMeta = POI_CATEGORIES.find((c) => c.key === poi.category);
   const IconComp = catMeta ? POI_ICON_MAP[catMeta.iconName] : null;
+  const displayPOI = useMemo(() => toDisplayPOIForSegments(poi, segments), [poi, segments]);
 
   const distAhead = useMemo(() => {
-    if (!snappedPosition) return null;
-    return poi.effectiveDistanceMeters - snappedPosition.distanceAlongRouteMeters;
-  }, [poi.effectiveDistanceMeters, snappedPosition]);
+    if (!snappedPosition || !displayPOI) return null;
+    return displayPOI.effectiveDistanceMeters - snappedPosition.distanceAlongRouteMeters;
+  }, [displayPOI, snappedPosition]);
 
-  const etaResult = useMemo(() => getETAToPOI(poi), [poi, getETAToPOI]);
+  const etaResult = useMemo(
+    () => (displayPOI ? getETAToPOI(displayPOI) : null),
+    [displayPOI, getETAToPOI],
+  );
 
   const openingHoursRaw = poi.tags?.opening_hours;
   const ohStatus = useMemo(

--- a/components/map/ProfileTabContent.tsx
+++ b/components/map/ProfileTabContent.tsx
@@ -13,9 +13,10 @@ import { computeSliceAscent, computeSliceDescent, extractRouteSlice } from "@/ut
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import { climbDifficultyColor } from "@/constants/climbHelpers";
 import { stitchPOIs } from "@/services/stitchingService";
+import { toDisplayPOIs } from "@/services/displayDistance";
 import UpcomingElevation from "./UpcomingElevation";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
-import type { PanelMode, POI, ActiveRouteData, Climb } from "@/types";
+import type { PanelMode, POI, ActiveRouteData, DisplayClimb } from "@/types";
 
 const MAX_SNAP_DISTANCE_M = 1000;
 const HEADER_HEIGHT = 44;
@@ -73,7 +74,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
       }
       return stitchPOIs(activeSegments, poisByRoute);
     }
-    return getStarredPOIs(activeRouteIds[0]);
+    return toDisplayPOIs(getStarredPOIs(activeRouteIds[0]));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeId, activeRouteIds, activeSegments, getStarredPOIs, starredPOIIds]);
 
@@ -98,7 +99,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
   const climbSlice = useMemo(() => {
     if (!currentClimb || !activeRoutePoints?.length) return null;
     const padding = 500;
-    const startDist = Math.max(0, currentClimb.startDistanceMeters - padding);
+    const startDist = Math.max(0, currentClimb.effectiveStartDistanceMeters - padding);
     let startIdx = 0;
     for (let i = 0; i < activeRoutePoints.length; i++) {
       if (activeRoutePoints[i].distanceFromStartMeters >= startDist) {
@@ -107,7 +108,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
       }
     }
     const totalSliceM =
-      currentClimb.endDistanceMeters +
+      currentClimb.effectiveEndDistanceMeters +
       padding -
       activeRoutePoints[startIdx].distanceFromStartMeters;
     const sliced = extractRouteSlice(activeRoutePoints, startIdx, totalSliceM);
@@ -128,12 +129,12 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
   const climbProgressText = useMemo(() => {
     if (!currentClimb || !isSnapped || !snappedPosition || !activeRoutePoints?.length) return null;
     const currentDist = snappedPosition.distanceAlongRouteMeters;
-    const distToTop = currentClimb.endDistanceMeters - currentDist;
+    const distToTop = currentClimb.effectiveEndDistanceMeters - currentDist;
     if (distToTop <= 0) return null;
     const ascentRemaining = computeSliceAscent(
       activeRoutePoints,
       snappedPosition.pointIndex,
-      currentClimb.endDistanceMeters,
+      currentClimb.effectiveEndDistanceMeters,
     );
     return `↑ ${formatElevation(ascentRemaining, units)} remaining  ·  ${formatDistance(distToTop, units)} to top  ·  ${currentClimb.averageGradientPercent}% avg`;
   }, [currentClimb, isSnapped, snappedPosition, activeRoutePoints, units]);
@@ -159,11 +160,15 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
     return `↑ ${formatElevation(asc, units)}  ·  ↓ ${formatElevation(desc, units)}`;
   }, [isSnapped, activeRoutePoints, riderIdx, windowEndDist, units]);
 
-  const climbsAhead = useMemo<Climb[]>(() => {
+  const climbsAhead = useMemo<DisplayClimb[]>(() => {
     if (climbsForChart.length === 0) return [];
     return climbsForChart
-      .filter((c) => c.endDistanceMeters > windowStartDist && c.startDistanceMeters < windowEndDist)
-      .sort((a, b) => a.startDistanceMeters - b.startDistanceMeters)
+      .filter(
+        (c) =>
+          c.effectiveEndDistanceMeters > windowStartDist &&
+          c.effectiveStartDistanceMeters < windowEndDist,
+      )
+      .sort((a, b) => a.effectiveStartDistanceMeters - b.effectiveStartDistanceMeters)
       .slice(0, MAX_CLIMBS_AHEAD);
   }, [climbsForChart, windowStartDist, windowEndDist]);
 
@@ -281,8 +286,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
             climbs={climbsForChart}
             fitToWidth
             onPOIPress={(poi) => {
-              const raw = usePoiStore.getState().pois[poi.routeId]?.find((p) => p.id === poi.id);
-              setSelectedPOI(raw ?? poi);
+              setSelectedPOI(poi);
             }}
           />
         )}
@@ -351,11 +355,11 @@ function ClimbsAheadStrip({
   height,
   onClimbPress,
 }: {
-  climbs: Climb[];
+  climbs: DisplayClimb[];
   riderDistance: number;
   units: "metric" | "imperial";
   height: number;
-  onClimbPress?: (climb: Climb) => void;
+  onClimbPress?: (climb: DisplayClimb) => void;
 }) {
   const colors = useThemeColors();
   return (
@@ -380,7 +384,7 @@ function ClimbsAheadStrip({
         scrollEnabled={climbs.length > MAX_CLIMBS_AHEAD}
       >
         {climbs.map((climb) => {
-          const distTo = Math.max(0, climb.startDistanceMeters - riderDistance);
+          const distTo = Math.max(0, climb.effectiveDistanceMeters - riderDistance);
           const color = climbDifficultyColor(climb.difficultyScore);
           return (
             <TouchableOpacity

--- a/components/map/UpcomingElevation.tsx
+++ b/components/map/UpcomingElevation.tsx
@@ -4,7 +4,7 @@ import { Text } from "@/components/ui/text";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import { extractRouteSlice } from "@/utils/geo";
 import { LOOK_BACK_RATIO } from "@/constants";
-import type { RoutePoint, UnitSystem, POI, Climb } from "@/types";
+import type { RoutePoint, UnitSystem, DisplayPOI, DisplayClimb } from "@/types";
 
 interface UpcomingElevationProps {
   points: RoutePoint[];
@@ -15,11 +15,11 @@ interface UpcomingElevationProps {
   width: number;
   height: number;
   /** POIs to display on the elevation chart */
-  pois?: POI[];
+  pois?: DisplayPOI[];
   /** Called when a POI marker is tapped */
-  onPOIPress?: (poi: POI) => void;
+  onPOIPress?: (poi: DisplayPOI) => void;
   /** Climbs to render as shading */
-  climbs?: Climb[];
+  climbs?: DisplayClimb[];
   /** Force fit-to-width — disables horizontal scrolling and the overview minimap */
   fitToWidth?: boolean;
 }
@@ -86,8 +86,7 @@ export default function UpcomingElevation({
   const visiblePOIs = useMemo(() => {
     if (!pois) return undefined;
     return pois.filter(
-      (p) =>
-        p.distanceAlongRouteMeters >= offsetMeters && p.distanceAlongRouteMeters <= sliceEndDist,
+      (p) => p.effectiveDistanceMeters >= offsetMeters && p.effectiveDistanceMeters <= sliceEndDist,
     );
   }, [pois, offsetMeters, sliceEndDist]);
 
@@ -95,7 +94,9 @@ export default function UpcomingElevation({
   const visibleClimbs = useMemo(() => {
     if (!climbs) return undefined;
     return climbs.filter(
-      (c) => c.endDistanceMeters >= offsetMeters && c.startDistanceMeters <= sliceEndDist,
+      (c) =>
+        c.effectiveEndDistanceMeters >= offsetMeters &&
+        c.effectiveStartDistanceMeters <= sliceEndDist,
     );
   }, [climbs, offsetMeters, sliceEndDist]);
 

--- a/components/poi/POIListItem.tsx
+++ b/components/poi/POIListItem.tsx
@@ -11,12 +11,12 @@ import { ohStatusColorKey } from "@/constants/poiHelpers";
 import { formatDistance, formatDuration, formatETA } from "@/utils/formatters";
 import { getOpeningHoursStatus } from "@/services/openingHoursParser";
 import { useEtaStore } from "@/store/etaStore";
-import type { POI } from "@/types";
+import type { DisplayPOI } from "@/types";
 
 interface POIListItemProps {
-  poi: POI;
+  poi: DisplayPOI;
   currentDistAlongRoute: number | null;
-  onPress: (poi: POI) => void;
+  onPress: (poi: DisplayPOI) => void;
 }
 
 export default function POIListItem({ poi, currentDistAlongRoute, onPress }: POIListItemProps) {
@@ -30,7 +30,7 @@ export default function POIListItem({ poi, currentDistAlongRoute, onPress }: POI
   const getETAToPOI = useEtaStore((s) => s.getETAToPOI);
 
   const distAhead =
-    currentDistAlongRoute != null ? poi.distanceAlongRouteMeters - currentDistAlongRoute : null;
+    currentDistAlongRoute != null ? poi.effectiveDistanceMeters - currentDistAlongRoute : null;
 
   const etaResult = useMemo(() => getETAToPOI(poi), [poi, getETAToPOI]);
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,19 +110,16 @@ OSM opening hours are often missing or wrong for gas stations and groceries — 
 
 Routes are stored individually. Collections reference routes via `collection_segments` table with position-based slots. At display time, selected segments are stitched (points concatenated with distance offsets). `RoutePoint[]` consumers (snapping, ETA cumulative time, weather, elevation rendering) receive the stitched array unchanged — their input is already in "stitched coords".
 
-**Two coordinate systems for POIs and climbs.** POIs and climbs are stored per-route with `distanceAlongRouteMeters` / `startDistanceMeters` relative to **their own route** ("raw coords"). When a collection is active, the snapped position and `cumulativeTime` array live in **stitched coords** (raw + `segment.distanceOffsetMeters`). Every consumer that compares a POI/climb distance against the snapped position or looks it up in `cumulativeTime` must first convert raw → stitched.
+**Two coordinate systems for POIs and climbs.** POIs and climbs are stored per-route with `distanceAlongRouteMeters` / `startDistanceMeters` relative to **their own route** ("raw coords"). When a collection is active, snapped position, `RoutePoint.distanceFromStartMeters`, and ETA `cumulativeTime` live in **stitched coords** (raw + `segment.distanceOffsetMeters`).
 
-Conversion currently happens in several places:
+Displayed POIs and climbs use explicit display types:
 
-- `services/stitchingService.ts:stitchPOIs` — rewrites `distanceAlongRouteMeters` for the expanded POI list
-- `store/climbStore.ts:getClimbsForDisplay` — rewrites `startDistanceMeters` / `endDistanceMeters` for climb display
-- `components/map/POITabContent.tsx:starredUpcoming` — inline offset math for the starred compact list
-- `components/map/POITabContent.tsx:InlinePOIDetail` — inline offset math for `distAhead`
-- `components/map/ClimbHighlightLayer.tsx` — uses `distanceOffset` to locate climb on stitched geometry
-- `components/elevation/ElevationProfile.tsx` — converts stitched climb back to local coords for rendering
-- `store/etaStore.ts:getETAToPOI` — applies `segment.distanceOffsetMeters` before resolving ETA
+- `DisplayPOI.effectiveDistanceMeters`
+- `DisplayClimb.effectiveDistanceMeters`
+- `DisplayClimb.effectiveStartDistanceMeters`
+- `DisplayClimb.effectiveEndDistanceMeters`
 
-Every new feature touching POIs/climbs has to make the same decision. Historically this has produced silent bugs when one site forgot the offset while its neighbors got it right — see `docs/known-issues.md` ("Two-coordinate-system fragility") and the refactor entry in `docs/ideas.md`.
+For standalone routes, effective distance equals raw distance. For collections, conversion is centralized at display-data boundaries: POIs through `services/stitchingService.ts:stitchPOIs` / `services/displayDistance.ts`, climbs through `store/climbStore.ts:getClimbsForDisplay` / `services/displayDistance.ts`. Components compare against snapped position and ETA using effective fields only; raw fields remain raw for persistence and route-local operations.
 
 ### Climb Detection
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,6 +119,8 @@ Displayed POIs and climbs use explicit display types:
 - `DisplayClimb.effectiveStartDistanceMeters`
 - `DisplayClimb.effectiveEndDistanceMeters`
 
+Those fields use the branded `DisplayDistanceMeters` TypeScript type. This is compile-time only; it does not affect persisted data or runtime values. The intent is to make display/stitched distances explicit at call sites like ETA lookup, while raw route-local fields stay plain numbers because they come directly from persisted route data.
+
 For standalone routes, effective distance equals raw distance. For collections, conversion is centralized at display-data boundaries: POIs through `services/stitchingService.ts:stitchPOIs` / `services/displayDistance.ts`, climbs through `store/climbStore.ts:getClimbsForDisplay` / `services/displayDistance.ts`. Components compare against snapped position and ETA using effective fields only; raw fields remain raw for persistence and route-local operations.
 
 ### Climb Detection

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -38,8 +38,4 @@ Future feature ideas and improvements.
 
 ## Refactors
 
-### Unify POI/climb coordinate space
-
-- **Problem.** POIs and climbs carry raw (per-route) distances, but downstream code (snapped position, `cumulativeTime`, elevation profile) operates in stitched coords. Every consumer has to remember to apply `segment.distanceOffsetMeters`; missing one silently returns `null` or wrong values (see `docs/architecture.md` → Collections and Stitching for the full list of conversion sites).
-- **Proposal.** Extend the POI/climb display types with an `effectiveDistanceMeters` field populated once — at stitch time for collections, equal to the raw distance for standalone routes. Every consumer reads that field; the raw↔stitched conversion exists in exactly one place (`stitchPOIs` / `getClimbsForDisplay`). `etaStore.getETAToPOI` collapses back to a one-liner.
-- **Blockers.** Touches many call sites with no regression tests. Gate on the unit-test backlog (`docs/tests.md`) landing first, then refactor with a safety net.
+None currently tracked.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -37,12 +37,6 @@ Small bugs and warnings to address later.
 - **Issue:** Nearly identical distance-based route splitting with 1-point overlap
 - **Fix:** Consolidate into a single parameterized function in `utils/geo.ts`
 
-### Two-coordinate-system fragility (POIs & climbs)
-
-- **Where:** Conversion between raw (per-route) and stitched (collection) distances is scattered across ~7 sites — see `docs/architecture.md` → Collections and Stitching for the full list.
-- **Issue:** Each consumer has to remember to apply `segment.distanceOffsetMeters`. Every missed conversion is a silent bug: `getETAToDistance` hits its `distanceMeters < 0` guard and returns `null`, or compares against the wrong point index. Multiple bugs traced to this pattern (POI detail ETA, starred compact list before it was inlined, ETA cache staleness on variant swap).
-- **Fix:** See `docs/ideas.md` → "Unify POI/climb coordinate space". Gated on unit tests landing first (`docs/tests.md`).
-
 ## Bugs
 
 None currently tracked.

--- a/services/displayDistance.ts
+++ b/services/displayDistance.ts
@@ -1,9 +1,15 @@
-import type { Climb, DisplayClimb, DisplayPOI, POI } from "@/types";
+import type { Climb, DisplayClimb, DisplayDistanceMeters, DisplayPOI, POI } from "@/types";
+
+export function toDisplayDistanceMeters(distanceMeters: number): DisplayDistanceMeters {
+  return distanceMeters as DisplayDistanceMeters;
+}
 
 export function toDisplayPOI(poi: POI, distanceOffsetMeters = 0): DisplayPOI {
   return {
     ...poi,
-    effectiveDistanceMeters: poi.distanceAlongRouteMeters + distanceOffsetMeters,
+    effectiveDistanceMeters: toDisplayDistanceMeters(
+      poi.distanceAlongRouteMeters + distanceOffsetMeters,
+    ),
   };
 }
 
@@ -12,8 +18,12 @@ export function toDisplayPOIs(pois: POI[], distanceOffsetMeters = 0): DisplayPOI
 }
 
 export function toDisplayClimb(climb: Climb, distanceOffsetMeters = 0): DisplayClimb {
-  const effectiveStartDistanceMeters = climb.startDistanceMeters + distanceOffsetMeters;
-  const effectiveEndDistanceMeters = climb.endDistanceMeters + distanceOffsetMeters;
+  const effectiveStartDistanceMeters = toDisplayDistanceMeters(
+    climb.startDistanceMeters + distanceOffsetMeters,
+  );
+  const effectiveEndDistanceMeters = toDisplayDistanceMeters(
+    climb.endDistanceMeters + distanceOffsetMeters,
+  );
 
   return {
     ...climb,

--- a/services/displayDistance.ts
+++ b/services/displayDistance.ts
@@ -1,4 +1,11 @@
-import type { Climb, DisplayClimb, DisplayDistanceMeters, DisplayPOI, POI } from "@/types";
+import type {
+  Climb,
+  DisplayClimb,
+  DisplayDistanceMeters,
+  DisplayPOI,
+  POI,
+  StitchedSegmentInfo,
+} from "@/types";
 
 export function toDisplayDistanceMeters(distanceMeters: number): DisplayDistanceMeters {
   return distanceMeters as DisplayDistanceMeters;
@@ -15,6 +22,16 @@ export function toDisplayPOI(poi: POI, distanceOffsetMeters = 0): DisplayPOI {
 
 export function toDisplayPOIs(pois: POI[], distanceOffsetMeters = 0): DisplayPOI[] {
   return pois.map((poi) => toDisplayPOI(poi, distanceOffsetMeters));
+}
+
+export function toDisplayPOIForSegments(
+  poi: POI,
+  segments: StitchedSegmentInfo[] | null,
+): DisplayPOI | null {
+  if (!segments) return toDisplayPOI(poi);
+
+  const segment = segments.find((s) => s.routeId === poi.routeId);
+  return segment ? toDisplayPOI(poi, segment.distanceOffsetMeters) : null;
 }
 
 export function toDisplayClimb(climb: Climb, distanceOffsetMeters = 0): DisplayClimb {

--- a/services/displayDistance.ts
+++ b/services/displayDistance.ts
@@ -1,0 +1,28 @@
+import type { Climb, DisplayClimb, DisplayPOI, POI } from "@/types";
+
+export function toDisplayPOI(poi: POI, distanceOffsetMeters = 0): DisplayPOI {
+  return {
+    ...poi,
+    effectiveDistanceMeters: poi.distanceAlongRouteMeters + distanceOffsetMeters,
+  };
+}
+
+export function toDisplayPOIs(pois: POI[], distanceOffsetMeters = 0): DisplayPOI[] {
+  return pois.map((poi) => toDisplayPOI(poi, distanceOffsetMeters));
+}
+
+export function toDisplayClimb(climb: Climb, distanceOffsetMeters = 0): DisplayClimb {
+  const effectiveStartDistanceMeters = climb.startDistanceMeters + distanceOffsetMeters;
+  const effectiveEndDistanceMeters = climb.endDistanceMeters + distanceOffsetMeters;
+
+  return {
+    ...climb,
+    effectiveDistanceMeters: effectiveStartDistanceMeters,
+    effectiveStartDistanceMeters,
+    effectiveEndDistanceMeters,
+  };
+}
+
+export function toDisplayClimbs(climbs: Climb[], distanceOffsetMeters = 0): DisplayClimb[] {
+  return climbs.map((climb) => toDisplayClimb(climb, distanceOffsetMeters));
+}

--- a/services/stitchingService.ts
+++ b/services/stitchingService.ts
@@ -1,5 +1,6 @@
 import { getRouteWithPoints, getCollectionSegments } from "@/db/database";
-import type { StitchedCollection, StitchedSegmentInfo, RoutePoint, POI } from "@/types";
+import { toDisplayPOI } from "@/services/displayDistance";
+import type { StitchedCollection, StitchedSegmentInfo, RoutePoint, POI, DisplayPOI } from "@/types";
 
 export async function stitchCollection(collectionId: string): Promise<StitchedCollection> {
   const allSegments = await getCollectionSegments(collectionId);
@@ -69,21 +70,18 @@ export async function stitchCollection(collectionId: string): Promise<StitchedCo
 export function stitchPOIs(
   segments: StitchedSegmentInfo[],
   poisByRoute: Record<string, POI[]>,
-): POI[] {
-  const combined: POI[] = [];
+): DisplayPOI[] {
+  const combined: DisplayPOI[] = [];
 
   for (const seg of segments) {
     const pois = poisByRoute[seg.routeId];
     if (!pois) continue;
 
     for (const poi of pois) {
-      combined.push({
-        ...poi,
-        distanceAlongRouteMeters: poi.distanceAlongRouteMeters + seg.distanceOffsetMeters,
-      });
+      combined.push(toDisplayPOI(poi, seg.distanceOffsetMeters));
     }
   }
 
-  combined.sort((a, b) => a.distanceAlongRouteMeters - b.distanceAlongRouteMeters);
+  combined.sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
   return combined;
 }

--- a/store/climbStore.ts
+++ b/store/climbStore.ts
@@ -1,26 +1,30 @@
 import { create } from "zustand";
-import type { Climb, StitchedSegmentInfo } from "@/types";
+import type { Climb, DisplayClimb, StitchedSegmentInfo } from "@/types";
 import { getClimbsForRoute, updateClimbName } from "@/db/database";
 import { MIN_GAIN_M } from "@/services/climbDetector";
+import { toDisplayClimb, toDisplayClimbs } from "@/services/displayDistance";
 
 interface ClimbState {
   // Climb data per route
   climbs: Record<string, Climb[]>;
 
   // UI state
-  selectedClimb: Climb | null;
+  selectedClimb: DisplayClimb | null;
   currentClimbId: string | null;
   isClimbZoomed: boolean;
 
   // Actions
   loadClimbs: (routeId: string) => Promise<void>;
   renameClimb: (climbId: string, routeId: string, name: string | null) => Promise<void>;
-  setSelectedClimb: (climb: Climb | null) => void;
+  setSelectedClimb: (climb: DisplayClimb | null) => void;
   setClimbZoomed: (zoomed: boolean) => void;
   clearClimbCache: () => void;
 
   // Computed
-  getClimbsForDisplay: (routeIds: string[], segments: StitchedSegmentInfo[] | null) => Climb[];
+  getClimbsForDisplay: (
+    routeIds: string[],
+    segments: StitchedSegmentInfo[] | null,
+  ) => DisplayClimb[];
   updateCurrentClimb: (
     distanceAlongRoute: number,
     routeIds: string[],
@@ -89,65 +93,43 @@ export const useClimbStore = create<ClimbState>((set, get) => ({
     const state = get();
 
     if (segments && segments.length > 0) {
-      // Collection mode — offset distances per segment
-      const combined: Climb[] = [];
+      const combined: DisplayClimb[] = [];
       for (const seg of segments) {
         const routeClimbs = state.climbs[seg.routeId];
         if (!routeClimbs) continue;
         for (const c of routeClimbs) {
-          combined.push({
-            ...c,
-            startDistanceMeters: c.startDistanceMeters + seg.distanceOffsetMeters,
-            endDistanceMeters: c.endDistanceMeters + seg.distanceOffsetMeters,
-          });
+          combined.push(toDisplayClimb(c, seg.distanceOffsetMeters));
         }
       }
-      combined.sort((a, b) => a.startDistanceMeters - b.startDistanceMeters);
+      combined.sort((a, b) => a.effectiveStartDistanceMeters - b.effectiveStartDistanceMeters);
       return mergeAdjacentClimbs(combined, segments);
     }
 
     // Single route mode
     if (routeIds.length === 1) {
-      return state.climbs[routeIds[0]] ?? [];
+      return toDisplayClimbs(state.climbs[routeIds[0]] ?? []);
     }
 
     // Multiple routes (shouldn't happen outside collections, but handle gracefully)
-    const all: Climb[] = [];
+    const all: DisplayClimb[] = [];
     for (const id of routeIds) {
       const routeClimbs = state.climbs[id];
-      if (routeClimbs) all.push(...routeClimbs);
+      if (routeClimbs) all.push(...toDisplayClimbs(routeClimbs));
     }
-    all.sort((a, b) => a.startDistanceMeters - b.startDistanceMeters);
+    all.sort((a, b) => a.effectiveStartDistanceMeters - b.effectiveStartDistanceMeters);
     return all;
   },
 
   updateCurrentClimb: (distanceAlongRoute, routeIds, segments) => {
     const state = get();
-
-    // Scan raw climb data without allocating intermediate arrays
-    let newId: string | null = null;
-    if (segments && segments.length > 0) {
-      for (const seg of segments) {
-        const routeClimbs = state.climbs[seg.routeId];
-        if (!routeClimbs) continue;
-        for (const c of routeClimbs) {
-          const adjStart = c.startDistanceMeters + seg.distanceOffsetMeters;
-          const adjEnd = c.endDistanceMeters + seg.distanceOffsetMeters;
-          if (distanceAlongRoute >= adjStart && distanceAlongRoute <= adjEnd) {
-            newId = c.id;
-            break;
-          }
-        }
-        if (newId) break;
-      }
-    } else if (routeIds.length > 0) {
-      const routeClimbs = state.climbs[routeIds[0]];
-      const found = routeClimbs?.find(
+    const found = state
+      .getClimbsForDisplay(routeIds, segments)
+      .find(
         (c) =>
-          distanceAlongRoute >= c.startDistanceMeters && distanceAlongRoute <= c.endDistanceMeters,
+          distanceAlongRoute >= c.effectiveStartDistanceMeters &&
+          distanceAlongRoute <= c.effectiveEndDistanceMeters,
       );
-      if (found) newId = found.id;
-    }
+    const newId = found?.id ?? null;
 
     if (newId !== state.currentClimbId) {
       set({
@@ -172,7 +154,10 @@ export const useClimbStore = create<ClimbState>((set, get) => ({
  * Merge climbs at collection segment boundaries using the absorption rule.
  * Only merges pairs that directly straddle a junction — no cascading.
  */
-function mergeAdjacentClimbs(sorted: Climb[], segments: StitchedSegmentInfo[]): Climb[] {
+function mergeAdjacentClimbs(
+  sorted: DisplayClimb[],
+  segments: StitchedSegmentInfo[],
+): DisplayClimb[] {
   if (sorted.length <= 1 || segments.length <= 1) return sorted;
 
   // Build the set of interior junction distances (where segments meet)
@@ -193,8 +178,8 @@ function mergeAdjacentClimbs(sorted: Climb[], segments: StitchedSegmentInfo[]): 
 
     // Check if there's a junction between the end of A and start of B
     // Only consider gaps < 5km — a real split climb wouldn't have a larger gap
-    const gapStart = a.endDistanceMeters;
-    const gapEnd = b.startDistanceMeters;
+    const gapStart = a.effectiveEndDistanceMeters;
+    const gapEnd = b.effectiveStartDistanceMeters;
     if (gapEnd - gapStart > 5000) continue;
 
     let hasJunction = false;
@@ -217,19 +202,20 @@ function mergeAdjacentClimbs(sorted: Climb[], segments: StitchedSegmentInfo[]): 
   }
 
   // Second pass: build result by merging marked pairs
-  const result: Climb[] = [];
+  const result: DisplayClimb[] = [];
   let i = 0;
   while (i < sorted.length) {
     if (mergeWithNext[i] && i + 1 < sorted.length) {
       const a = sorted[i];
       const b = sorted[i + 1];
-      const mergedLength = b.endDistanceMeters - a.startDistanceMeters;
+      const mergedLength = b.effectiveEndDistanceMeters - a.effectiveStartDistanceMeters;
       const mergedAscent = a.totalAscentMeters + b.totalAscentMeters;
       result.push({
         ...a,
         id: `${a.id}_${b.id}`,
         name: a.name ?? b.name,
         endDistanceMeters: b.endDistanceMeters,
+        effectiveEndDistanceMeters: b.effectiveEndDistanceMeters,
         endElevationMeters: b.endElevationMeters,
         lengthMeters: mergedLength,
         totalAscentMeters: mergedAscent,

--- a/store/etaStore.ts
+++ b/store/etaStore.ts
@@ -1,11 +1,9 @@
 import { create } from "zustand";
 import { createMMKV, type MMKV } from "react-native-mmkv";
-import type { PowerModelConfig, ETAResult, RoutePoint, POI } from "@/types";
+import type { PowerModelConfig, ETAResult, RoutePoint, DisplayPOI } from "@/types";
 import { DEFAULT_POWER_CONFIG } from "@/constants";
 import { computeRouteETA, getETAToDistance } from "@/services/etaCalculator";
 import { useRouteStore } from "./routeStore";
-import { useCollectionStore } from "./collectionStore";
-import { usePoiStore } from "./poiStore";
 
 let storage: MMKV | null = null;
 
@@ -34,7 +32,7 @@ interface ETAState {
   computeETAForRoute: (routeId: string, points: RoutePoint[]) => void;
   invalidateCache: () => void;
 
-  getETAToPOI: (poi: POI) => ETAResult | null;
+  getETAToPOI: (poi: DisplayPOI) => ETAResult | null;
   getETAToDistance: (distAlongRouteM: number) => ETAResult | null;
   _resolveETA: (targetDistM: number) => ETAResult | null;
 }
@@ -69,21 +67,7 @@ export const useEtaStore = create<ETAState>((set, get) => ({
   },
 
   getETAToPOI: (poi) => {
-    // Canonicalize the distance: look up the raw POI from the store so we
-    // don't double-apply the offset when a caller passes a POI that's
-    // already been rewritten by stitchPOIs.
-    const rawPoi = usePoiStore.getState().pois[poi.routeId]?.find((p) => p.id === poi.id);
-    let targetDist = (rawPoi ?? poi).distanceAlongRouteMeters;
-
-    // If the active context is a stitched collection, shift the POI into
-    // stitched coords so it aligns with cumulativeTime / snapped pointIndex.
-    const stitched = useCollectionStore.getState().activeStitchedCollection;
-    if (stitched && stitched.collectionId === get().routeId) {
-      const seg = stitched.segments.find((s) => s.routeId === poi.routeId);
-      if (seg) targetDist += seg.distanceOffsetMeters;
-    }
-
-    return get()._resolveETA(targetDist);
+    return get()._resolveETA(poi.effectiveDistanceMeters);
   },
 
   getETAToDistance: (distAlongRouteM) => {

--- a/store/etaStore.ts
+++ b/store/etaStore.ts
@@ -9,7 +9,9 @@ import type {
 } from "@/types";
 import { DEFAULT_POWER_CONFIG } from "@/constants";
 import { computeRouteETA, getETAToDistance } from "@/services/etaCalculator";
+import { toDisplayPOIForSegments } from "@/services/displayDistance";
 import { useRouteStore } from "./routeStore";
+import { useCollectionStore } from "./collectionStore";
 
 let storage: MMKV | null = null;
 
@@ -73,7 +75,12 @@ export const useEtaStore = create<ETAState>((set, get) => ({
   },
 
   getETAToPOI: (poi) => {
-    return get()._resolveETA(poi.effectiveDistanceMeters);
+    const stitched = useCollectionStore.getState().activeStitchedCollection;
+    const segments = stitched && stitched.collectionId === get().routeId ? stitched.segments : null;
+    const displayPOI = toDisplayPOIForSegments(poi, segments);
+    if (!displayPOI) return null;
+
+    return get()._resolveETA(displayPOI.effectiveDistanceMeters);
   },
 
   getETAToDistance: (distAlongRouteM) => {

--- a/store/etaStore.ts
+++ b/store/etaStore.ts
@@ -1,6 +1,12 @@
 import { create } from "zustand";
 import { createMMKV, type MMKV } from "react-native-mmkv";
-import type { PowerModelConfig, ETAResult, RoutePoint, DisplayPOI } from "@/types";
+import type {
+  PowerModelConfig,
+  ETAResult,
+  RoutePoint,
+  DisplayDistanceMeters,
+  DisplayPOI,
+} from "@/types";
 import { DEFAULT_POWER_CONFIG } from "@/constants";
 import { computeRouteETA, getETAToDistance } from "@/services/etaCalculator";
 import { useRouteStore } from "./routeStore";
@@ -33,8 +39,8 @@ interface ETAState {
   invalidateCache: () => void;
 
   getETAToPOI: (poi: DisplayPOI) => ETAResult | null;
-  getETAToDistance: (distAlongRouteM: number) => ETAResult | null;
-  _resolveETA: (targetDistM: number) => ETAResult | null;
+  getETAToDistance: (distAlongRouteM: DisplayDistanceMeters) => ETAResult | null;
+  _resolveETA: (targetDistM: DisplayDistanceMeters) => ETAResult | null;
 }
 
 export const useEtaStore = create<ETAState>((set, get) => ({

--- a/store/poiStore.ts
+++ b/store/poiStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { createMMKV, type MMKV } from "react-native-mmkv";
-import type { POI, POICategory, POIFetchStatus, POISource, RoutePoint } from "@/types";
+import type { DisplayPOI, POI, POICategory, POIFetchStatus, POISource, RoutePoint } from "@/types";
 import { DEFAULT_CORRIDOR_WIDTH_M, POI_CATEGORIES } from "@/constants";
 import { getPOIsForRoute, deletePOIsBySource, deletePOIsForRoute } from "@/db/database";
 import { fetchOsmPOIs, fetchGooglePOIs } from "@/services/poiFetcher";
@@ -139,7 +139,7 @@ function buildRouteScrubPatch(
     pois: Record<string, POI[]>;
     sourceInfo: Record<string, Record<POISource, SourceInfo>>;
     starredPOIIds: Set<string>;
-    selectedPOI: POI | null;
+    selectedPOI: DisplayPOI | null;
   },
   routeId: string,
   mode: ScrubMode,
@@ -187,7 +187,7 @@ interface POIState {
   sourceInfo: Record<string, Record<POISource, SourceInfo>>; // routeId -> source -> info
 
   // UI state
-  selectedPOI: POI | null;
+  selectedPOI: DisplayPOI | null;
 
   // Actions
   loadPOIs: (routeId: string) => Promise<void>;
@@ -202,7 +202,7 @@ interface POIState {
   getStarredPOIs: (routeId: string) => POI[];
   clearPOIs: (routeId: string) => Promise<void>;
   cleanupRouteState: (routeId: string) => void;
-  setSelectedPOI: (poi: POI | null) => void;
+  setSelectedPOI: (poi: DisplayPOI | null) => void;
 
   // Computed helpers
   getVisiblePOIs: (routeId: string) => POI[];

--- a/tests/services/displayDistance.test.ts
+++ b/tests/services/displayDistance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { toDisplayClimb, toDisplayPOI } from "@/services/displayDistance";
-import type { Climb, POI } from "@/types";
+import { toDisplayClimb, toDisplayPOI, toDisplayPOIForSegments } from "@/services/displayDistance";
+import type { Climb, POI, StitchedSegmentInfo } from "@/types";
 
 const poi = (distanceAlongRouteMeters: number): POI => ({
   id: "poi-1",
@@ -31,6 +31,18 @@ const climb = (startDistanceMeters: number, endDistanceMeters: number): Climb =>
   difficultyScore: 120,
 });
 
+const segment = (routeId: string, distanceOffsetMeters: number): StitchedSegmentInfo => ({
+  routeId,
+  routeName: routeId,
+  position: 0,
+  startPointIndex: 0,
+  endPointIndex: 1,
+  distanceOffsetMeters,
+  segmentDistanceMeters: 1_000,
+  segmentAscentMeters: 10,
+  segmentDescentMeters: 10,
+});
+
 describe("displayDistance", () => {
   it("adds POI effective distance without mutating the raw route distance", () => {
     const displayed = toDisplayPOI(poi(50), 1_000);
@@ -47,5 +59,19 @@ describe("displayDistance", () => {
     expect(displayed.effectiveDistanceMeters).toBe(2_100);
     expect(displayed.effectiveStartDistanceMeters).toBe(2_100);
     expect(displayed.effectiveEndDistanceMeters).toBe(2_600);
+  });
+
+  it("recomputes POI display distance from the current segment offset", () => {
+    const stale = toDisplayPOI(poi(50), 1_000);
+    const displayed = toDisplayPOIForSegments(stale, [segment("route-1", 2_000)]);
+
+    expect(displayed?.distanceAlongRouteMeters).toBe(50);
+    expect(displayed?.effectiveDistanceMeters).toBe(2_050);
+  });
+
+  it("returns null for a POI outside the current stitched segments", () => {
+    const displayed = toDisplayPOIForSegments(poi(50), [segment("other-route", 1_000)]);
+
+    expect(displayed).toBeNull();
   });
 });

--- a/tests/services/displayDistance.test.ts
+++ b/tests/services/displayDistance.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { toDisplayClimb, toDisplayPOI } from "@/services/displayDistance";
+import type { Climb, POI } from "@/types";
+
+const poi = (distanceAlongRouteMeters: number): POI => ({
+  id: "poi-1",
+  sourceId: "poi-1",
+  source: "osm",
+  name: "Water",
+  category: "water",
+  latitude: 0,
+  longitude: 0,
+  tags: {},
+  distanceFromRouteMeters: 10,
+  distanceAlongRouteMeters,
+  routeId: "route-1",
+});
+
+const climb = (startDistanceMeters: number, endDistanceMeters: number): Climb => ({
+  id: "climb-1",
+  routeId: "route-1",
+  name: "Climb",
+  startDistanceMeters,
+  endDistanceMeters,
+  lengthMeters: endDistanceMeters - startDistanceMeters,
+  totalAscentMeters: 150,
+  startElevationMeters: 200,
+  endElevationMeters: 350,
+  averageGradientPercent: 5,
+  maxGradientPercent: 9,
+  difficultyScore: 120,
+});
+
+describe("displayDistance", () => {
+  it("adds POI effective distance without mutating the raw route distance", () => {
+    const displayed = toDisplayPOI(poi(50), 1_000);
+
+    expect(displayed.distanceAlongRouteMeters).toBe(50);
+    expect(displayed.effectiveDistanceMeters).toBe(1_050);
+  });
+
+  it("adds climb effective bounds without mutating raw route distances", () => {
+    const displayed = toDisplayClimb(climb(100, 600), 2_000);
+
+    expect(displayed.startDistanceMeters).toBe(100);
+    expect(displayed.endDistanceMeters).toBe(600);
+    expect(displayed.effectiveDistanceMeters).toBe(2_100);
+    expect(displayed.effectiveStartDistanceMeters).toBe(2_100);
+    expect(displayed.effectiveEndDistanceMeters).toBe(2_600);
+  });
+});

--- a/tests/services/stitchingService.test.ts
+++ b/tests/services/stitchingService.test.ts
@@ -103,7 +103,7 @@ describe("stitchingService", () => {
     expect(stitched.pointsByRouteId).toEqual({});
   });
 
-  it("stitchPOIs offsets and sorts distances", () => {
+  it("stitchPOIs keeps raw distances and sorts by effective distances", () => {
     const segments = [
       {
         routeId: "r1",
@@ -136,6 +136,7 @@ describe("stitchingService", () => {
     });
 
     expect(combined.map((p) => p.id)).toEqual(["a", "b"]);
-    expect(combined.map((p) => p.distanceAlongRouteMeters)).toEqual([900, 1_010]);
+    expect(combined.map((p) => p.distanceAlongRouteMeters)).toEqual([900, 10]);
+    expect(combined.map((p) => p.effectiveDistanceMeters)).toEqual([900, 1_010]);
   });
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -46,6 +46,11 @@ export interface SnappedPosition {
   distanceFromRouteMeters: number;
 }
 
+declare const DisplayDistanceMetersBrand: unique symbol;
+export type DisplayDistanceMeters = number & {
+  readonly [DisplayDistanceMetersBrand]: true;
+};
+
 // --- Phase 2b: Panel types ---
 
 export type PanelMode =
@@ -84,7 +89,7 @@ export interface POI {
 }
 
 export interface DisplayPOI extends POI {
-  effectiveDistanceMeters: number;
+  effectiveDistanceMeters: DisplayDistanceMeters;
 }
 
 export interface POICategoryMeta {
@@ -240,9 +245,9 @@ export interface Climb {
 }
 
 export interface DisplayClimb extends Climb {
-  effectiveDistanceMeters: number;
-  effectiveStartDistanceMeters: number;
-  effectiveEndDistanceMeters: number;
+  effectiveDistanceMeters: DisplayDistanceMeters;
+  effectiveStartDistanceMeters: DisplayDistanceMeters;
+  effectiveEndDistanceMeters: DisplayDistanceMeters;
 }
 
 export type ClimbDifficulty = "low" | "medium" | "hard";

--- a/types/index.ts
+++ b/types/index.ts
@@ -83,6 +83,10 @@ export interface POI {
   routeId: string;
 }
 
+export interface DisplayPOI extends POI {
+  effectiveDistanceMeters: number;
+}
+
 export interface POICategoryMeta {
   key: POICategory;
   label: string;
@@ -233,6 +237,12 @@ export interface Climb {
   averageGradientPercent: number;
   maxGradientPercent: number;
   difficultyScore: number;
+}
+
+export interface DisplayClimb extends Climb {
+  effectiveDistanceMeters: number;
+  effectiveStartDistanceMeters: number;
+  effectiveEndDistanceMeters: number;
 }
 
 export type ClimbDifficulty = "low" | "medium" | "hard";

--- a/utils/climbSelect.ts
+++ b/utils/climbSelect.ts
@@ -1,20 +1,21 @@
-import type { Climb } from "@/types";
+import type { DisplayClimb } from "@/types";
 
 /** Pick the most relevant climb: current (by distance), next upcoming, or last. */
 export function resolveActiveClimb(
-  climbs: Climb[],
+  climbs: DisplayClimb[],
   currentDist: number | null,
-  selectedClimb: Climb | null,
-): Climb | null {
+  selectedClimb: DisplayClimb | null,
+): DisplayClimb | null {
   if (selectedClimb) return selectedClimb;
   if (climbs.length === 0) return null;
   if (currentDist == null) return climbs[0];
 
   const current = climbs.find(
-    (c) => currentDist >= c.startDistanceMeters && currentDist <= c.endDistanceMeters,
+    (c) =>
+      currentDist >= c.effectiveStartDistanceMeters && currentDist <= c.effectiveEndDistanceMeters,
   );
   if (current) return current;
 
-  const next = climbs.find((c) => c.startDistanceMeters > currentDist);
+  const next = climbs.find((c) => c.effectiveStartDistanceMeters > currentDist);
   return next ?? climbs[climbs.length - 1];
 }


### PR DESCRIPTION
## Summary
- Add explicit `DisplayPOI` / `DisplayClimb` effective distance fields while keeping persisted raw route distances unchanged.
- Brand effective distances as `DisplayDistanceMeters` so display/stitched ETA inputs are compile-time distinct from plain raw distances.
- Centralize POI conversion through `stitchPOIs` / display helpers and climb conversion through `getClimbsForDisplay`.
- Update map, panel, elevation, ETA, and selection consumers to read effective distances instead of recomputing segment offsets inline.
- Refresh docs and regression tests for the display distance contract.

Fixes #4

## Verification
- `npx tsc --noEmit`
- `npm test`
- `npm run lint`
- `npm run format:check`