### PR TITLE
Optimize long route and collection performance

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -66,15 +66,16 @@ export default function RootLayout() {
     return unsubscribe;
   }, []);
 
-  // Prefetch route + collection state during splash so the first tab mount is instant.
+  // Prefetch cheap metadata during splash. Full route geometry is loaded by
+  // the active riding/detail screens when they actually need it.
   useEffect(() => {
     useRouteStore
       .getState()
-      .loadRoutesAndPoints()
+      .loadRouteMetadata()
       .catch((e) => console.warn("Route prefetch failed:", e));
     useCollectionStore
       .getState()
-      .loadCollections()
+      .loadCollectionMetadata()
       .catch((e) => console.warn("Collection prefetch failed:", e));
   }, []);
 

--- a/app/collection/[id].tsx
+++ b/app/collection/[id].tsx
@@ -7,7 +7,6 @@ import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { useThemeColors } from "@/theme";
 import { useCollectionStore } from "@/store/collectionStore";
-import { useRouteStore } from "@/store/routeStore";
 import { useSettingsStore } from "@/store/settingsStore";
 import { useClimbStore } from "@/store/climbStore";
 import type { Collection, CollectionSegmentWithRoute, StitchedCollection } from "@/types";
@@ -46,7 +45,6 @@ export default function CollectionDetailScreen() {
   const selectVariant = useCollectionStore((s) => s.selectVariant);
   const setActiveCollection = useCollectionStore((s) => s.setActiveCollection);
   const deleteCollection = useCollectionStore((s) => s.deleteCollection);
-  const visibleRoutePoints = useRouteStore((s) => s.visibleRoutePoints);
   const units = useSettingsStore((s) => s.units);
 
   const loadData = useCallback(async () => {
@@ -72,12 +70,6 @@ export default function CollectionDetailScreen() {
           s.pointsByRouteId[unselectedRouteIds[i]] = unselectedPoints[i];
         }
         setStitched(s);
-        // Inject per-segment points for mini map RouteLayer rendering
-        const currentPoints = {
-          ...useRouteStore.getState().visibleRoutePoints,
-          ...s.pointsByRouteId,
-        };
-        useRouteStore.setState({ visibleRoutePoints: currentPoints });
       } catch {
         setStitched(null);
       }
@@ -290,7 +282,7 @@ export default function CollectionDetailScreen() {
                 }
               />
               {selectedSegmentRoutes.map((route) => {
-                const points = visibleRoutePoints[route.id];
+                const points = stitched?.pointsByRouteId[route.id];
                 if (!points) return null;
                 return (
                   <RouteLayer

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -57,7 +57,8 @@ export default function MapScreen() {
 
   const routes = useRouteStore((s) => s.routes);
   const visibleRoutePoints = useRouteStore((s) => s.visibleRoutePoints);
-  const loadRoutesAndPoints = useRouteStore((s) => s.loadRoutesAndPoints);
+  const loadRouteMetadata = useRouteStore((s) => s.loadRouteMetadata);
+  const loadRoutePoints = useRouteStore((s) => s.loadRoutePoints);
   const snappedPosition = useRouteStore((s) => s.snappedPosition);
   const setSnappedPosition = useRouteStore((s) => s.setSnappedPosition);
   const loadCollections = useCollectionStore((s) => s.loadCollections);
@@ -73,16 +74,20 @@ export default function MapScreen() {
   const activeRouteIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const activeRouteIdsKey = useMemo(() => activeRouteIds.join(","), [activeRouteIds]);
 
-  // Set of routeIds that are part of the active collection (for RouteLayer styling)
-  const activeCollectionRouteIds = useMemo(() => {
-    if (activeData?.type === "collection") return new Set(activeData.routeIds);
-    return null;
-  }, [activeData]);
+  useEffect(() => {
+    loadRouteMetadata();
+    loadCollections();
+  }, [loadRouteMetadata, loadCollections]);
+
+  const activeStandaloneRouteId = useMemo(
+    () => routes.find((route) => route.isActive)?.id ?? null,
+    [routes],
+  );
 
   useEffect(() => {
-    loadRoutesAndPoints();
-    loadCollections();
-  }, [loadRoutesAndPoints, loadCollections]);
+    if (!activeStandaloneRouteId) return;
+    loadRoutePoints([activeStandaloneRouteId], { prune: true });
+  }, [activeStandaloneRouteId, loadRoutePoints]);
 
   const loadClimbs = useClimbStore((s) => s.loadClimbs);
   const updateCurrentClimb = useClimbStore((s) => s.updateCurrentClimb);
@@ -138,7 +143,10 @@ export default function MapScreen() {
     if (!activeData || !activeRoutePoints?.length) return;
     const pos = useMapStore.getState().userPosition;
     if (!pos) return;
-    const snapped = snapToRoute(pos.latitude, pos.longitude, activeData.id, activeRoutePoints);
+    const previous = useRouteStore.getState().snappedPosition;
+    const snapped = snapToRoute(pos.latitude, pos.longitude, activeData.id, activeRoutePoints, {
+      previousPointIndex: previous?.routeId === activeData.id ? previous.pointIndex : undefined,
+    });
     setSnappedPosition(snapped);
     // Intentional: fire only when active id or points change; the full activeData reference isn't meaningful
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -149,7 +157,10 @@ export default function MapScreen() {
     (position: { latitude: number; longitude: number }) => {
       const data = getActiveRouteDataImperative();
       if (data && data.points.length > 0) {
-        const snapped = snapToRoute(position.latitude, position.longitude, data.id, data.points);
+        const previous = useRouteStore.getState().snappedPosition;
+        const snapped = snapToRoute(position.latitude, position.longitude, data.id, data.points, {
+          previousPointIndex: previous?.routeId === data.id ? previous.pointIndex : undefined,
+        });
         setSnappedPosition(snapped);
       }
     },
@@ -271,27 +282,35 @@ export default function MapScreen() {
     [themeColors.accent],
   );
 
-  // Routes that should be rendered on the map (active or part of active collection, with loaded points)
+  // Standalone active route rendering; collections render as one stitched route below.
   const renderedRoutes = useMemo(
-    () =>
-      routes.filter(
-        (r) =>
-          r.isVisible &&
-          visibleRoutePoints[r.id] &&
-          (r.isActive || (activeCollectionRouteIds?.has(r.id) ?? false)),
-      ),
-    [routes, visibleRoutePoints, activeCollectionRouteIds],
+    () => routes.filter((r) => r.isVisible && r.isActive && visibleRoutePoints[r.id]),
+    [routes, visibleRoutePoints],
   );
+
+  const activeCollectionRoute = useMemo(() => {
+    if (activeData?.type !== "collection") return null;
+    return {
+      id: activeData.id,
+      name: activeData.name,
+      fileName: `${activeData.id}.collection`,
+      color: "",
+      isActive: true,
+      isVisible: true,
+      totalDistanceMeters: activeData.totalDistanceMeters,
+      totalAscentMeters: activeData.totalAscentMeters,
+      totalDescentMeters: activeData.totalDescentMeters,
+      pointCount: activeRoutePoints?.length ?? 0,
+      createdAt: "",
+    };
+  }, [activeData, activeRoutePoints?.length]);
 
   // Forces LocationPuck to remount so its layer is recreated on top of route/POI layers.
   const renderedRouteKey = useMemo(() => {
-    return (
-      renderedRoutes
-        .map((r) => r.id)
-        .sort()
-        .join(",") + `-${mapStyle.styleKey}`
-    );
-  }, [renderedRoutes, mapStyle.styleKey]);
+    const ids = renderedRoutes.map((r) => r.id);
+    if (activeCollectionRoute) ids.push(activeCollectionRoute.id);
+    return ids.sort().join(",") + `-${mapStyle.styleKey}`;
+  }, [renderedRoutes, activeCollectionRoute, mapStyle.styleKey]);
 
   // Climb to highlight on the map — active when Climbs tab is selected
   const highlightedClimb = useMemo(() => {
@@ -343,6 +362,11 @@ export default function MapScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [highlightedClimb?.id]);
 
+  const currentPOIDistanceMeters =
+    snappedPosition && activeData && snappedPosition.routeId === activeData.id
+      ? snappedPosition.distanceAlongRouteMeters
+      : null;
+
   return (
     <View className="flex-1">
       <MapboxMapView
@@ -375,11 +399,20 @@ export default function MapScreen() {
             />
           );
         })}
+        {activeCollectionRoute && activeRoutePoints && activeRoutePoints.length > 1 && (
+          <RouteLayer
+            key={`${activeCollectionRoute.id}-${mapStyle.styleKey}`}
+            route={activeCollectionRoute}
+            points={activeRoutePoints}
+            dimmed={highlightedClimb != null}
+          />
+        )}
         {activeRouteIds.length > 0 && (
           <POILayer
             key={mapStyle.styleKey}
             routeIds={activeRouteIds}
             segments={activeData?.segments ?? null}
+            currentDistanceMeters={currentPOIDistanceMeters}
           />
         )}
         {highlightedClimb && activeRoutePoints && (

--- a/components/map/POILayer.tsx
+++ b/components/map/POILayer.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useCallback } from "react";
 import { ShapeSource, CircleLayer } from "@rnmapbox/maps";
 import { usePoiStore } from "@/store/poiStore";
 import { useThemeColors } from "@/theme";
-import { POI_CATEGORIES } from "@/constants";
+import { POI_BEHIND_THRESHOLD_M, POI_CATEGORIES, POI_MAP_LOOKAHEAD_M } from "@/constants";
 import { haversineDistance } from "@/utils/geo";
 import { toDisplayPOIs } from "@/services/displayDistance";
 import { stitchPOIs } from "@/services/stitchingService";
@@ -13,9 +13,10 @@ const categoryColorMap = Object.fromEntries(POI_CATEGORIES.map((c) => [c.key, c.
 interface POILayerProps {
   routeIds: string[];
   segments: StitchedSegmentInfo[] | null;
+  currentDistanceMeters: number | null;
 }
 
-export default function POILayer({ routeIds, segments }: POILayerProps) {
+export default function POILayer({ routeIds, segments, currentDistanceMeters }: POILayerProps) {
   const getVisiblePOIs = usePoiStore((s) => s.getVisiblePOIs);
   const enabledCategories = usePoiStore((s) => s.enabledCategories);
   const starredPOIIds = usePoiStore((s) => s.starredPOIIds);
@@ -24,21 +25,36 @@ export default function POILayer({ routeIds, segments }: POILayerProps) {
   const colors = useThemeColors();
 
   const visiblePOIs = useMemo(() => {
+    const distanceWindow =
+      currentDistanceMeters == null
+        ? undefined
+        : {
+            startDistanceMeters: currentDistanceMeters - POI_BEHIND_THRESHOLD_M,
+            endDistanceMeters: currentDistanceMeters + POI_MAP_LOOKAHEAD_M,
+          };
+
     if (segments) {
       const poisByRoute: Record<string, POI[]> = {};
       for (const routeId of routeIds) {
         poisByRoute[routeId] = getVisiblePOIs(routeId);
       }
-      return stitchPOIs(segments, poisByRoute);
+      return stitchPOIs(segments, poisByRoute, distanceWindow);
     }
 
     const combined: DisplayPOI[] = [];
     for (const routeId of routeIds) {
-      combined.push(...toDisplayPOIs(getVisiblePOIs(routeId)));
+      const routePois = getVisiblePOIs(routeId).filter((poi) => {
+        if (!distanceWindow) return true;
+        return (
+          poi.distanceAlongRouteMeters >= distanceWindow.startDistanceMeters &&
+          poi.distanceAlongRouteMeters <= distanceWindow.endDistanceMeters
+        );
+      });
+      combined.push(...toDisplayPOIs(routePois));
     }
     return combined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeIds, segments, allPois, enabledCategories, starredPOIIds]);
+  }, [routeIds, segments, currentDistanceMeters, allPois, enabledCategories, starredPOIIds]);
 
   const geoJSON = useMemo(
     (): GeoJSON.FeatureCollection => ({

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -22,6 +22,7 @@ import { formatDistance, formatDuration, formatETA } from "@/utils/formatters";
 import { getOpeningHoursStatus, isOpenAt, getDaySchedules } from "@/services/openingHoursParser";
 import { stitchPOIs } from "@/services/stitchingService";
 import { toDisplayPOIForSegments, toDisplayPOIs } from "@/services/displayDistance";
+import { getETAToDistance as resolveETAToDistance } from "@/services/etaCalculator";
 import POIFilterBar from "@/components/map/POIFilterBar";
 import POIListItem from "@/components/poi/POIListItem";
 import type { ActiveRouteData, DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
@@ -72,16 +73,8 @@ export default function POITabContent({ activeData }: POITabContentProps) {
         currentDist != null &&
         effectiveDist > currentDist
       ) {
-        let poiIdx = currentIdx;
-        for (let i = currentIdx; i < routePoints.length; i++) {
-          if (routePoints[i].distanceFromStartMeters >= effectiveDist) {
-            poiIdx = i;
-            break;
-          }
-          poiIdx = i;
-        }
-        const seconds = cumulativeTime[poiIdx] - cumulativeTime[currentIdx];
-        if (seconds > 0) ridingTime = seconds;
+        const eta = resolveETAToDistance(cumulativeTime, routePoints, currentIdx, effectiveDist);
+        if (eta && eta.ridingTimeSeconds > 0) ridingTime = eta.ridingTimeSeconds;
       }
       allStarred.push({ ...poi, ridingTimeSeconds: ridingTime });
     }

--- a/components/map/ProfileTabContent.tsx
+++ b/components/map/ProfileTabContent.tsx
@@ -9,7 +9,12 @@ import { useSettingsStore } from "@/store/settingsStore";
 import { usePoiStore } from "@/store/poiStore";
 import { useClimbStore } from "@/store/climbStore";
 import { PANEL_MODES } from "@/constants";
-import { computeSliceAscent, computeSliceDescent, extractRouteSlice } from "@/utils/geo";
+import {
+  computeSliceAscent,
+  computeSliceDescent,
+  extractRouteSlice,
+  findFirstPointAtOrAfterDistance,
+} from "@/utils/geo";
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import { climbDifficultyColor } from "@/constants/climbHelpers";
 import { stitchPOIs } from "@/services/stitchingService";
@@ -100,13 +105,11 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
     if (!currentClimb || !activeRoutePoints?.length) return null;
     const padding = 500;
     const startDist = Math.max(0, currentClimb.effectiveStartDistanceMeters - padding);
-    let startIdx = 0;
-    for (let i = 0; i < activeRoutePoints.length; i++) {
-      if (activeRoutePoints[i].distanceFromStartMeters >= startDist) {
-        startIdx = Math.max(0, i - 1);
-        break;
-      }
-    }
+    const firstAtOrAfterStart = findFirstPointAtOrAfterDistance(activeRoutePoints, startDist);
+    const startIdx =
+      activeRoutePoints[firstAtOrAfterStart]?.distanceFromStartMeters === startDist
+        ? firstAtOrAfterStart
+        : Math.max(0, firstAtOrAfterStart - 1);
     const totalSliceM =
       currentClimb.effectiveEndDistanceMeters +
       padding -

--- a/components/map/RouteLayer.tsx
+++ b/components/map/RouteLayer.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { ShapeSource, LineLayer } from "@rnmapbox/maps";
-import { routeToGeoJSON } from "@/utils/geo";
+import { routeToMapGeoJSON } from "@/utils/geo";
 import { useThemeColors } from "@/theme";
 import { ACTIVE_ROUTE_COLOR, INACTIVE_ROUTE_COLOR } from "@/constants";
 import type { Route, RoutePoint } from "@/types";
@@ -14,7 +14,7 @@ interface RouteLayerProps {
 
 export default function RouteLayer({ route, points, dimmed }: RouteLayerProps) {
   const colors = useThemeColors();
-  const geoJSON = useMemo(() => routeToGeoJSON(points), [points]);
+  const geoJSON = useMemo(() => routeToMapGeoJSON(points), [points]);
 
   const outlineStyle = useMemo(
     () => ({

--- a/components/map/UpcomingElevation.tsx
+++ b/components/map/UpcomingElevation.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { View } from "react-native";
 import { Text } from "@/components/ui/text";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
-import { extractRouteSlice } from "@/utils/geo";
+import { extractRouteSlice, findFirstPointAtOrAfterDistance } from "@/utils/geo";
 import { LOOK_BACK_RATIO } from "@/constants";
 import type { RoutePoint, UnitSystem, DisplayPOI, DisplayClimb } from "@/types";
 
@@ -64,10 +64,11 @@ export default function UpcomingElevation({
       startDist = currentDist - desiredBack;
     }
 
-    let startIdx = currentPointIndex;
-    while (startIdx > 0 && points[startIdx - 1].distanceFromStartMeters >= startDist) {
-      startIdx--;
-    }
+    const firstAtOrAfterStart = findFirstPointAtOrAfterDistance(points, startDist);
+    const startIdx =
+      points[firstAtOrAfterStart]?.distanceFromStartMeters === startDist
+        ? firstAtOrAfterStart
+        : Math.max(0, firstAtOrAfterStart - 1);
 
     const sliceOffsetMeters = points[startIdx].distanceFromStartMeters;
     const totalSliceM = totalWindow;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -47,6 +47,8 @@ export const POI_CATEGORIES: POICategoryMeta[] = [
 
 /** How far behind the rider a POI remains visible in the list */
 export const POI_BEHIND_THRESHOLD_M = 1000;
+/** Ordinary riding map view keeps POIs route-windowed to avoid rendering full collections. */
+export const POI_MAP_LOOKAHEAD_M = 100_000;
 
 export const DEFAULT_CORRIDOR_WIDTH_M = 1000;
 export const MAX_CORRIDOR_WIDTH_M = 10000;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,9 @@ Stack and conventions are in `AGENTS.md`. This doc covers data models, offline s
 
 ## Data Models
 
+For long-route performance notes and expected loading behavior, see
+`docs/performance-notes.md`.
+
 ### Route
 
 ```typescript

--- a/docs/performance-notes.md
+++ b/docs/performance-notes.md
@@ -1,0 +1,35 @@
+# Performance Notes
+
+Issue 18 focused on long ultra-distance routes and active collections.
+
+## Route Point Loading
+
+Before: app startup and the map tab called `loadRoutesAndPoints()`, which loaded full point arrays for every visible route.
+
+After: startup loads route metadata only. The map tab lazy-loads full points only for the active standalone route, while active collections are loaded through the collection stitching path. Route and collection detail screens still load full geometry when opened explicitly.
+
+Representative memory shape:
+
+- 4 visible imported routes × 100k points: startup changes from 400k loaded route points to metadata only.
+- Active standalone route: map keeps only that route's full point array.
+- Active collection: map uses the stitched collection geometry and no longer injects raw per-segment point arrays into `routeStore`.
+
+## Collection Activation
+
+Before: collection activation stored both a stitched full-resolution point array and `pointsByRouteId` raw arrays in long-lived store state, then copied those raw arrays into `routeStore.visibleRoutePoints`.
+
+After: active collection stitching omits `pointsByRouteId`, loads selected segments sequentially, and keeps only the stitched points plus segment offsets in the active collection view model. Collection detail still requests raw per-segment points because the planning screen needs mini-map routes and per-segment ETA rows.
+
+Representative 3 × 100k-point collection:
+
+- Before: 300k raw point objects retained plus 300k stitched point objects retained.
+- After active activation: 300k stitched point objects retained; raw selected segment arrays are temporary during stitching.
+
+## Lookup And Rendering
+
+- ETA-to-distance lookup now uses binary search over cumulative route distance instead of scanning forward from the current point.
+- Upcoming elevation and climb slice boundaries use binary distance lookups before slicing.
+- Snapping first checks a local window around the previous snapped index and falls back to a full-route scan only when the position jumps or the local result is too far from the route.
+- Mapbox route layers receive cached, Ramer-Douglas-Peucker simplified geometry with a 20 m tolerance instead of full GPX/KML precision.
+- POI map rendering is route-distance windowed during ordinary riding, while the expanded POI list preserves full-list behavior.
+- Offline POI association builds a route-segment grid once per fetch so each candidate POI checks nearby route segments first, with full-route fallback for sparse/out-of-window cases.

--- a/services/etaCalculator.ts
+++ b/services/etaCalculator.ts
@@ -1,5 +1,6 @@
 import type { RoutePoint, PowerModelConfig, ETAResult } from "@/types";
 import { computeSegmentTime } from "./powerModel";
+import { findFirstPointAtOrAfterDistance } from "@/utils/geo";
 
 /**
  * Compute cumulative riding time (seconds) at each route point.
@@ -54,18 +55,10 @@ export function getETAToDistance(
   const distanceMeters = targetDistanceAlongRouteM - fromDist;
   if (distanceMeters < 0) return null;
 
-  // Find the two points bracketing the target distance
-  let lo = fromIndex;
-  let hi = points.length - 1;
-
-  // Linear scan forward from fromIndex (POIs are usually relatively close)
-  for (let i = fromIndex; i < points.length; i++) {
-    if (points[i].distanceFromStartMeters >= targetDistanceAlongRouteM) {
-      hi = i;
-      lo = Math.max(fromIndex, i - 1);
-      break;
-    }
-  }
+  // Find the two points bracketing the target distance.
+  const targetIndex = findFirstPointAtOrAfterDistance(points, targetDistanceAlongRouteM, fromIndex);
+  const hi = targetIndex < points.length ? targetIndex : points.length - 1;
+  const lo = Math.max(fromIndex, hi - 1);
 
   // Interpolate time between lo and hi
   const loTime = cumulativeTime[lo];

--- a/services/poiFetcher.ts
+++ b/services/poiFetcher.ts
@@ -3,7 +3,7 @@ import type { POI, POISource, RoutePoint } from "@/types";
 import { fetchAllPOIs } from "./overpassClient";
 import { mapOverpassToPOIs, type ClassifiedPOI } from "./poiClassifier";
 import { fetchGooglePlacesPOIs } from "./googlePlacesClient";
-import { computePOIRouteAssociation } from "@/utils/geo";
+import { buildRouteSegmentSpatialIndex, computePOIRouteAssociation } from "@/utils/geo";
 import { insertPOIs, deletePOIsBySource } from "@/db/database";
 
 /** Associate classified POIs with route and filter by corridor */
@@ -15,8 +15,9 @@ function associateAndFilter(
   source: POISource,
 ): POI[] {
   const pois: POI[] = [];
+  const routeIndex = buildRouteSegmentSpatialIndex(routePoints, corridorWidthM);
   for (const c of classified) {
-    const assoc = computePOIRouteAssociation(c.latitude, c.longitude, routePoints);
+    const assoc = computePOIRouteAssociation(c.latitude, c.longitude, routePoints, routeIndex);
     if (assoc.distanceFromRouteMeters > corridorWidthM) continue;
     pois.push({
       id: `${routeId}_${c.sourceId}`,

--- a/services/routeSnapping.ts
+++ b/services/routeSnapping.ts
@@ -3,6 +3,85 @@ import type { RoutePoint, SnappedPosition } from "@/types";
 
 const MAX_SNAP_DISTANCE_M = 1000; // Don't snap if >1km from route
 const LOCAL_SEARCH_WINDOW_POINTS = 500;
+const LOCAL_EDGE_GUARD_POINTS = 25;
+const TRUST_LOCAL_DISTANCE_M = 50;
+const SPATIAL_CELL_SIZE_DEG = 0.01; // ~1.1km latitude; checked with a 2-cell radius below.
+const SPATIAL_QUERY_RADIUS_CELLS = 2;
+
+interface RoutePointSpatialIndex {
+  cells: Map<string, number[]>;
+}
+
+const routePointIndexCache = new WeakMap<RoutePoint[], RoutePointSpatialIndex>();
+
+function cellKey(latCell: number, lonCell: number): string {
+  return `${latCell}:${lonCell}`;
+}
+
+function buildSpatialIndex(points: RoutePoint[]): RoutePointSpatialIndex {
+  const cached = routePointIndexCache.get(points);
+  if (cached) return cached;
+
+  const cells = new Map<string, number[]>();
+  for (let i = 0; i < points.length; i++) {
+    const latCell = Math.floor(points[i].latitude / SPATIAL_CELL_SIZE_DEG);
+    const lonCell = Math.floor(points[i].longitude / SPATIAL_CELL_SIZE_DEG);
+    const key = cellKey(latCell, lonCell);
+    const bucket = cells.get(key);
+    if (bucket) bucket.push(i);
+    else cells.set(key, [i]);
+  }
+
+  const index = { cells };
+  routePointIndexCache.set(points, index);
+  return index;
+}
+
+function findNearestPointWithSpatialIndex(
+  lat: number,
+  lon: number,
+  points: RoutePoint[],
+): { index: number; distanceMeters: number } {
+  const index = buildSpatialIndex(points);
+  const latCell = Math.floor(lat / SPATIAL_CELL_SIZE_DEG);
+  const lonCell = Math.floor(lon / SPATIAL_CELL_SIZE_DEG);
+  const candidateIndexes = new Set<number>();
+
+  for (let dLat = -SPATIAL_QUERY_RADIUS_CELLS; dLat <= SPATIAL_QUERY_RADIUS_CELLS; dLat++) {
+    for (let dLon = -SPATIAL_QUERY_RADIUS_CELLS; dLon <= SPATIAL_QUERY_RADIUS_CELLS; dLon++) {
+      const bucket = index.cells.get(cellKey(latCell + dLat, lonCell + dLon));
+      if (!bucket) continue;
+      for (const pointIndex of bucket) candidateIndexes.add(pointIndex);
+    }
+  }
+
+  if (candidateIndexes.size === 0) {
+    return findNearestPointOnRoute(lat, lon, points);
+  }
+
+  let nearest: { index: number; distanceMeters: number } | null = null;
+  for (const pointIndex of candidateIndexes) {
+    const candidate = findNearestPointOnRoute(lat, lon, points, {
+      startIndex: pointIndex,
+      endIndex: pointIndex,
+    });
+    if (!nearest || candidate.distanceMeters < nearest.distanceMeters) {
+      nearest = candidate;
+    }
+  }
+  return nearest!;
+}
+
+function isTrustedLocalSnap(
+  nearest: { index: number; distanceMeters: number },
+  startIndex: number,
+  endIndex: number,
+): boolean {
+  if (nearest.distanceMeters > TRUST_LOCAL_DISTANCE_M) return false;
+  if (nearest.index - startIndex <= LOCAL_EDGE_GUARD_POINTS) return false;
+  if (endIndex - nearest.index <= LOCAL_EDGE_GUARD_POINTS) return false;
+  return true;
+}
 
 export function snapToRoute(
   lat: number,
@@ -16,14 +95,20 @@ export function snapToRoute(
   let nearest: { index: number; distanceMeters: number } | null = null;
   const previousPointIndex = options?.previousPointIndex;
   if (previousPointIndex != null && previousPointIndex >= 0 && previousPointIndex < points.length) {
+    const startIndex = Math.max(0, previousPointIndex - LOCAL_SEARCH_WINDOW_POINTS);
+    const endIndex = Math.min(points.length - 1, previousPointIndex + LOCAL_SEARCH_WINDOW_POINTS);
     nearest = findNearestPointOnRoute(lat, lon, points, {
-      startIndex: Math.max(0, previousPointIndex - LOCAL_SEARCH_WINDOW_POINTS),
-      endIndex: Math.min(points.length - 1, previousPointIndex + LOCAL_SEARCH_WINDOW_POINTS),
+      startIndex,
+      endIndex,
     });
+
+    if (!isTrustedLocalSnap(nearest, startIndex, endIndex)) {
+      nearest = findNearestPointWithSpatialIndex(lat, lon, points);
+    }
   }
 
-  if (!nearest || nearest.distanceMeters > MAX_SNAP_DISTANCE_M) {
-    nearest = findNearestPointOnRoute(lat, lon, points);
+  if (!nearest) {
+    nearest = findNearestPointWithSpatialIndex(lat, lon, points);
   }
 
   const { index, distanceMeters } = nearest;

--- a/services/routeSnapping.ts
+++ b/services/routeSnapping.ts
@@ -2,16 +2,31 @@ import { findNearestPointOnRoute } from "@/utils/geo";
 import type { RoutePoint, SnappedPosition } from "@/types";
 
 const MAX_SNAP_DISTANCE_M = 1000; // Don't snap if >1km from route
+const LOCAL_SEARCH_WINDOW_POINTS = 500;
 
 export function snapToRoute(
   lat: number,
   lon: number,
   routeId: string,
   points: RoutePoint[],
+  options?: { previousPointIndex?: number | null },
 ): SnappedPosition | null {
   if (points.length === 0) return null;
 
-  const { index, distanceMeters } = findNearestPointOnRoute(lat, lon, points);
+  let nearest: { index: number; distanceMeters: number } | null = null;
+  const previousPointIndex = options?.previousPointIndex;
+  if (previousPointIndex != null && previousPointIndex >= 0 && previousPointIndex < points.length) {
+    nearest = findNearestPointOnRoute(lat, lon, points, {
+      startIndex: Math.max(0, previousPointIndex - LOCAL_SEARCH_WINDOW_POINTS),
+      endIndex: Math.min(points.length - 1, previousPointIndex + LOCAL_SEARCH_WINDOW_POINTS),
+    });
+  }
+
+  if (!nearest || nearest.distanceMeters > MAX_SNAP_DISTANCE_M) {
+    nearest = findNearestPointOnRoute(lat, lon, points);
+  }
+
+  const { index, distanceMeters } = nearest;
 
   if (distanceMeters > MAX_SNAP_DISTANCE_M) return null;
 

--- a/services/stitchingService.ts
+++ b/services/stitchingService.ts
@@ -2,13 +2,34 @@ import { getRouteWithPoints, getCollectionSegments } from "@/db/database";
 import { toDisplayPOI } from "@/services/displayDistance";
 import type { StitchedCollection, StitchedSegmentInfo, RoutePoint, POI, DisplayPOI } from "@/types";
 
-export async function stitchCollection(collectionId: string): Promise<StitchedCollection> {
+interface StitchCollectionOptions {
+  /** Keep raw per-segment point arrays in the returned view model. */
+  includePointsByRouteId?: boolean;
+}
+
+interface DistanceWindow {
+  startDistanceMeters?: number;
+  endDistanceMeters?: number;
+}
+
+function isInDistanceWindow(distanceMeters: number, window?: DistanceWindow): boolean {
+  if (!window) return true;
+  if (window.startDistanceMeters != null && distanceMeters < window.startDistanceMeters) {
+    return false;
+  }
+  if (window.endDistanceMeters != null && distanceMeters > window.endDistanceMeters) {
+    return false;
+  }
+  return true;
+}
+
+export async function stitchCollection(
+  collectionId: string,
+  options: StitchCollectionOptions = {},
+): Promise<StitchedCollection> {
   const allSegments = await getCollectionSegments(collectionId);
   const selected = allSegments.filter((s) => s.isSelected);
   selected.sort((a, b) => a.position - b.position);
-
-  // Load all segment routes in parallel
-  const routeResults = await Promise.all(selected.map((seg) => getRouteWithPoints(seg.routeId)));
 
   const stitchedPoints: RoutePoint[] = [];
   const segmentInfos: StitchedSegmentInfo[] = [];
@@ -19,11 +40,13 @@ export async function stitchCollection(collectionId: string): Promise<StitchedCo
   let totalDescent = 0;
 
   for (let i = 0; i < selected.length; i++) {
-    const route = routeResults[i];
+    const route = await getRouteWithPoints(selected[i].routeId);
     if (!route) continue;
 
     const points = route.points;
-    pointsByRouteId[route.id] = points;
+    if (options.includePointsByRouteId ?? true) {
+      pointsByRouteId[route.id] = points;
+    }
     const startPointIndex = globalIndex;
 
     for (const pt of points) {
@@ -70,6 +93,7 @@ export async function stitchCollection(collectionId: string): Promise<StitchedCo
 export function stitchPOIs(
   segments: StitchedSegmentInfo[],
   poisByRoute: Record<string, POI[]>,
+  window?: DistanceWindow,
 ): DisplayPOI[] {
   const combined: DisplayPOI[] = [];
 
@@ -78,6 +102,8 @@ export function stitchPOIs(
     if (!pois) continue;
 
     for (const poi of pois) {
+      const effectiveDistanceMeters = poi.distanceAlongRouteMeters + seg.distanceOffsetMeters;
+      if (!isInDistanceWindow(effectiveDistanceMeters, window)) continue;
       combined.push(toDisplayPOI(poi, seg.distanceOffsetMeters));
     }
   }

--- a/store/collectionStore.ts
+++ b/store/collectionStore.ts
@@ -38,6 +38,7 @@ interface CollectionState {
   assignedRouteIds: Set<string>;
   isLoading: boolean;
 
+  loadCollectionMetadata: () => Promise<void>;
   loadCollections: () => Promise<void>;
   createCollection: (name: string) => Promise<string>;
   deleteCollection: (id: string) => Promise<void>;
@@ -70,24 +71,29 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
   assignedRouteIds: new Set<string>(),
   isLoading: false,
 
-  loadCollections: async () => {
+  loadCollectionMetadata: async () => {
     try {
       const [collections, assignedRouteIds] = await Promise.all([
         getAllCollections(),
         getAllAssignedRouteIds(),
       ]);
       set({ collections, assignedRouteIds });
-      // If there's an active collection, load its stitched data.
-      // loadStitchedCollection is fingerprint-cached, so unchanged collections
-      // short-circuit without re-reading points.
-      const active = collections.find((c) => c.isActive);
-      if (active) {
-        await get().loadStitchedCollection(active.id);
-      } else {
+      if (!collections.some((c) => c.isActive)) {
         set({ activeStitchedCollection: null, activeStitchedFingerprint: null });
       }
     } catch (e: any) {
       console.warn("Failed to load collections:", e);
+    }
+  },
+
+  loadCollections: async () => {
+    await get().loadCollectionMetadata();
+    // If there's an active collection, load its stitched data. This is
+    // fingerprint-cached, so unchanged collections short-circuit without
+    // re-reading points.
+    const active = get().collections.find((c) => c.isActive);
+    if (active) {
+      await get().loadStitchedCollection(active.id);
     }
   },
 
@@ -236,7 +242,8 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
     await setRoutesVisible(selectedRouteIds);
     // Reload route store to clear route isActive flags and pick up visibility changes
     const { useRouteStore } = await import("@/store/routeStore");
-    await useRouteStore.getState().loadRoutesAndPoints();
+    await useRouteStore.getState().loadRouteMetadata();
+    await useRouteStore.getState().loadRoutePoints([], { prune: true });
     await get().loadCollections();
     set({ isLoading: false });
   },
@@ -254,16 +261,8 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
         return;
       }
 
-      const stitched = await stitchCollection(id);
+      const stitched = await stitchCollection(id, { includePointsByRouteId: false });
       set({ activeStitchedCollection: stitched, activeStitchedFingerprint: fingerprint });
-      // Inject stitched + per-segment points into routeStore so etaStore and RouteLayer work
-      const { useRouteStore } = await import("@/store/routeStore");
-      const current = {
-        ...useRouteStore.getState().visibleRoutePoints,
-        [id]: stitched.points,
-        ...stitched.pointsByRouteId,
-      };
-      useRouteStore.setState({ visibleRoutePoints: current });
     } catch (e: any) {
       console.warn("Failed to stitch collection:", e);
     }

--- a/store/etaStore.ts
+++ b/store/etaStore.ts
@@ -88,13 +88,13 @@ export const useEtaStore = create<ETAState>((set, get) => ({
   },
 
   _resolveETA: (targetDistM) => {
-    const { cumulativeTime, routeId } = get();
+    const { cumulativeTime, routeId, cachedPoints } = get();
     if (!cumulativeTime || !routeId) return null;
 
     const snapped = useRouteStore.getState().snappedPosition;
     if (!snapped) return null;
 
-    const routePoints = useRouteStore.getState().visibleRoutePoints[routeId];
+    const routePoints = cachedPoints ?? useRouteStore.getState().visibleRoutePoints[routeId];
     if (!routePoints?.length) return null;
 
     return getETAToDistance(cumulativeTime, routePoints, snapped.pointIndex, targetDistM);

--- a/store/routeStore.ts
+++ b/store/routeStore.ts
@@ -20,13 +20,15 @@ interface RouteState {
   routes: Route[];
   isLoading: boolean;
   error: string | null;
-  // Cached points for visible routes (for map rendering)
+  // Lazily cached point arrays for routes that currently need full geometry.
   visibleRoutePoints: Record<string, RoutePoint[]>;
   // Snapped position on active route
   snappedPosition: SnappedPosition | null;
 
   /** Fetch route metadata only. Cheap; safe to call on every tab mount. */
   loadRouteMetadata: () => Promise<void>;
+  /** Ensure point arrays are loaded for the given routes without touching unrelated metadata. */
+  loadRoutePoints: (routeIds: string[], options?: { prune?: boolean }) => Promise<void>;
   /**
    * Ensure `visibleRoutePoints` contains points for every currently-visible
    * route. Reuses already-cached entries and fetches missing ones in parallel.
@@ -64,6 +66,39 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   loadRoutesAndPoints: async () => {
     await get().loadRouteMetadata();
     await get().loadVisibleRoutePoints();
+  },
+
+  loadRoutePoints: async (routeIds, options) => {
+    const ids = [...new Set(routeIds.filter(Boolean))];
+    const current = get().visibleRoutePoints;
+
+    if (ids.length === 0) {
+      if (options?.prune && Object.keys(current).length > 0) {
+        set({ visibleRoutePoints: {} });
+      }
+      return;
+    }
+
+    const keepIds = new Set(ids);
+    const toLoad = ids.filter((id) => !current[id]);
+    if (toLoad.length === 0 && !options?.prune) return;
+
+    const loaded = await Promise.all(
+      toLoad.map(async (id) => [id, await getRoutePoints(id)] as const),
+    );
+
+    const next: Record<string, RoutePoint[]> = {};
+    if (options?.prune) {
+      for (const id of ids) {
+        if (current[id]) next[id] = current[id];
+      }
+    } else {
+      Object.assign(next, current);
+    }
+    for (const [id, pts] of loaded) {
+      if (!options?.prune || keepIds.has(id)) next[id] = pts;
+    }
+    set({ visibleRoutePoints: next });
   },
 
   importFromUri: async (uri: string, fileName: string) => {
@@ -108,7 +143,7 @@ export const useRouteStore = create<RouteState>((set, get) => ({
     const { detectAndStoreClimbs } = await import("@/services/climbDetector");
     await detectAndStoreClimbs(route.id, parsed.points);
 
-    await get().loadRoutesAndPoints();
+    await get().loadRouteMetadata();
     return route;
   },
 
@@ -164,8 +199,14 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   toggleVisibility: async (id) => {
     const route = get().routes.find((r) => r.id === id);
     if (!route) return;
-    await updateRouteVisibility(id, !route.isVisible);
-    await get().loadRoutesAndPoints();
+    const nextVisible = !route.isVisible;
+    await updateRouteVisibility(id, nextVisible);
+    if (!nextVisible && get().visibleRoutePoints[id]) {
+      const next = { ...get().visibleRoutePoints };
+      delete next[id];
+      set({ visibleRoutePoints: next });
+    }
+    await get().loadRouteMetadata();
   },
 
   setActiveRoute: async (id) => {
@@ -174,8 +215,9 @@ export const useRouteStore = create<RouteState>((set, get) => ({
     const { useCollectionStore } = await import("@/store/collectionStore");
     useCollectionStore.getState().clearActiveStitched();
     await useCollectionStore.getState().loadCollections();
-    // Active flag only; visibility didn't change, so no point fetch needed.
+    // Load only the active route's points for the riding view.
     await get().loadRouteMetadata();
+    await get().loadRoutePoints([id], { prune: true });
   },
 
   getRouteDetail: async (id) => {
@@ -184,34 +226,10 @@ export const useRouteStore = create<RouteState>((set, get) => ({
 
   loadVisibleRoutePoints: async () => {
     const routes = get().routes.filter((r) => r.isVisible);
-    const current = get().visibleRoutePoints;
-    const visibleIds = new Set(routes.map((r) => r.id));
-
-    const toLoad = routes.filter((r) => !current[r.id]);
-
-    // Fast path: nothing new to load. Still drop stale entries for routes
-    // that are no longer visible.
-    if (toLoad.length === 0) {
-      let changed = false;
-      const next: Record<string, RoutePoint[]> = {};
-      for (const [id, pts] of Object.entries(current)) {
-        if (visibleIds.has(id)) next[id] = pts;
-        else changed = true;
-      }
-      if (changed) set({ visibleRoutePoints: next });
-      return;
-    }
-
-    const loaded = await Promise.all(
-      toLoad.map(async (r) => [r.id, await getRoutePoints(r.id)] as const),
+    await get().loadRoutePoints(
+      routes.map((r) => r.id),
+      { prune: true },
     );
-
-    const next: Record<string, RoutePoint[]> = {};
-    for (const [id, pts] of Object.entries(current)) {
-      if (visibleIds.has(id)) next[id] = pts;
-    }
-    for (const [id, pts] of loaded) next[id] = pts;
-    set({ visibleRoutePoints: next });
   },
 
   setSnappedPosition: (snappedPosition) => {

--- a/store/routeStore.ts
+++ b/store/routeStore.ts
@@ -207,6 +207,9 @@ export const useRouteStore = create<RouteState>((set, get) => ({
       set({ visibleRoutePoints: next });
     }
     await get().loadRouteMetadata();
+    if (nextVisible && route.isActive) {
+      await get().loadRoutePoints([id], { prune: true });
+    }
   },
 
   setActiveRoute: async (id) => {

--- a/tests/mocks/database.ts
+++ b/tests/mocks/database.ts
@@ -2,6 +2,8 @@ import { vi } from "vitest";
 import type {
   deletePOIsBySource,
   deletePOIsForRoute,
+  deleteRoute,
+  getAllRoutes,
   getClimbsForRoute,
   getCollectionSegments,
   getPOICountsBySource,
@@ -9,12 +11,17 @@ import type {
   getRoute,
   getRoutePoints,
   getRouteWithPoints,
+  insertRoute,
+  setActiveRoute,
   updateClimbName,
+  updateRouteVisibility,
 } from "@/db/database";
 
 export const databaseMocks = {
   deletePOIsBySource: vi.fn<typeof deletePOIsBySource>(),
   deletePOIsForRoute: vi.fn<typeof deletePOIsForRoute>(),
+  deleteRoute: vi.fn<typeof deleteRoute>(),
+  getAllRoutes: vi.fn<typeof getAllRoutes>(),
   getClimbsForRoute: vi.fn<typeof getClimbsForRoute>(),
   getCollectionSegments: vi.fn<typeof getCollectionSegments>(),
   getPOICountsBySource: vi.fn<typeof getPOICountsBySource>(),
@@ -22,12 +29,17 @@ export const databaseMocks = {
   getRoute: vi.fn<typeof getRoute>(),
   getRoutePoints: vi.fn<typeof getRoutePoints>(),
   getRouteWithPoints: vi.fn<typeof getRouteWithPoints>(),
+  insertRoute: vi.fn<typeof insertRoute>(),
+  setActiveRoute: vi.fn<typeof setActiveRoute>(),
   updateClimbName: vi.fn<typeof updateClimbName>(),
+  updateRouteVisibility: vi.fn<typeof updateRouteVisibility>(),
 };
 
 export function resetDatabaseMocks(): void {
   databaseMocks.deletePOIsBySource.mockResolvedValue(undefined);
   databaseMocks.deletePOIsForRoute.mockResolvedValue(undefined);
+  databaseMocks.deleteRoute.mockResolvedValue(undefined);
+  databaseMocks.getAllRoutes.mockResolvedValue([]);
   databaseMocks.getClimbsForRoute.mockResolvedValue([]);
   databaseMocks.getCollectionSegments.mockResolvedValue([]);
   databaseMocks.getPOICountsBySource.mockResolvedValue({ osm: 0, google: 0 });
@@ -35,5 +47,8 @@ export function resetDatabaseMocks(): void {
   databaseMocks.getRoute.mockResolvedValue(null);
   databaseMocks.getRoutePoints.mockResolvedValue([]);
   databaseMocks.getRouteWithPoints.mockResolvedValue(null);
+  databaseMocks.insertRoute.mockResolvedValue(undefined);
+  databaseMocks.setActiveRoute.mockResolvedValue(undefined);
   databaseMocks.updateClimbName.mockResolvedValue(undefined);
+  databaseMocks.updateRouteVisibility.mockResolvedValue(undefined);
 }

--- a/tests/services/routeSnapping.test.ts
+++ b/tests/services/routeSnapping.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { snapToRoute } from "@/services/routeSnapping";
+import type { RoutePoint } from "@/types";
+
+function point(idx: number, latitude: number): RoutePoint {
+  return {
+    latitude,
+    longitude: 0,
+    elevationMeters: 0,
+    distanceFromStartMeters: idx * 100,
+    idx,
+  };
+}
+
+describe("routeSnapping", () => {
+  it("uses previous snap locality but falls back when the position jumps beyond the window", () => {
+    const points = Array.from({ length: 1_200 }, (_, idx) => point(idx, idx * 0.001));
+
+    const local = snapToRoute(0.01, 0, "r1", points, { previousPointIndex: 9 });
+    const jumped = snapToRoute(1.1, 0, "r1", points, { previousPointIndex: 9 });
+
+    expect(local?.pointIndex).toBe(10);
+    expect(jumped?.pointIndex).toBe(1_100);
+  });
+});

--- a/tests/services/routeSnapping.test.ts
+++ b/tests/services/routeSnapping.test.ts
@@ -22,4 +22,15 @@ describe("routeSnapping", () => {
     expect(local?.pointIndex).toBe(10);
     expect(jumped?.pointIndex).toBe(1_100);
   });
+
+  it("falls back globally when a stale local window has a plausible but wrong candidate", () => {
+    const points = Array.from({ length: 1_200 }, (_, idx) => point(idx, 5 + idx * 0.001));
+    points[10] = point(10, 0.005); // ~556m away, inside the old local window.
+    points[900] = point(900, 0); // True current position, outside the old local window.
+
+    const snapped = snapToRoute(0, 0, "r1", points, { previousPointIndex: 10 });
+
+    expect(snapped?.pointIndex).toBe(900);
+    expect(snapped?.distanceAlongRouteMeters).toBe(90_000);
+  });
 });

--- a/tests/services/stitchingService.test.ts
+++ b/tests/services/stitchingService.test.ts
@@ -89,6 +89,18 @@ describe("stitchingService", () => {
     expect(stitched.pointsByRouteId).toEqual({});
   });
 
+  it("can omit raw per-segment point arrays for active collection view models", async () => {
+    databaseMocks.getCollectionSegments.mockResolvedValue([
+      { collectionId: "c1", routeId: "r1", position: 0, isSelected: true },
+    ]);
+    databaseMocks.getRouteWithPoints.mockResolvedValue(route("r1"));
+
+    const stitched = await stitchCollection("c1", { includePointsByRouteId: false });
+
+    expect(stitched.points).toHaveLength(2);
+    expect(stitched.pointsByRouteId).toEqual({});
+  });
+
   it("stitchPOIs keeps raw distances and sorts by effective distances", () => {
     const segments = [
       {
@@ -124,5 +136,44 @@ describe("stitchingService", () => {
     expect(combined.map((p) => p.id)).toEqual(["a", "b"]);
     expect(combined.map((p) => p.distanceAlongRouteMeters)).toEqual([900, 10]);
     expect(combined.map((p) => p.effectiveDistanceMeters)).toEqual([900, 1_010]);
+  });
+
+  it("stitchPOIs filters by stitched distance window before copying display POIs", () => {
+    const segments = [
+      {
+        routeId: "r1",
+        routeName: "r1",
+        position: 0,
+        startPointIndex: 0,
+        endPointIndex: 1,
+        distanceOffsetMeters: 0,
+        segmentDistanceMeters: 1_000,
+        segmentAscentMeters: 10,
+        segmentDescentMeters: 10,
+      },
+      {
+        routeId: "r2",
+        routeName: "r2",
+        position: 1,
+        startPointIndex: 2,
+        endPointIndex: 3,
+        distanceOffsetMeters: 1_000,
+        segmentDistanceMeters: 1_000,
+        segmentAscentMeters: 10,
+        segmentDescentMeters: 10,
+      },
+    ];
+
+    const combined = stitchPOIs(
+      segments,
+      {
+        r1: [poi("behind", "r1", 100), poi("near", "r1", 900)],
+        r2: [poi("ahead", "r2", 100), poi("far", "r2", 900)],
+      },
+      { startDistanceMeters: 800, endDistanceMeters: 1_200 },
+    );
+
+    expect(combined.map((p) => p.id)).toEqual(["near", "ahead"]);
+    expect(combined.map((p) => p.effectiveDistanceMeters)).toEqual([900, 1_100]);
   });
 });

--- a/tests/store/routeStore.test.ts
+++ b/tests/store/routeStore.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { databaseMocks } from "@/tests/mocks/database";
+import type { Route, RoutePoint } from "@/types";
+
+vi.mock("expo-document-picker", () => ({
+  getDocumentAsync: vi.fn(),
+}));
+
+vi.mock("expo-file-system", () => ({
+  File: class {
+    text = vi.fn();
+    delete = vi.fn();
+  },
+  Paths: { cache: "" },
+}));
+
+import { useRouteStore } from "@/store/routeStore";
+
+const route = (overrides: Partial<Route> = {}): Route => ({
+  id: "r1",
+  name: "Route 1",
+  fileName: "route.gpx",
+  color: "#fff",
+  isActive: true,
+  isVisible: false,
+  totalDistanceMeters: 1_000,
+  totalAscentMeters: 100,
+  totalDescentMeters: 50,
+  pointCount: 2,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
+const point = (idx: number): RoutePoint => ({
+  latitude: idx,
+  longitude: 0,
+  elevationMeters: 100,
+  distanceFromStartMeters: idx * 100,
+  idx,
+});
+
+describe("routeStore", () => {
+  beforeEach(() => {
+    useRouteStore.setState({
+      routes: [],
+      isLoading: false,
+      error: null,
+      visibleRoutePoints: {},
+      snappedPosition: null,
+    });
+  });
+
+  it("reloads active route points when visibility is turned back on", async () => {
+    const hiddenActiveRoute = route();
+    const visibleActiveRoute = route({ isVisible: true });
+    const points = [point(0), point(1)];
+
+    useRouteStore.setState({ routes: [hiddenActiveRoute], visibleRoutePoints: {} });
+    databaseMocks.getAllRoutes.mockResolvedValue([visibleActiveRoute]);
+    databaseMocks.getRoutePoints.mockResolvedValue(points);
+
+    await useRouteStore.getState().toggleVisibility("r1");
+
+    expect(databaseMocks.updateRouteVisibility).toHaveBeenCalledWith("r1", true);
+    expect(databaseMocks.getRoutePoints).toHaveBeenCalledWith("r1");
+    expect(useRouteStore.getState().routes).toEqual([visibleActiveRoute]);
+    expect(useRouteStore.getState().visibleRoutePoints).toEqual({ r1: points });
+  });
+});

--- a/tests/utils/geo.test.ts
+++ b/tests/utils/geo.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRouteSegmentSpatialIndex,
+  computePOIRouteAssociation,
+  findFirstPointAtOrAfterDistance,
+  findLastPointAtOrBeforeDistance,
+  routeToMapGeoJSON,
+  simplifyRoutePointsForMap,
+} from "@/utils/geo";
+import type { RoutePoint } from "@/types";
+
+function point(idx: number, distanceFromStartMeters: number, latitude = 0): RoutePoint {
+  return {
+    latitude,
+    longitude: distanceFromStartMeters / 100_000,
+    elevationMeters: 100,
+    distanceFromStartMeters,
+    idx,
+  };
+}
+
+describe("geo route performance helpers", () => {
+  it("finds distance boundaries with binary search semantics", () => {
+    const points = [point(0, 0), point(1, 100), point(2, 200), point(3, 400)];
+
+    expect(findFirstPointAtOrAfterDistance(points, 150)).toBe(2);
+    expect(findFirstPointAtOrAfterDistance(points, 400)).toBe(3);
+    expect(findFirstPointAtOrAfterDistance(points, 401)).toBe(4);
+    expect(findLastPointAtOrBeforeDistance(points, 150)).toBe(1);
+    expect(findLastPointAtOrBeforeDistance(points, 50, 1)).toBe(0);
+  });
+
+  it("simplifies map geometry while preserving useful route shape", () => {
+    const points = [
+      point(0, 0, 0),
+      point(1, 100, 0),
+      point(2, 200, 0),
+      point(3, 300, 0.01),
+      point(4, 400, 0),
+      point(5, 500, 0),
+    ];
+
+    const simplified = simplifyRoutePointsForMap(points, 20);
+
+    expect(simplified[0]).toBe(points[0]);
+    expect(simplified[simplified.length - 1]).toBe(points[points.length - 1]);
+    expect(simplified).toContain(points[3]);
+    expect(simplified.length).toBeLessThan(points.length);
+  });
+
+  it("caches map GeoJSON by route point array reference", () => {
+    const points = [point(0, 0), point(1, 100), point(2, 200)];
+
+    expect(routeToMapGeoJSON(points)).toBe(routeToMapGeoJSON(points));
+  });
+
+  it("matches full POI route association when using a segment spatial index", () => {
+    const points = Array.from({ length: 200 }, (_, idx) => point(idx, idx * 100));
+    const indexed = buildRouteSegmentSpatialIndex(points, 1_000);
+
+    const full = computePOIRouteAssociation(0.001, 0.05, points);
+    const withIndex = computePOIRouteAssociation(0.001, 0.05, points, indexed);
+
+    expect(withIndex.distanceAlongRouteMeters).toBeCloseTo(full.distanceAlongRouteMeters, 4);
+    expect(withIndex.distanceFromRouteMeters).toBeCloseTo(full.distanceFromRouteMeters, 4);
+    expect(withIndex.nearestIndex).toBe(full.nearestIndex);
+  });
+});

--- a/utils/geo.ts
+++ b/utils/geo.ts
@@ -1,6 +1,9 @@
 import type { RoutePoint } from "@/types";
 
 const EARTH_RADIUS_M = 6_371_000;
+const METERS_PER_LAT_DEGREE = 111_320;
+const MAP_SIMPLIFY_TOLERANCE_M = 20;
+const mapGeoJSONCache = new WeakMap<RoutePoint[], GeoJSON.Feature<GeoJSON.LineString>>();
 
 export function toRad(deg: number): number {
   return (deg * Math.PI) / 180;
@@ -85,11 +88,14 @@ export function findNearestPointOnRoute(
   lat: number,
   lon: number,
   points: RoutePoint[],
+  options?: { startIndex?: number; endIndex?: number },
 ): { index: number; distanceMeters: number } {
   let minDist = Infinity;
-  let minIndex = 0;
+  let minIndex = options?.startIndex ?? 0;
+  const startIndex = Math.max(0, options?.startIndex ?? 0);
+  const endIndex = Math.min(points.length - 1, options?.endIndex ?? points.length - 1);
 
-  for (let i = 0; i < points.length; i++) {
+  for (let i = startIndex; i <= endIndex; i++) {
     const d = haversineDistance(lat, lon, points[i].latitude, points[i].longitude);
     if (d < minDist) {
       minDist = d;
@@ -98,6 +104,34 @@ export function findNearestPointOnRoute(
   }
 
   return { index: minIndex, distanceMeters: minDist };
+}
+
+/** First point index with distance >= targetDistanceMeters. Returns points.length if none. */
+export function findFirstPointAtOrAfterDistance(
+  points: RoutePoint[],
+  targetDistanceMeters: number,
+  startIndex = 0,
+): number {
+  let lo = Math.max(0, startIndex);
+  let hi = points.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (points[mid].distanceFromStartMeters < targetDistanceMeters) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** Last point index with distance <= targetDistanceMeters. Returns startIndex - 1 if none. */
+export function findLastPointAtOrBeforeDistance(
+  points: RoutePoint[],
+  targetDistanceMeters: number,
+  startIndex = 0,
+): number {
+  const firstAfter = findFirstPointAtOrAfterDistance(points, targetDistanceMeters, startIndex);
+  if (firstAfter >= points.length) return points.length - 1;
+  if (points[firstAfter].distanceFromStartMeters <= targetDistanceMeters) return firstAfter;
+  return firstAfter - 1;
 }
 
 /** Downsample an array to at most maxPoints using Ramer-Douglas-Peucker on elevation vs distance */
@@ -161,12 +195,11 @@ export function extractRouteSlice(
   const startDist = points[startIndex].distanceFromStartMeters;
   const endDist = startDist + maxDistanceM;
 
-  let endIndex = startIndex;
-  while (endIndex < points.length - 1 && points[endIndex + 1].distanceFromStartMeters <= endDist) {
-    endIndex++;
-  }
-  // Include one point past the boundary for a complete slice
-  if (endIndex < points.length - 1) endIndex++;
+  // Include one point past the boundary for a complete slice.
+  const endIndex = Math.min(
+    points.length - 1,
+    findFirstPointAtOrAfterDistance(points, endDist, startIndex),
+  );
 
   const slice = points.slice(startIndex, endIndex + 1);
   return slice.map((p, i) => ({
@@ -206,8 +239,8 @@ export function computeSliceAscent(
   endDistanceMeters: number,
 ): number {
   let ascent = 0;
-  for (let i = startIndex + 1; i < points.length; i++) {
-    if (points[i].distanceFromStartMeters > endDistanceMeters) break;
+  const endIndex = findLastPointAtOrBeforeDistance(points, endDistanceMeters, startIndex + 1);
+  for (let i = startIndex + 1; i <= endIndex; i++) {
     const prev = points[i - 1].elevationMeters;
     const curr = points[i].elevationMeters;
     if (prev != null && curr != null && curr > prev) ascent += curr - prev;
@@ -222,8 +255,8 @@ export function computeSliceDescent(
   endDistanceMeters: number,
 ): number {
   let descent = 0;
-  for (let i = startIndex + 1; i < points.length; i++) {
-    if (points[i].distanceFromStartMeters > endDistanceMeters) break;
+  const endIndex = findLastPointAtOrBeforeDistance(points, endDistanceMeters, startIndex + 1);
+  for (let i = startIndex + 1; i <= endIndex; i++) {
     const prev = points[i - 1].elevationMeters;
     const curr = points[i].elevationMeters;
     if (prev != null && curr != null && curr < prev) descent += prev - curr;
@@ -272,6 +305,81 @@ export function pointToSegmentDistance(
   };
 }
 
+export interface RouteSegmentSpatialIndex {
+  points: RoutePoint[];
+  cellSizeDeg: number;
+  segmentsByCell: Map<string, number[]>;
+}
+
+function cellKey(latCell: number, lonCell: number): string {
+  return `${latCell}:${lonCell}`;
+}
+
+function degreePaddingForMeters(meters: number, latitude: number): { lat: number; lon: number } {
+  const lat = meters / METERS_PER_LAT_DEGREE;
+  const cosLat = Math.max(0.2, Math.abs(Math.cos(toRad(latitude))));
+  return { lat, lon: meters / (METERS_PER_LAT_DEGREE * cosLat) };
+}
+
+export function buildRouteSegmentSpatialIndex(
+  routePoints: RoutePoint[],
+  corridorWidthM: number,
+): RouteSegmentSpatialIndex | null {
+  if (routePoints.length < 2) return null;
+
+  const cellSizeDeg = Math.max(0.02, Math.min(0.2, (Math.max(corridorWidthM, 500) * 2) / 111_320));
+  const segmentsByCell = new Map<string, number[]>();
+
+  for (let i = 0; i < routePoints.length - 1; i++) {
+    const a = routePoints[i];
+    const b = routePoints[i + 1];
+    const midLat = (a.latitude + b.latitude) / 2;
+    const pad = degreePaddingForMeters(corridorWidthM, midLat);
+
+    const minLat = Math.min(a.latitude, b.latitude) - pad.lat;
+    const maxLat = Math.max(a.latitude, b.latitude) + pad.lat;
+    const minLon = Math.min(a.longitude, b.longitude) - pad.lon;
+    const maxLon = Math.max(a.longitude, b.longitude) + pad.lon;
+
+    const minLatCell = Math.floor(minLat / cellSizeDeg);
+    const maxLatCell = Math.floor(maxLat / cellSizeDeg);
+    const minLonCell = Math.floor(minLon / cellSizeDeg);
+    const maxLonCell = Math.floor(maxLon / cellSizeDeg);
+
+    for (let latCell = minLatCell; latCell <= maxLatCell; latCell++) {
+      for (let lonCell = minLonCell; lonCell <= maxLonCell; lonCell++) {
+        const key = cellKey(latCell, lonCell);
+        const bucket = segmentsByCell.get(key);
+        if (bucket) bucket.push(i);
+        else segmentsByCell.set(key, [i]);
+      }
+    }
+  }
+
+  return { points: routePoints, cellSizeDeg, segmentsByCell };
+}
+
+function getCandidateSegmentIndexes(
+  poiLat: number,
+  poiLon: number,
+  index?: RouteSegmentSpatialIndex | null,
+): number[] | null {
+  if (!index) return null;
+  const latCell = Math.floor(poiLat / index.cellSizeDeg);
+  const lonCell = Math.floor(poiLon / index.cellSizeDeg);
+  const candidates = new Set<number>();
+
+  for (let dLat = -1; dLat <= 1; dLat++) {
+    for (let dLon = -1; dLon <= 1; dLon++) {
+      const bucket = index.segmentsByCell.get(cellKey(latCell + dLat, lonCell + dLon));
+      if (!bucket) continue;
+      for (const segmentIndex of bucket) candidates.add(segmentIndex);
+    }
+  }
+
+  return candidates.size > 0 ? [...candidates] : null;
+}
+
 /**
  * For a POI at (lat, lon), find the nearest point on the route
  * and compute both perpendicular distance and distance along route.
@@ -281,6 +389,7 @@ export function computePOIRouteAssociation(
   poiLat: number,
   poiLon: number,
   routePoints: RoutePoint[],
+  spatialIndex?: RouteSegmentSpatialIndex | null,
 ): {
   distanceFromRouteMeters: number;
   distanceAlongRouteMeters: number;
@@ -306,8 +415,11 @@ export function computePOIRouteAssociation(
   let bestDist = Infinity;
   let bestAlongRoute = 0;
   let bestIndex = 0;
+  const candidateIndexes = getCandidateSegmentIndexes(poiLat, poiLon, spatialIndex);
+  const segmentsToCheck =
+    candidateIndexes ?? Array.from({ length: routePoints.length - 1 }, (_, i) => i);
 
-  for (let i = 0; i < routePoints.length - 1; i++) {
+  for (const i of segmentsToCheck) {
     const a = routePoints[i];
     const b = routePoints[i + 1];
 
@@ -347,4 +459,81 @@ export function routeToGeoJSON(points: RoutePoint[]): GeoJSON.Feature<GeoJSON.Li
       coordinates: points.map((p) => [p.longitude, p.latitude]),
     },
   };
+}
+
+function projectedPoint(point: RoutePoint, origin: RoutePoint): { x: number; y: number } {
+  const cosLat = Math.cos(toRad(origin.latitude));
+  return {
+    x: (point.longitude - origin.longitude) * METERS_PER_LAT_DEGREE * cosLat,
+    y: (point.latitude - origin.latitude) * METERS_PER_LAT_DEGREE,
+  };
+}
+
+function perpendicularDistanceMeters(
+  point: { x: number; y: number },
+  start: { x: number; y: number },
+  end: { x: number; y: number },
+): number {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  if (dx === 0 && dy === 0) {
+    return Math.hypot(point.x - start.x, point.y - start.y);
+  }
+  const t = Math.max(
+    0,
+    Math.min(1, ((point.x - start.x) * dx + (point.y - start.y) * dy) / (dx * dx + dy * dy)),
+  );
+  const projX = start.x + t * dx;
+  const projY = start.y + t * dy;
+  return Math.hypot(point.x - projX, point.y - projY);
+}
+
+export function simplifyRoutePointsForMap(
+  points: RoutePoint[],
+  toleranceMeters = MAP_SIMPLIFY_TOLERANCE_M,
+): RoutePoint[] {
+  if (points.length <= 2) return points;
+
+  const origin = points[0];
+  const projected = points.map((point) => projectedPoint(point, origin));
+  const keep = new Uint8Array(points.length);
+  keep[0] = 1;
+  keep[points.length - 1] = 1;
+
+  const stack: [number, number][] = [[0, points.length - 1]];
+  while (stack.length > 0) {
+    const [start, end] = stack.pop()!;
+    if (end <= start + 1) continue;
+
+    let maxDistance = -1;
+    let maxIndex = -1;
+    for (let i = start + 1; i < end; i++) {
+      const distance = perpendicularDistanceMeters(projected[i], projected[start], projected[end]);
+      if (distance > maxDistance) {
+        maxDistance = distance;
+        maxIndex = i;
+      }
+    }
+
+    if (maxIndex !== -1 && maxDistance > toleranceMeters) {
+      keep[maxIndex] = 1;
+      stack.push([start, maxIndex], [maxIndex, end]);
+    }
+  }
+
+  const simplified: RoutePoint[] = [];
+  for (let i = 0; i < points.length; i++) {
+    if (keep[i]) simplified.push(points[i]);
+  }
+  return simplified;
+}
+
+/** Convert route points to simplified, cached GeoJSON for Mapbox rendering. */
+export function routeToMapGeoJSON(points: RoutePoint[]): GeoJSON.Feature<GeoJSON.LineString> {
+  const cached = mapGeoJSONCache.get(points);
+  if (cached) return cached;
+  const simplified = simplifyRoutePointsForMap(points);
+  const geoJSON = routeToGeoJSON(simplified);
+  mapGeoJSONCache.set(points, geoJSON);
+  return geoJSON;
 }


### PR DESCRIPTION
## Summary

- Load route and collection metadata during startup, then lazy-load full route geometry for the active riding/detail contexts.
- Keep active collection state lighter by omitting retained raw segment point arrays, rendering collections from stitched geometry, and avoiding route-store injection for collection detail mini maps.
- Add cached simplified Mapbox route geometry, binary distance helpers for ETA/slices, local-window route snapping, windowed POI map rendering, and a grid-backed POI association path.
- Add performance notes plus tests for stitching windows, route snapping fallback, map simplification/cache behavior, distance boundary helpers, and spatial POI association.

Fixes #18

## Verification

- `npx tsc --noEmit`
- `npm test`
- `npm run lint`
- `git diff --check`
- Commit hook: `oxfmt`, `oxlint --fix`, `tsc --noEmit`