### PR TITLE
Clarify offline preparation

### DIFF
--- a/components/collection/CollectionOfflineSection.tsx
+++ b/components/collection/CollectionOfflineSection.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo, useState, useCallback } from "react";
+import React, { useEffect, useMemo, useState, useCallback } from "react";
 import { View, TouchableOpacity, Alert } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { useOfflineStore } from "@/store/offlineStore";
-import { usePoiStore } from "@/store/poiStore";
+import { usePoiStore, type SourceInfo } from "@/store/poiStore";
 import type { POISource, StitchedCollection } from "@/types";
 import { formatFileSize } from "@/utils/formatters";
 import { estimateDownloadSize } from "@/services/offlineTiles";
@@ -13,18 +13,38 @@ interface CollectionOfflineSectionProps {
   stitched: StitchedCollection;
 }
 
+function isSourceReady(info: SourceInfo | undefined): boolean {
+  return info?.status === "done" || (info?.count ?? 0) > 0;
+}
+
+function sourceLabel(source: POISource): string {
+  return source === "google" ? "Google Places" : "OpenStreetMap";
+}
+
 export default function CollectionOfflineSection({ stitched }: CollectionOfflineSectionProps) {
   const isConnected = useOfflineStore((s) => s.isConnected);
-  const startDownload = useOfflineStore((s) => s.startDownload);
+  const prepareRouteOffline = useOfflineStore((s) => s.prepareRouteOffline);
   const deleteOfflineData = useOfflineStore((s) => s.deleteOfflineData);
   const routeInfo = useOfflineStore((s) => s.routeInfo);
   const allPois = usePoiStore((s) => s.pois);
   const allSourceInfo = usePoiStore((s) => s.sourceInfo);
+  const loadPOIs = usePoiStore((s) => s.loadPOIs);
 
   const [isDownloading, setIsDownloading] = useState(false);
   const [progress, setProgress] = useState({ done: 0, total: 0 });
 
   const segments = stitched.segments;
+  const segmentRouteIdsKey = useMemo(
+    () => segments.map((seg) => seg.routeId).join("\n"),
+    [segments],
+  );
+
+  useEffect(() => {
+    if (!segmentRouteIdsKey) return;
+    for (const routeId of segmentRouteIdsKey.split("\n")) {
+      loadPOIs(routeId);
+    }
+  }, [segmentRouteIdsKey, loadPOIs]);
 
   const stats = useMemo(() => {
     let readyCount = 0;
@@ -32,14 +52,24 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
     let estimatedBytes = 0;
     let totalPOIs = 0;
     let anyDownloading = false;
+    let anySourceFetching = false;
+    let poiReadyCount = 0;
+    let offlineReadyCount = 0;
 
     for (const seg of segments) {
       const info = routeInfo[seg.routeId];
+      const sources = allSourceInfo[seg.routeId];
+      const poiReady = isSourceReady(sources?.osm) && isSourceReady(sources?.google);
       if (info?.status === "complete") {
         readyCount++;
         downloadedBytes += info.downloadedBytes;
       }
       if (info?.status === "downloading") anyDownloading = true;
+      if (sources?.osm?.status === "fetching" || sources?.google?.status === "fetching") {
+        anySourceFetching = true;
+      }
+      if (poiReady) poiReadyCount++;
+      if (info?.status === "complete" && poiReady) offlineReadyCount++;
       totalPOIs += allPois[seg.routeId]?.length ?? 0;
     }
 
@@ -53,10 +83,14 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
       estimatedBytes,
       totalPOIs,
       anyDownloading,
+      anySourceFetching,
+      poiReadyCount,
+      offlineReadyCount,
     };
-  }, [segments, routeInfo, allPois, stitched.points]);
+  }, [segments, routeInfo, allPois, allSourceInfo, stitched.points]);
 
-  const allReady = stats.readyCount === stats.total && stats.total > 0;
+  const allTilesReady = stats.readyCount === stats.total && stats.total > 0;
+  const allOfflineReady = stats.offlineReadyCount === stats.total && stats.total > 0;
 
   const poiErrors = useMemo(() => {
     const out: { routeName: string; source: POISource; error: string }[] = [];
@@ -71,19 +105,56 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
   }, [segments, allSourceInfo]);
 
   // Pick the first actively-fetching source across segments. Only one runs at
-  // a time (startDownload serializes), so this is the progress we should show.
+  // a time (prepareRouteOffline serializes), so this is the progress we show.
   const activePoiFetch = useMemo(() => {
     for (const seg of segments) {
       const src = allSourceInfo[seg.routeId];
-      if (src?.osm?.status === "fetching" && src.osm.progress) {
-        return { routeName: seg.routeName, progress: src.osm.progress };
+      if (src?.google?.status === "fetching") {
+        return {
+          routeName: seg.routeName,
+          source: "google" as const,
+          progress: src.google.progress,
+        };
       }
-      if (src?.google?.status === "fetching" && src.google.progress) {
-        return { routeName: seg.routeName, progress: src.google.progress };
+      if (src?.osm?.status === "fetching") {
+        return { routeName: seg.routeName, source: "osm" as const, progress: src.osm.progress };
       }
     }
     return null;
   }, [segments, allSourceInfo]);
+
+  const activeTileDownload = useMemo(() => {
+    for (const seg of segments) {
+      const info = routeInfo[seg.routeId];
+      if (info?.status === "downloading") {
+        return { routeName: seg.routeName, info };
+      }
+    }
+    return null;
+  }, [segments, routeInfo]);
+
+  const isPreparing = isDownloading || stats.anyDownloading || stats.anySourceFetching;
+  const currentSegmentLabel =
+    progress.total > 0
+      ? `segment ${Math.min(progress.done + 1, progress.total)} / ${progress.total}`
+      : (activePoiFetch?.routeName ?? activeTileDownload?.routeName ?? "segment");
+  const activeSourceProgress = activePoiFetch?.progress;
+  const activeStepFraction = activeTileDownload
+    ? activeTileDownload.info.percentage / 100
+    : activeSourceProgress
+      ? activeSourceProgress.done / Math.max(1, activeSourceProgress.total)
+      : 0;
+  const aggregateProgress =
+    progress.total > 0
+      ? ((progress.done + Math.min(1, activeStepFraction)) / progress.total) * 100
+      : 0;
+  const activeStatus = activePoiFetch
+    ? activeSourceProgress
+      ? `${activeSourceProgress.phase} ${sourceLabel(activePoiFetch.source)}... ${activeSourceProgress.done}/${activeSourceProgress.total} (${currentSegmentLabel})`
+      : `Fetching ${sourceLabel(activePoiFetch.source)}... (${currentSegmentLabel})`
+    : activeTileDownload
+      ? `Downloading map tiles... ${Math.round(activeTileDownload.info.percentage)}% (${currentSegmentLabel})`
+      : `Preparing... ${progress.done} / ${progress.total}`;
 
   const handleDownloadAll = useCallback(async () => {
     setIsDownloading(true);
@@ -92,22 +163,27 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
     for (let i = 0; i < segments.length; i++) {
       const seg = segments[i];
       const info = routeInfo[seg.routeId];
-      if (info?.status === "complete") {
+      const sources = allSourceInfo[seg.routeId];
+      const segmentReady =
+        info?.status === "complete" &&
+        isSourceReady(sources?.osm) &&
+        isSourceReady(sources?.google);
+      if (segmentReady) {
         setProgress({ done: i + 1, total: segments.length });
         continue;
       }
       try {
         const points =
           stitched.pointsByRouteId?.[seg.routeId] ?? (await getRoutePoints(seg.routeId));
-        await startDownload(seg.routeId, points);
-      } catch (e: any) {
-        console.warn(`Failed to download segment ${seg.routeName}:`, e);
+        await prepareRouteOffline(seg.routeId, points);
+      } catch (error) {
+        console.warn(`Failed to prepare segment ${seg.routeName}:`, error);
       }
       setProgress({ done: i + 1, total: segments.length });
     }
 
     setIsDownloading(false);
-  }, [segments, routeInfo, stitched.pointsByRouteId, startDownload]);
+  }, [segments, routeInfo, allSourceInfo, stitched.pointsByRouteId, prepareRouteOffline]);
 
   const clearPOIs = usePoiStore((s) => s.clearPOIs);
 
@@ -156,7 +232,7 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
         <View className="flex-row items-center justify-between py-1">
           <Text className="text-[15px] font-barlow text-foreground">Map tiles</Text>
           <Text className="text-[14px] font-barlow-sc-medium text-muted-foreground">
-            {allReady
+            {allTilesReady
               ? formatFileSize(stats.downloadedBytes)
               : `${stats.readyCount} / ${stats.total} segments`}
           </Text>
@@ -165,32 +241,30 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
         <View className="flex-row items-center justify-between py-1">
           <Text className="text-[15px] font-barlow text-foreground">POI data</Text>
           <Text className="text-[14px] font-barlow-sc-medium text-muted-foreground">
-            {stats.totalPOIs > 0 ? `${stats.totalPOIs} POIs cached` : "Not fetched"}
+            {stats.poiReadyCount === stats.total && stats.total > 0
+              ? `${stats.totalPOIs} POIs cached`
+              : `${stats.poiReadyCount} / ${stats.total} segments`}
           </Text>
         </View>
       </View>
 
-      {!allReady && !isDownloading && !stats.anyDownloading && (
+      {!allTilesReady && !isPreparing && (
         <Text className="text-[13px] text-muted-foreground px-4 mb-2 font-barlow">
           ~{formatFileSize(stats.estimatedBytes)} estimated for map tiles
         </Text>
       )}
 
-      {(isDownloading || stats.anyDownloading) && (
+      {isPreparing && (
         <View className="mx-4 mb-2">
           <View className="h-2 bg-border rounded-full overflow-hidden">
             <View
               className="h-full bg-primary rounded-full"
               style={{
-                width: `${Math.min(100, (progress.done / Math.max(1, progress.total)) * 100)}%`,
+                width: `${Math.min(100, aggregateProgress)}%`,
               }}
             />
           </View>
-          <Text className="text-[13px] text-muted-foreground font-barlow mt-1">
-            {activePoiFetch
-              ? `${activePoiFetch.progress.phase} POIs... ${activePoiFetch.progress.done}/${activePoiFetch.progress.total} (segment ${progress.done + 1} / ${progress.total})`
-              : `Downloading tiles... segment ${progress.done} / ${progress.total}`}
-          </Text>
+          <Text className="text-[13px] text-muted-foreground font-barlow mt-1">{activeStatus}</Text>
         </View>
       )}
 
@@ -213,13 +287,13 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
         ) : (
           <Button
             onPress={handleDownloadAll}
-            disabled={isDownloading || stats.anyDownloading}
-            variant={allReady ? "secondary" : "default"}
+            disabled={isPreparing || allOfflineReady}
+            variant={allOfflineReady ? "secondary" : "default"}
             label={
               isDownloading
-                ? "Downloading..."
-                : allReady
-                  ? "Update All Offline Data"
+                ? "Preparing..."
+                : allOfflineReady
+                  ? "Offline Ready"
                   : "Prepare for Offline"
             }
           />
@@ -235,7 +309,7 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
         </TouchableOpacity>
       )}
 
-      {allReady && (
+      {allTilesReady && (
         <TouchableOpacity
           className="px-4 py-2 min-h-[48px] justify-center"
           onPress={handleDeleteAll}

--- a/components/route/DataSection.tsx
+++ b/components/route/DataSection.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, Alert } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
@@ -22,11 +22,19 @@ function formatDate(iso: string): string {
   return `${day} ${month}, ${h}:${m}`;
 }
 
+function isSourceReady(info: SourceInfo): boolean {
+  return info.status === "done" || info.count > 0;
+}
+
 export default function DataSection({ routeId, points }: DataSectionProps) {
+  const [isPreparingOffline, setIsPreparingOffline] = useState(false);
+
   // Map tiles state
   const tileInfo = useOfflineStore((s) => s.getRouteInfo(routeId));
   const isConnected = useOfflineStore((s) => s.isConnected);
-  const startTileDownload = useOfflineStore((s) => s.startDownload);
+  const startTileDownload = useOfflineStore((s) => s.startTileDownload);
+  const prepareRouteOffline = useOfflineStore((s) => s.prepareRouteOffline);
+  const cancelDownload = useOfflineStore((s) => s.cancelDownload);
   const deleteTiles = useOfflineStore((s) => s.deleteOfflineData);
   const tilesReady = tileInfo.status === "complete";
   const tilesDownloading = tileInfo.status === "downloading";
@@ -36,6 +44,22 @@ export default function DataSection({ routeId, points }: DataSectionProps) {
   const googleInfo = usePoiStore((s) => s.sourceInfo[routeId]?.google) ?? DEFAULT_SOURCE_INFO;
   const fetchSource = usePoiStore((s) => s.fetchSource);
   const clearSource = usePoiStore((s) => s.clearSource);
+  const osmFetching = osmInfo.status === "fetching";
+  const googleFetching = googleInfo.status === "fetching";
+  const osmReady = isSourceReady(osmInfo);
+  const googleReady = isSourceReady(googleInfo);
+  const routeOfflineReady = tilesReady && osmReady && googleReady;
+  const hasBusySource = osmFetching || googleFetching;
+  const prepBusy = isPreparingOffline || tilesDownloading || hasBusySource;
+
+  const handlePrepareOffline = async () => {
+    setIsPreparingOffline(true);
+    try {
+      await prepareRouteOffline(routeId, points);
+    } finally {
+      setIsPreparingOffline(false);
+    }
+  };
 
   const handleDeleteTiles = () => {
     Alert.alert("Delete Map Tiles", "Remove downloaded tiles for this route?", [
@@ -47,7 +71,7 @@ export default function DataSection({ routeId, points }: DataSectionProps) {
   const handleCancelTiles = () => {
     Alert.alert("Cancel Download", "Stop downloading map tiles?", [
       { text: "Continue", style: "cancel" },
-      { text: "Cancel", style: "destructive", onPress: () => deleteTiles(routeId) },
+      { text: "Cancel", style: "destructive", onPress: () => cancelDownload(routeId) },
     ]);
   };
 
@@ -61,6 +85,31 @@ export default function DataSection({ routeId, points }: DataSectionProps) {
   return (
     <View>
       <Text className="text-[22px] font-barlow-semibold text-foreground px-4 mt-4 mb-3">Data</Text>
+
+      <View className="mx-4 bg-card rounded-xl px-4 py-3 mb-4">
+        <View className="mb-3">
+          <Text className="text-[15px] font-barlow-semibold text-foreground">
+            Prepare for Offline
+          </Text>
+          <Text className="text-[13px] text-muted-foreground font-barlow mt-1">
+            {routeOfflineReady
+              ? "Map tiles, Google Places, and OpenStreetMap ready"
+              : "Map tiles + missing Google Places and OpenStreetMap"}
+          </Text>
+        </View>
+        <Button
+          disabled={!isConnected || prepBusy || routeOfflineReady}
+          variant={routeOfflineReady ? "secondary" : "default"}
+          onPress={handlePrepareOffline}
+          label={
+            isPreparingOffline
+              ? "Preparing..."
+              : routeOfflineReady
+                ? "Offline Ready"
+                : "Prepare for Offline"
+          }
+        />
+      </View>
 
       {/* Map Tiles */}
       <DataRow
@@ -180,7 +229,7 @@ function SourceRow({
   isConnected: boolean;
 }) {
   const isFetching = info.status === "fetching";
-  const hasData = info.count > 0;
+  const hasData = isSourceReady(info);
   const progress = info.progress;
 
   return (
@@ -188,8 +237,10 @@ function SourceRow({
       <DataRow
         title={title}
         subtitle={
-          isFetching && progress
-            ? `${progress.phase}: ${progress.done}/${progress.total}`
+          isFetching
+            ? progress
+              ? `${progress.phase}: ${progress.done}/${progress.total}`
+              : "Fetching..."
             : hasData
               ? `${info.count} POIs`
               : "Not fetched"

--- a/store/offlineStore.ts
+++ b/store/offlineStore.ts
@@ -47,7 +47,9 @@ interface OfflineState {
   isConnected: boolean;
 
   // Actions
-  startDownload: (routeId: string, points: RoutePoint[]) => Promise<void>;
+  startTileDownload: (routeId: string, points: RoutePoint[]) => Promise<void>;
+  prepareRouteOffline: (routeId: string, points: RoutePoint[]) => Promise<void>;
+  cancelDownload: (routeId: string) => Promise<void>;
   deleteOfflineData: (routeId: string) => Promise<void>;
   refreshAllStatuses: () => Promise<void>;
   initConnectivityListener: () => () => void;
@@ -56,6 +58,18 @@ interface OfflineState {
   getRouteInfo: (routeId: string) => OfflineRouteInfo;
   isRouteOfflineReady: (routeId: string) => boolean;
   getTotalStorageBytes: () => number;
+}
+
+const downloadGenerations = new Map<string, number>();
+
+function nextDownloadGeneration(routeId: string): number {
+  const next = (downloadGenerations.get(routeId) ?? 0) + 1;
+  downloadGenerations.set(routeId, next);
+  return next;
+}
+
+function isCurrentDownload(routeId: string, generation: number): boolean {
+  return downloadGenerations.get(routeId) === generation;
 }
 
 export const useOfflineStore = create<OfflineState>((set, get) => ({
@@ -80,11 +94,15 @@ export const useOfflineStore = create<OfflineState>((set, get) => ({
     return total;
   },
 
-  startDownload: async (routeId, points) => {
+  startTileDownload: async (routeId, points) => {
+    if (get().routeInfo[routeId]?.status === "downloading") return;
+
+    const generation = nextDownloadGeneration(routeId);
     const estimated = estimateDownloadSize(points);
 
     // Persist-and-set helper for non-progress updates
     const updateInfo = (partial: Partial<OfflineRouteInfo>) => {
+      if (!isCurrentDownload(routeId, generation)) return;
       set((s) => {
         const updated = {
           ...s.routeInfo,
@@ -103,55 +121,90 @@ export const useOfflineStore = create<OfflineState>((set, get) => ({
       error: null,
     });
 
-    // Fetch any missing POI sources through usePoiStore so per-source state
-    // (count, status, error, progress) stays in sync with the UI. Errors are
-    // captured in sourceInfo per-source; tile download continues regardless.
-    const { usePoiStore } = await import("@/store/poiStore");
-    const poiStore = usePoiStore.getState();
-    const counts = await getPOICountsBySource(routeId);
-    if (counts.osm === 0) {
-      await poiStore.fetchSource(routeId, "osm", points);
-    }
-    if (counts.google === 0) {
-      await poiStore.fetchSource(routeId, "google", points);
-    }
-
     // Throttled progress: update store at most every 500ms, skip MMKV persist
     let lastProgressUpdate = 0;
-    await downloadRouteTiles(
-      routeId,
-      points,
-      (percentage, completedBytes) => {
-        const now = Date.now();
-        if (now - lastProgressUpdate < 500) return;
-        lastProgressUpdate = now;
-        const current = get().routeInfo[routeId];
-        if (current?.status !== "downloading") return;
-        set((s) => ({
-          routeInfo: {
-            ...s.routeInfo,
-            [routeId]: {
-              ...(s.routeInfo[routeId] ?? DEFAULT_ROUTE_INFO),
-              percentage,
-              downloadedBytes: completedBytes,
+    try {
+      await downloadRouteTiles(
+        routeId,
+        points,
+        (percentage, completedBytes) => {
+          if (!isCurrentDownload(routeId, generation)) return;
+          const now = Date.now();
+          if (now - lastProgressUpdate < 500) return;
+          lastProgressUpdate = now;
+          const current = get().routeInfo[routeId];
+          if (current?.status !== "downloading") return;
+          set((s) => ({
+            routeInfo: {
+              ...s.routeInfo,
+              [routeId]: {
+                ...(s.routeInfo[routeId] ?? DEFAULT_ROUTE_INFO),
+                percentage,
+                downloadedBytes: completedBytes,
+              },
             },
-          },
-        }));
-      },
-      () => {
-        updateInfo({
-          status: "complete",
-          percentage: 100,
-          downloadedAt: new Date().toISOString(),
-        });
-      },
-      (error) => {
-        updateInfo({ status: "error", error });
-      },
-    );
+          }));
+        },
+        () => {
+          updateInfo({
+            status: "complete",
+            percentage: 100,
+            downloadedAt: new Date().toISOString(),
+          });
+        },
+        (error) => {
+          updateInfo({ status: "error", error });
+        },
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Download failed";
+      updateInfo({ status: "error", error: message });
+    }
+  },
+
+  prepareRouteOffline: async (routeId, points) => {
+    const { usePoiStore } = await import("@/store/poiStore");
+    const poiStore = usePoiStore.getState();
+    let counts = { osm: 0, google: 0 };
+
+    try {
+      counts = await getPOICountsBySource(routeId);
+    } catch (error) {
+      console.warn("Failed to read POI counts before offline preparation:", error);
+    }
+
+    const fetchIfMissing = async (source: "google" | "osm", count: number) => {
+      if (count > 0) return;
+      try {
+        await poiStore.fetchSource(routeId, source, points);
+      } catch (error) {
+        console.warn(`Failed to prepare ${source} POIs for route ${routeId}:`, error);
+      }
+    };
+
+    // Keep source failures scoped. A Google API error should not prevent OSM
+    // from fetching or map tiles from starting.
+    await fetchIfMissing("google", counts.google);
+    await fetchIfMissing("osm", counts.osm);
+
+    const info = get().routeInfo[routeId];
+    if (info?.status === "complete" || info?.status === "downloading") return;
+    await get().startTileDownload(routeId, points);
+  },
+
+  cancelDownload: async (routeId) => {
+    nextDownloadGeneration(routeId);
+    await deleteRoutePacks(routeId);
+    set((s) => {
+      const updated = { ...s.routeInfo };
+      delete updated[routeId];
+      persistRouteInfo(updated);
+      return { routeInfo: updated };
+    });
   },
 
   deleteOfflineData: async (routeId) => {
+    nextDownloadGeneration(routeId);
     await deleteRoutePacks(routeId);
     set((s) => {
       const updated = { ...s.routeInfo };

--- a/store/poiStore.ts
+++ b/store/poiStore.ts
@@ -67,6 +67,28 @@ export const DEFAULT_SOURCE_INFO: SourceInfo = {
   progress: null,
 };
 
+const fetchGenerations = new Map<string, number>();
+
+function fetchGenerationKey(routeId: string, source: POISource): string {
+  return `${routeId}:${source}`;
+}
+
+function nextFetchGeneration(routeId: string, source: POISource): number {
+  const key = fetchGenerationKey(routeId, source);
+  const next = (fetchGenerations.get(key) ?? 0) + 1;
+  fetchGenerations.set(key, next);
+  return next;
+}
+
+function isCurrentFetch(routeId: string, source: POISource, generation: number): boolean {
+  return fetchGenerations.get(fetchGenerationKey(routeId, source)) === generation;
+}
+
+function invalidateRouteFetches(routeId: string): void {
+  nextFetchGeneration(routeId, "osm");
+  nextFetchGeneration(routeId, "google");
+}
+
 const SOURCE_INFO_KEY_PREFIX = "sourceInfo_";
 const sourceInfoKey = (routeId: string, source: POISource) =>
   `${SOURCE_INFO_KEY_PREFIX}${source}_${routeId}`;
@@ -258,7 +280,9 @@ export const usePoiStore = create<POIState>((set, get) => ({
   },
 
   fetchSource: async (routeId, source, routePoints) => {
+    const generation = nextFetchGeneration(routeId, source);
     const updateSourceInfo = (partial: Partial<SourceInfo>, opts?: { persist?: boolean }) => {
+      if (!isCurrentFetch(routeId, source, generation)) return;
       set((s) => {
         const current = s.sourceInfo[routeId]?.[source] ?? { ...DEFAULT_SOURCE_INFO };
         const updated = { ...current, ...partial };
@@ -289,7 +313,9 @@ export const usePoiStore = create<POIState>((set, get) => ({
         progress: null,
       });
 
+      if (!isCurrentFetch(routeId, source, generation)) return;
       const pois = await getPOIsForRoute(routeId);
+      if (!isCurrentFetch(routeId, source, generation)) return;
       set((s) => ({ pois: { ...s.pois, [routeId]: pois } }));
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to fetch POIs";
@@ -298,6 +324,7 @@ export const usePoiStore = create<POIState>((set, get) => ({
   },
 
   clearSource: async (routeId, source) => {
+    nextFetchGeneration(routeId, source);
     await deletePOIsBySource(routeId, source);
     clearSourceInfo(routeId, source);
 
@@ -378,6 +405,7 @@ export const usePoiStore = create<POIState>((set, get) => ({
   },
 
   clearPOIs: async (routeId) => {
+    invalidateRouteFetches(routeId);
     await deletePOIsForRoute(routeId);
     clearSourceInfo(routeId, "osm");
     clearSourceInfo(routeId, "google");
@@ -387,6 +415,7 @@ export const usePoiStore = create<POIState>((set, get) => ({
   cleanupRouteState: (routeId) => {
     // Called when a route is deleted. DB cascade handles pois rows; this
     // only scrubs in-memory state + MMKV source metadata so nothing orphans.
+    invalidateRouteFetches(routeId);
     clearSourceInfo(routeId, "osm");
     clearSourceInfo(routeId, "google");
     set((s) => buildRouteScrubPatch(s, routeId, "remove"));

--- a/tests/mocks/database.ts
+++ b/tests/mocks/database.ts
@@ -1,7 +1,39 @@
 import { vi } from "vitest";
-import type { getClimbsForRoute, updateClimbName } from "@/db/database";
+import type {
+  deletePOIsBySource,
+  deletePOIsForRoute,
+  getClimbsForRoute,
+  getCollectionSegments,
+  getPOICountsBySource,
+  getPOIsForRoute,
+  getRoute,
+  getRoutePoints,
+  getRouteWithPoints,
+  updateClimbName,
+} from "@/db/database";
 
 export const databaseMocks = {
+  deletePOIsBySource: vi.fn<typeof deletePOIsBySource>(),
+  deletePOIsForRoute: vi.fn<typeof deletePOIsForRoute>(),
   getClimbsForRoute: vi.fn<typeof getClimbsForRoute>(),
+  getCollectionSegments: vi.fn<typeof getCollectionSegments>(),
+  getPOICountsBySource: vi.fn<typeof getPOICountsBySource>(),
+  getPOIsForRoute: vi.fn<typeof getPOIsForRoute>(),
+  getRoute: vi.fn<typeof getRoute>(),
+  getRoutePoints: vi.fn<typeof getRoutePoints>(),
+  getRouteWithPoints: vi.fn<typeof getRouteWithPoints>(),
   updateClimbName: vi.fn<typeof updateClimbName>(),
 };
+
+export function resetDatabaseMocks(): void {
+  databaseMocks.deletePOIsBySource.mockResolvedValue(undefined);
+  databaseMocks.deletePOIsForRoute.mockResolvedValue(undefined);
+  databaseMocks.getClimbsForRoute.mockResolvedValue([]);
+  databaseMocks.getCollectionSegments.mockResolvedValue([]);
+  databaseMocks.getPOICountsBySource.mockResolvedValue({ osm: 0, google: 0 });
+  databaseMocks.getPOIsForRoute.mockResolvedValue([]);
+  databaseMocks.getRoute.mockResolvedValue(null);
+  databaseMocks.getRoutePoints.mockResolvedValue([]);
+  databaseMocks.getRouteWithPoints.mockResolvedValue(null);
+  databaseMocks.updateClimbName.mockResolvedValue(undefined);
+}

--- a/tests/mocks/expoNetwork.ts
+++ b/tests/mocks/expoNetwork.ts
@@ -1,0 +1,11 @@
+import { vi } from "vitest";
+
+export const expoNetworkMocks = {
+  addNetworkStateListener: vi.fn(() => ({ remove: vi.fn() })),
+  getNetworkStateAsync: vi.fn(() => Promise.resolve({ isConnected: true })),
+};
+
+export function resetExpoNetworkMocks(): void {
+  expoNetworkMocks.addNetworkStateListener.mockReturnValue({ remove: vi.fn() });
+  expoNetworkMocks.getNetworkStateAsync.mockResolvedValue({ isConnected: true });
+}

--- a/tests/mocks/offlineTiles.ts
+++ b/tests/mocks/offlineTiles.ts
@@ -1,0 +1,25 @@
+import { vi } from "vitest";
+import type {
+  deleteRoutePacks,
+  downloadRouteTiles,
+  estimateDownloadSize,
+  getAllRoutePacks,
+} from "@/services/offlineTiles";
+
+export const offlineTilesMocks = {
+  deleteRoutePacks: vi.fn<typeof deleteRoutePacks>(),
+  downloadRouteTiles: vi.fn<typeof downloadRouteTiles>(),
+  estimateDownloadSize: vi.fn<typeof estimateDownloadSize>(),
+  getAllRoutePacks: vi.fn<typeof getAllRoutePacks>(),
+};
+
+export function resetOfflineTilesMocks(): void {
+  offlineTilesMocks.deleteRoutePacks.mockResolvedValue(undefined);
+  offlineTilesMocks.downloadRouteTiles.mockImplementation(
+    async (_routeId, _points, _onProgress, onComplete) => {
+      onComplete();
+    },
+  );
+  offlineTilesMocks.estimateDownloadSize.mockReturnValue(0);
+  offlineTilesMocks.getAllRoutePacks.mockResolvedValue([]);
+}

--- a/tests/mocks/reactNativeMmkv.ts
+++ b/tests/mocks/reactNativeMmkv.ts
@@ -1,13 +1,24 @@
 import { vi } from "vitest";
 
 export const reactNativeMmkvMocks = {
+  getAllKeys: vi.fn(() => [] as string[]),
   getString: vi.fn(() => null as string | null),
+  remove: vi.fn(),
   set: vi.fn(),
 };
 
 export function createMockMMKV() {
   return {
+    getAllKeys: reactNativeMmkvMocks.getAllKeys,
     getString: reactNativeMmkvMocks.getString,
+    remove: reactNativeMmkvMocks.remove,
     set: reactNativeMmkvMocks.set,
   };
+}
+
+export function resetReactNativeMmkvMocks(): void {
+  reactNativeMmkvMocks.getAllKeys.mockReturnValue([]);
+  reactNativeMmkvMocks.getString.mockReturnValue(null);
+  reactNativeMmkvMocks.remove.mockReturnValue(undefined);
+  reactNativeMmkvMocks.set.mockReturnValue(undefined);
 }

--- a/tests/services/stitchingService.test.ts
+++ b/tests/services/stitchingService.test.ts
@@ -1,16 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { stitchCollection, stitchPOIs } from "@/services/stitchingService";
+import { databaseMocks } from "@/tests/mocks/database";
 import type { POI, RouteWithPoints } from "@/types";
-
-const { mockGetCollectionSegments, mockGetRouteWithPoints } = vi.hoisted(() => ({
-  mockGetCollectionSegments: vi.fn(),
-  mockGetRouteWithPoints: vi.fn(),
-}));
-
-vi.mock("@/db/database", () => ({
-  getCollectionSegments: mockGetCollectionSegments,
-  getRouteWithPoints: mockGetRouteWithPoints,
-}));
 
 const poi = (id: string, routeId: string, distanceAlongRouteMeters: number): POI => ({
   id,
@@ -57,18 +48,13 @@ const route = (id: string, distanceOffset = 0): RouteWithPoints => ({
 });
 
 describe("stitchingService", () => {
-  beforeEach(() => {
-    mockGetCollectionSegments.mockReset();
-    mockGetRouteWithPoints.mockReset();
-  });
-
   it("stitches selected segments in position order", async () => {
-    mockGetCollectionSegments.mockResolvedValue([
+    databaseMocks.getCollectionSegments.mockResolvedValue([
       { collectionId: "c1", routeId: "r2", position: 1, isSelected: true },
       { collectionId: "c1", routeId: "r1", position: 0, isSelected: true },
       { collectionId: "c1", routeId: "r3", position: 2, isSelected: false },
     ]);
-    mockGetRouteWithPoints.mockImplementation(async (routeId: string) => {
+    databaseMocks.getRouteWithPoints.mockImplementation(async (routeId: string) => {
       if (routeId === "r1") return route("r1");
       if (routeId === "r2") return route("r2");
       return null;
@@ -89,7 +75,7 @@ describe("stitchingService", () => {
   });
 
   it("returns empty stitched collection when no selected routes exist", async () => {
-    mockGetCollectionSegments.mockResolvedValue([
+    databaseMocks.getCollectionSegments.mockResolvedValue([
       { collectionId: "c1", routeId: "r1", position: 0, isSelected: false },
     ]);
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,40 @@
+import { beforeEach, vi } from "vitest";
+
+vi.mock("react-native-mmkv", async () => {
+  const { createMockMMKV } = await import("@/tests/mocks/reactNativeMmkv");
+  return { createMMKV: createMockMMKV };
+});
+
+vi.mock("expo-network", async () => {
+  const { expoNetworkMocks } = await import("@/tests/mocks/expoNetwork");
+  return expoNetworkMocks;
+});
+
+vi.mock("@/db/database", async () => {
+  const { databaseMocks } = await import("@/tests/mocks/database");
+  return databaseMocks;
+});
+
+vi.mock("@/services/offlineTiles", async () => {
+  const { offlineTilesMocks } = await import("@/tests/mocks/offlineTiles");
+  return offlineTilesMocks;
+});
+
+beforeEach(async () => {
+  const [
+    { resetDatabaseMocks },
+    { resetExpoNetworkMocks },
+    { resetOfflineTilesMocks },
+    { resetReactNativeMmkvMocks },
+  ] = await Promise.all([
+    import("@/tests/mocks/database"),
+    import("@/tests/mocks/expoNetwork"),
+    import("@/tests/mocks/offlineTiles"),
+    import("@/tests/mocks/reactNativeMmkv"),
+  ]);
+
+  resetDatabaseMocks();
+  resetExpoNetworkMocks();
+  resetOfflineTilesMocks();
+  resetReactNativeMmkvMocks();
+});

--- a/tests/store/etaAndClimbCollectionBehavior.test.ts
+++ b/tests/store/etaAndClimbCollectionBehavior.test.ts
@@ -4,15 +4,10 @@ import { buildStitchedCollection, stitchedSegmentsFixture } from "@/tests/fixtur
 import { buildPoi } from "@/tests/fixtures/poi";
 import { buildRoutePoint } from "@/tests/fixtures/route";
 import { createStitchedCollectionHarness } from "@/tests/helpers/stitchedCollectionHarness";
-import { databaseMocks } from "@/tests/mocks/database";
 import { etaCalculatorMocks } from "@/tests/mocks/etaCalculator";
-import { createMockMMKV } from "@/tests/mocks/reactNativeMmkv";
+import { toDisplayPOI } from "@/services/displayDistance";
 
 const stitchedHarness = createStitchedCollectionHarness();
-
-vi.mock("react-native-mmkv", () => ({
-  createMMKV: createMockMMKV,
-}));
 
 vi.mock("@/services/etaCalculator", async () => {
   const actual = await vi.importActual<typeof import("@/services/etaCalculator")>(
@@ -42,11 +37,6 @@ vi.mock("@/store/poiStore", () => ({
   },
 }));
 
-vi.mock("@/db/database", () => ({
-  getClimbsForRoute: databaseMocks.getClimbsForRoute,
-  updateClimbName: databaseMocks.updateClimbName,
-}));
-
 import { useEtaStore } from "@/store/etaStore";
 import { useClimbStore } from "@/store/climbStore";
 
@@ -65,8 +55,6 @@ describe("stitched collection coordinate behavior", () => {
     });
     stitchedHarness.reset();
     etaCalculatorMocks.computeRouteETA.mockReset();
-    databaseMocks.getClimbsForRoute.mockReset();
-    databaseMocks.updateClimbName.mockReset();
   });
 
   it("applies segment offsets for POI ETA and supports segment 0 and later segments", () => {
@@ -89,8 +77,8 @@ describe("stitched collection coordinate behavior", () => {
       points: stitchedPoints,
     });
 
-    const etaSegment0 = useEtaStore.getState().getETAToPOI(buildPoi("p0", "r1", 900));
-    const etaSegment1 = useEtaStore.getState().getETAToPOI(buildPoi("p1", "r2", 200));
+    const etaSegment0 = useEtaStore.getState().getETAToPOI(toDisplayPOI(buildPoi("p0", "r1", 900)));
+    const etaSegment1 = useEtaStore.getState().getETAToPOI(toDisplayPOI(buildPoi("p1", "r2", 200)));
 
     expect(etaSegment0?.ridingTimeSeconds).toBe(90);
     expect(etaSegment1?.ridingTimeSeconds).toBe(120);
@@ -119,7 +107,7 @@ describe("stitched collection coordinate behavior", () => {
       r2: [buildPoi("poi-late", "r2", 200)],
     };
 
-    const preStitched = buildPoi("poi-late", "r2", 1_200);
+    const preStitched = toDisplayPOI(buildPoi("poi-late", "r2", 200), 1_000);
     const eta = useEtaStore.getState().getETAToPOI(preStitched);
 
     expect(eta?.ridingTimeSeconds).toBe(120);
@@ -151,7 +139,9 @@ describe("stitched collection coordinate behavior", () => {
       .getState()
       .getClimbsForDisplay(["r1", "r2"], stitchedSegmentsFixture);
 
-    expect(display.map((c) => [c.id, c.startDistanceMeters, c.endDistanceMeters])).toEqual([
+    expect(
+      display.map((c) => [c.id, c.effectiveStartDistanceMeters, c.effectiveEndDistanceMeters]),
+    ).toEqual([
       ["c1", 700, 900],
       ["c2", 1_100, 1_400],
     ]);

--- a/tests/store/offlineStore.test.ts
+++ b/tests/store/offlineStore.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildRoutePoint } from "@/tests/fixtures/route";
+import { databaseMocks } from "@/tests/mocks/database";
+import { offlineTilesMocks } from "@/tests/mocks/offlineTiles";
+
+const mocks = vi.hoisted(() => ({
+  fetchSource: vi.fn(),
+}));
+
+vi.mock("@/store/poiStore", () => ({
+  usePoiStore: {
+    getState: () => ({
+      fetchSource: mocks.fetchSource,
+    }),
+  },
+}));
+
+import { useOfflineStore } from "@/store/offlineStore";
+
+const points = [buildRoutePoint(0, 0), buildRoutePoint(1_000, 1)];
+
+describe("offlineStore offline preparation", () => {
+  beforeEach(() => {
+    useOfflineStore.setState({ routeInfo: {}, isConnected: true });
+    mocks.fetchSource.mockResolvedValue(undefined);
+    offlineTilesMocks.estimateDownloadSize.mockReturnValue(1234);
+  });
+
+  it("downloads map tiles without fetching POI sources", async () => {
+    offlineTilesMocks.downloadRouteTiles.mockImplementation(
+      async (_routeId, _points, onProgress, onComplete) => {
+        onProgress(50, 512);
+        onComplete();
+      },
+    );
+
+    await useOfflineStore.getState().startTileDownload("r1", points);
+
+    expect(databaseMocks.getPOICountsBySource).not.toHaveBeenCalled();
+    expect(mocks.fetchSource).not.toHaveBeenCalled();
+    expect(offlineTilesMocks.downloadRouteTiles).toHaveBeenCalledOnce();
+    expect(useOfflineStore.getState().getRouteInfo("r1")).toMatchObject({
+      status: "complete",
+      percentage: 100,
+      downloadedBytes: 512,
+      estimatedBytes: 1234,
+      error: null,
+    });
+  });
+
+  it("prepares missing POI sources independently before starting missing tiles", async () => {
+    databaseMocks.getPOICountsBySource.mockResolvedValue({ google: 0, osm: 0 });
+    mocks.fetchSource.mockImplementation(async (_routeId, source) => {
+      if (source === "google") throw new Error("Google Places API error (503)");
+    });
+    offlineTilesMocks.downloadRouteTiles.mockImplementation(
+      async (_routeId, _points, _onProgress, onComplete) => {
+        onComplete();
+      },
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await useOfflineStore.getState().prepareRouteOffline("r1", points);
+
+    expect(mocks.fetchSource.mock.calls.map(([, source]) => source)).toEqual(["google", "osm"]);
+    expect(offlineTilesMocks.downloadRouteTiles).toHaveBeenCalledOnce();
+    expect(useOfflineStore.getState().getRouteInfo("r1").status).toBe("complete");
+    warn.mockRestore();
+  });
+
+  it("does not restart a tile download that starts while POIs are fetching", async () => {
+    let resolveDownload: (() => void) | undefined;
+    let tileDownload: Promise<void> | undefined;
+    offlineTilesMocks.downloadRouteTiles.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDownload = resolve;
+        }),
+    );
+    mocks.fetchSource.mockImplementation(async (_routeId, source) => {
+      if (source === "google") {
+        tileDownload = useOfflineStore.getState().startTileDownload("r1", points);
+      }
+    });
+
+    await useOfflineStore.getState().prepareRouteOffline("r1", points);
+
+    expect(mocks.fetchSource.mock.calls.map(([, source]) => source)).toEqual(["google", "osm"]);
+    expect(offlineTilesMocks.downloadRouteTiles).toHaveBeenCalledOnce();
+
+    resolveDownload?.();
+    await tileDownload;
+  });
+
+  it("cancel resets visible tile state and ignores late native errors", async () => {
+    let rejectDownload: ((error: string) => void) | undefined;
+    let resolveDownload: (() => void) | undefined;
+    offlineTilesMocks.downloadRouteTiles.mockImplementation(
+      (_routeId, _points, _onProgress, _onComplete, onError) =>
+        new Promise<void>((resolve) => {
+          rejectDownload = onError;
+          resolveDownload = resolve;
+        }),
+    );
+
+    const download = useOfflineStore.getState().startTileDownload("r1", points);
+
+    expect(useOfflineStore.getState().getRouteInfo("r1").status).toBe("downloading");
+
+    await useOfflineStore.getState().cancelDownload("r1");
+    expect(rejectDownload).toBeDefined();
+    expect(resolveDownload).toBeDefined();
+    rejectDownload?.("Download cancelled");
+    resolveDownload?.();
+    await download;
+
+    expect(useOfflineStore.getState().getRouteInfo("r1")).toMatchObject({
+      status: "idle",
+      percentage: 0,
+      error: null,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     include: ["tests/**/*.test.ts"],
     environment: "node",
     clearMocks: true,
+    setupFiles: ["tests/setup.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Split route offline work into explicit map-tile-only downloads and full offline preparation.
- Added a route-level `Prepare for Offline` action that clearly covers map tiles, Google Places, and OpenStreetMap.
- Updated collection preparation to show the active source/segment and to treat POI readiness separately from tile readiness.
- Added generation guards so canceled or superseded tile/POI work cannot later overwrite visible state with stale progress or errors.
- Added shared Vitest defaults for generic native/database/offline tile mocks, plus focused offline store coverage.
- Brought the stitched-coordinate tests in line with the current display-distance types.

Fixes #11

## Verification

- `npx tsc --noEmit`
- `npm test`
- `npm run lint`
- `npx oxfmt --check vitest.config.ts tests/setup.ts tests/mocks/database.ts tests/mocks/expoNetwork.ts tests/mocks/offlineTiles.ts tests/mocks/reactNativeMmkv.ts tests/services/stitchingService.test.ts tests/store/etaAndClimbCollectionBehavior.test.ts tests/store/offlineStore.test.ts`
- `npm run format:check` still reports existing formatting drift in `docs/roadmap.md`.
- `./scripts/smoke-test.sh` could not run because no iOS simulator was booted in this environment (`StopIteration` while locating a booted device).