### PR TITLE
Disambiguate route snapping on overlapping routes

### DIFF
--- a/app/route/[id].tsx
+++ b/app/route/[id].tsx
@@ -11,7 +11,12 @@ import { useClimbStore } from "@/store/climbStore";
 import type { RouteWithPoints, Climb } from "@/types";
 import { useMapStyle } from "@/hooks/useMapStyle";
 import { formatDistance, formatElevation } from "@/utils/formatters";
-import { computeElevationProgress, computeBounds } from "@/utils/geo";
+import {
+  computeBounds,
+  computeElevationProgressAtDistance,
+  findPointIndexAtOrAfterDistance,
+} from "@/utils/geo";
+import { resolveRouteProgress } from "@/utils/routeProgress";
 import { toDisplayClimbs, toDisplayPOIs } from "@/services/displayDistance";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import RouteLayer from "@/components/map/RouteLayer";
@@ -57,15 +62,21 @@ export default function RouteDetailScreen() {
     }
   }, [id, loadPOIs, loadClimbs]);
 
+  const activeRouteProgress = useMemo(
+    () => resolveRouteProgress(snappedPosition, id, route?.points),
+    [snappedPosition, id, route?.points],
+  );
+  const currentDistanceMeters = activeRouteProgress?.distanceAlongRouteMeters;
+
   const currentPointIndex = useMemo(() => {
-    if (snappedPosition?.routeId === id) return snappedPosition.pointIndex;
-    return undefined;
-  }, [snappedPosition, id]);
+    if (currentDistanceMeters == null || !route?.points.length) return undefined;
+    return findPointIndexAtOrAfterDistance(route.points, currentDistanceMeters);
+  }, [currentDistanceMeters, route]);
 
   const elevProgress = useMemo(() => {
-    if (currentPointIndex == null || !route) return null;
-    return computeElevationProgress(route.points, currentPointIndex);
-  }, [currentPointIndex, route]);
+    if (currentDistanceMeters == null || !route) return null;
+    return computeElevationProgressAtDistance(route.points, currentDistanceMeters);
+  }, [currentDistanceMeters, route]);
 
   const screenOptions = useMemo(() => ({ title: route?.name ?? "Route" }), [route?.name]);
 
@@ -163,6 +174,7 @@ export default function RouteDetailScreen() {
             width={chartWidth}
             height={chartHeight}
             currentPointIndex={currentPointIndex}
+            currentDistanceMeters={currentDistanceMeters}
             pois={chartPOIs}
             onPOIPress={setSelectedPOI}
             climbs={chartClimbs}
@@ -173,26 +185,16 @@ export default function RouteDetailScreen() {
         <DataSection routeId={id!} points={route.points} />
 
         {/* Progress (if snapped) */}
-        {currentPointIndex != null && elevProgress && (
+        {currentDistanceMeters != null && elevProgress && (
           <View className="mt-2">
             <Text className="text-[22px] font-barlow-semibold text-foreground px-4 mt-2 mb-3">
               Progress
             </Text>
             <View className="flex-row px-4 mb-3 gap-3">
-              <StatBox
-                label="Completed"
-                value={formatDistance(
-                  route.points[currentPointIndex].distanceFromStartMeters,
-                  units,
-                )}
-              />
+              <StatBox label="Completed" value={formatDistance(currentDistanceMeters, units)} />
               <StatBox
                 label="Remaining"
-                value={formatDistance(
-                  route.totalDistanceMeters -
-                    route.points[currentPointIndex].distanceFromStartMeters,
-                  units,
-                )}
+                value={formatDistance(route.totalDistanceMeters - currentDistanceMeters, units)}
               />
             </View>
             <View className="flex-row px-4 mb-3 gap-3">

--- a/components/elevation/ElevationProfile.tsx
+++ b/components/elevation/ElevationProfile.tsx
@@ -37,6 +37,7 @@ interface ElevationProfileProps {
   width: number;
   height: number;
   currentPointIndex?: number;
+  currentDistanceMeters?: number;
   showLegend?: boolean;
   /** Offset added to X-axis labels so they show absolute route distance */
   distanceOffsetMeters?: number;
@@ -207,6 +208,7 @@ export default function ElevationProfile({
   width,
   height,
   currentPointIndex,
+  currentDistanceMeters,
   showLegend = true,
   distanceOffsetMeters = 0,
   pois,
@@ -406,14 +408,30 @@ export default function ElevationProfile({
   }, [climbs, samples, totalMeters, distanceOffsetMeters, xScale, yScale, axisY]);
 
   const currentPos = useMemo(() => {
+    if (currentDistanceMeters != null) {
+      if (
+        !Number.isFinite(currentDistanceMeters) ||
+        currentDistanceMeters < 0 ||
+        currentDistanceMeters > totalMeters
+      ) {
+        return null;
+      }
+      const d = currentDistanceMeters;
+      return {
+        x: xScale(d),
+        y: yScale(interpolateElevation(samples, d)),
+        distanceMeters: d,
+      };
+    }
     if (currentPointIndex == null || currentPointIndex < 0 || currentPointIndex >= points.length)
       return null;
     const p = points[currentPointIndex];
     return {
       x: xScale(p.distanceFromStartMeters),
       y: yScale(p.elevationMeters ?? 0),
+      distanceMeters: p.distanceFromStartMeters,
     };
-  }, [currentPointIndex, points, xScale, yScale]);
+  }, [currentDistanceMeters, totalMeters, currentPointIndex, points, samples, xScale, yScale]);
 
   const scrollRef = useRef<ScrollView | null>(null);
   const [scrollX, setScrollX] = useState(0);
@@ -504,11 +522,10 @@ export default function ElevationProfile({
   }, [overviewShown, innerWidth, scrollX, viewportWidth, overviewInnerWidth]);
 
   const overviewCurrentX = useMemo(() => {
-    if (!overviewShown || !currentPos || totalMeters === 0 || currentPointIndex == null)
-      return null;
-    const frac = points[currentPointIndex].distanceFromStartMeters / totalMeters;
+    if (!overviewShown || !currentPos || totalMeters === 0) return null;
+    const frac = currentPos.distanceMeters / totalMeters;
     return PADDING.left + frac * overviewInnerWidth;
-  }, [overviewShown, currentPos, totalMeters, currentPointIndex, points, overviewInnerWidth]);
+  }, [overviewShown, currentPos, totalMeters, overviewInnerWidth]);
 
   const yLabels = useMemo(() => {
     const raw = buildYLabels(yMin, yMax, dataMin, dataMax).map((value) => ({

--- a/components/map/ClimbTabContent.tsx
+++ b/components/map/ClimbTabContent.tsx
@@ -19,7 +19,8 @@ import {
   getClimbDifficulty,
   CLIMB_DIFFICULTY_LABELS,
 } from "@/constants/climbHelpers";
-import { extractRouteSlice } from "@/utils/geo";
+import { extractRouteSlice, findNearestPointIndexAtDistance } from "@/utils/geo";
+import { resolveActiveRouteProgress } from "@/utils/routeProgress";
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import ClimbListItem from "@/components/climb/ClimbListItem";
@@ -54,7 +55,11 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
 
   const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const segments = activeData?.segments ?? null;
-  const currentDist = snappedPosition?.distanceAlongRouteMeters ?? null;
+  const activeRouteProgress = useMemo(
+    () => resolveActiveRouteProgress(activeData, snappedPosition),
+    [activeData, snappedPosition],
+  );
+  const currentDist = activeRouteProgress?.distanceAlongRouteMeters ?? null;
 
   const displayedClimbs = useMemo(
     () => getClimbsForDisplay(routeIds, segments),
@@ -91,16 +96,22 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
     const sliced = extractRouteSlice(points, startIdx, sliceLength);
     if (sliced.length < 2) return null;
     let currentIdxInSlice: number | undefined;
-    if (snappedPosition) {
-      const idx = snappedPosition.pointIndex - startIdx;
-      if (idx >= 0 && idx < sliced.length) currentIdxInSlice = idx;
+    let currentDistanceInSliceMeters: number | undefined;
+    if (currentDist != null) {
+      const relativeDistance = currentDist - points[startIdx].distanceFromStartMeters;
+      const sliceEndDistance = sliced[sliced.length - 1].distanceFromStartMeters;
+      if (relativeDistance >= 0 && relativeDistance <= sliceEndDistance) {
+        currentIdxInSlice = findNearestPointIndexAtDistance(sliced, relativeDistance);
+        currentDistanceInSliceMeters = relativeDistance;
+      }
     }
     return {
       points: sliced,
       offsetMeters: points[startIdx].distanceFromStartMeters,
       currentIdxInSlice,
+      currentDistanceInSliceMeters,
     };
-  }, [climb, activeData, snappedPosition]);
+  }, [climb, activeData, currentDist]);
 
   const handleStartEdit = () => {
     if (!climb) return;
@@ -223,6 +234,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
               showLegend={false}
               distanceOffsetMeters={climbProfile.offsetMeters}
               currentPointIndex={climbProfile.currentIdxInSlice}
+              currentDistanceMeters={climbProfile.currentDistanceInSliceMeters}
             />
           )}
         </View>

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -17,13 +17,15 @@ import POILayer from "./POILayer";
 import ClimbHighlightLayer from "./ClimbHighlightLayer";
 import TabbedBottomPanel from "./TabbedBottomPanel";
 import { resolveActiveClimb } from "@/utils/climbSelect";
-import { snapToRoute } from "@/services/routeSnapping";
+import { resolveActiveRouteProgress } from "@/utils/routeProgress";
+import { snapToRouteDetailed } from "@/services/routeSnapping";
 import { useActiveRouteData, getActiveRouteDataImperative } from "@/hooks/useActiveRouteData";
 import { usePoiStore } from "@/store/poiStore";
 import { useClimbStore } from "@/store/climbStore";
 import { useEtaStore } from "@/store/etaStore";
 import { useWeatherStore } from "@/store/weatherStore";
 import { useOfflineStore } from "@/store/offlineStore";
+import type { RoutePoint, UserPosition } from "@/types";
 
 // Initialize Mapbox with access token from app config
 try {
@@ -61,6 +63,8 @@ export default function MapScreen() {
   const loadRoutePoints = useRouteStore((s) => s.loadRoutePoints);
   const snappedPosition = useRouteStore((s) => s.snappedPosition);
   const setSnappedPosition = useRouteStore((s) => s.setSnappedPosition);
+  const recordSnapHistory = useRouteStore((s) => s.recordSnapHistory);
+  const clearRouteProgress = useRouteStore((s) => s.clearRouteProgress);
   const loadCollections = useCollectionStore((s) => s.loadCollections);
   const loadPOIs = usePoiStore((s) => s.loadPOIs);
   const computeETAForRoute = useEtaStore((s) => s.computeETAForRoute);
@@ -73,6 +77,11 @@ export default function MapScreen() {
   const activeRoutePoints = activeData?.points ?? null;
   const activeRouteIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const activeRouteIdsKey = useMemo(() => activeRouteIds.join(","), [activeRouteIds]);
+  const activeRouteProgress = useMemo(
+    () => resolveActiveRouteProgress(activeData, snappedPosition),
+    [activeData, snappedPosition],
+  );
+  const activeProgressDistanceMeters = activeRouteProgress?.distanceAlongRouteMeters ?? null;
 
   useEffect(() => {
     loadRouteMetadata();
@@ -96,15 +105,23 @@ export default function MapScreen() {
   const getClimbsForDisplay = useClimbStore((s) => s.getClimbsForDisplay);
   const allClimbData = useClimbStore((s) => s.climbs);
 
-  // Clear stale climb selection when active route/collection changes
+  // Clear stale climb selection and progress when active route/collection geometry changes.
   const activeContextKey = activeData ? `${activeData.id}:${activeRouteIdsKey}` : null;
-  const prevActiveContextKey = useRef(activeContextKey);
+  const prevActiveGeometry = useRef({
+    contextKey: activeContextKey,
+    points: activeRoutePoints,
+  });
   useEffect(() => {
-    if (activeContextKey !== prevActiveContextKey.current) {
-      prevActiveContextKey.current = activeContextKey;
+    const previous = prevActiveGeometry.current;
+    if (activeContextKey !== previous.contextKey || activeRoutePoints !== previous.points) {
+      prevActiveGeometry.current = {
+        contextKey: activeContextKey,
+        points: activeRoutePoints,
+      };
       setSelectedClimb(null);
+      clearRouteProgress();
     }
-  }, [activeContextKey, setSelectedClimb]);
+  }, [activeContextKey, activeRoutePoints, setSelectedClimb, clearRouteProgress]);
 
   // Load POIs and climbs when active context changes
   useEffect(() => {
@@ -128,43 +145,80 @@ export default function MapScreen() {
     if (
       activeData &&
       activeRoutePoints?.length &&
-      snappedPosition &&
+      activeRouteProgress &&
       cumulativeTime &&
       isConnected
     ) {
-      fetchWeather(activeData.id, activeRoutePoints, snappedPosition.pointIndex, cumulativeTime);
+      fetchWeather(
+        activeData.id,
+        activeRoutePoints,
+        activeRouteProgress.distanceAlongRouteMeters,
+        cumulativeTime,
+      );
     }
-    // Intentional: fire on id/pointIndex changes, not full object identities
+    // Intentional: fire on id/progress changes, not full object identities
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeData?.id, snappedPosition?.pointIndex, isConnected, cumulativeTime, fetchWeather]);
+  }, [activeData?.id, activeProgressDistanceMeters, isConnected, cumulativeTime, fetchWeather]);
+
+  const applyRouteSnap = useCallback(
+    (position: UserPosition, data: { id: string; points: RoutePoint[] }) => {
+      const routeState = useRouteStore.getState();
+      const previous = routeState.snappedPosition;
+      const snapped = snapToRouteDetailed(
+        position.latitude,
+        position.longitude,
+        data.id,
+        data.points,
+        {
+          previousPointIndex: previous?.routeId === data.id ? previous.pointIndex : undefined,
+          previousDistanceAlongRouteMeters:
+            previous?.routeId === data.id ? previous.distanceAlongRouteMeters : undefined,
+          history: routeState.snapHistory,
+          headingDegrees: position.heading,
+          speedMetersPerSecond: position.speed,
+          timestamp: position.timestamp,
+        },
+      );
+
+      if (!snapped) {
+        clearRouteProgress();
+        return;
+      }
+
+      setSnappedPosition(snapped.snappedPosition);
+
+      recordSnapHistory({
+        routeId: data.id,
+        latitude: position.latitude,
+        longitude: position.longitude,
+        timestamp: position.timestamp,
+        heading: position.heading,
+        speed: position.speed,
+        selectedCandidate: snapped.selectedCandidate,
+      });
+    },
+    [clearRouteProgress, recordSnapHistory, setSnappedPosition],
+  );
 
   // Snap eagerly when routes load (don't wait for next GPS refresh)
   useEffect(() => {
     if (!activeData || !activeRoutePoints?.length) return;
     const pos = useMapStore.getState().userPosition;
     if (!pos) return;
-    const previous = useRouteStore.getState().snappedPosition;
-    const snapped = snapToRoute(pos.latitude, pos.longitude, activeData.id, activeRoutePoints, {
-      previousPointIndex: previous?.routeId === activeData.id ? previous.pointIndex : undefined,
-    });
-    setSnappedPosition(snapped);
+    applyRouteSnap(pos, { id: activeData.id, points: activeRoutePoints });
     // Intentional: fire only when active id or points change; the full activeData reference isn't meaningful
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeData?.id, activeRoutePoints, setSnappedPosition]);
+  }, [activeData?.id, activeRoutePoints, applyRouteSnap]);
 
   // Snap to route after each position refresh
   const snapAfterRefresh = useCallback(
-    (position: { latitude: number; longitude: number }) => {
+    (position: UserPosition) => {
       const data = getActiveRouteDataImperative();
       if (data && data.points.length > 0) {
-        const previous = useRouteStore.getState().snappedPosition;
-        const snapped = snapToRoute(position.latitude, position.longitude, data.id, data.points, {
-          previousPointIndex: previous?.routeId === data.id ? previous.pointIndex : undefined,
-        });
-        setSnappedPosition(snapped);
+        applyRouteSnap(position, { id: data.id, points: data.points });
       }
     },
-    [setSnappedPosition],
+    [applyRouteSnap],
   );
 
   // On-demand GPS: fetch position on mount
@@ -196,16 +250,16 @@ export default function MapScreen() {
 
   // Track current climb based on snapped position
   useEffect(() => {
-    if (snappedPosition && activeData) {
+    if (activeRouteProgress && activeData) {
       updateCurrentClimb(
-        snappedPosition.distanceAlongRouteMeters,
+        activeRouteProgress.distanceAlongRouteMeters,
         activeData.routeIds,
         activeData.segments,
       );
     }
     // Intentional: fire on primitive id/distance changes, not on full object/array identities
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [snappedPosition?.distanceAlongRouteMeters, activeData?.id, updateCurrentClimb]);
+  }, [activeProgressDistanceMeters, activeData?.id, updateCurrentClimb]);
 
   // Fly to selected POI
   const selectedPOI = usePoiStore((s) => s.selectedPOI);
@@ -316,11 +370,7 @@ export default function MapScreen() {
   const highlightedClimb = useMemo(() => {
     if (panelTab !== "climbs") return null;
     const displayed = getClimbsForDisplay(activeRouteIds, activeData?.segments ?? null);
-    return resolveActiveClimb(
-      displayed,
-      snappedPosition?.distanceAlongRouteMeters ?? null,
-      selectedClimb,
-    );
+    return resolveActiveClimb(displayed, activeProgressDistanceMeters, selectedClimb);
     // allClimbData is a reactivity trigger: getClimbsForDisplay reads store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -328,7 +378,7 @@ export default function MapScreen() {
     selectedClimb,
     activeRouteIds,
     activeData?.segments,
-    snappedPosition?.distanceAlongRouteMeters,
+    activeProgressDistanceMeters,
     allClimbData,
   ]);
 
@@ -362,10 +412,7 @@ export default function MapScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [highlightedClimb?.id]);
 
-  const currentPOIDistanceMeters =
-    snappedPosition && activeData && snappedPosition.routeId === activeData.id
-      ? snappedPosition.distanceAlongRouteMeters
-      : null;
+  const currentPOIDistanceMeters = activeProgressDistanceMeters;
 
   return (
     <View className="flex-1">

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -22,7 +22,8 @@ import { formatDistance, formatDuration, formatETA } from "@/utils/formatters";
 import { getOpeningHoursStatus, isOpenAt, getDaySchedules } from "@/services/openingHoursParser";
 import { stitchPOIs } from "@/services/stitchingService";
 import { toDisplayPOIForSegments, toDisplayPOIs } from "@/services/displayDistance";
-import { getETAToDistance as resolveETAToDistance } from "@/services/etaCalculator";
+import { getETAToDistanceFromDistance as resolveETAToDistance } from "@/services/etaCalculator";
+import { resolveActiveRouteProgress } from "@/utils/routeProgress";
 import POIFilterBar from "@/components/map/POIFilterBar";
 import POIListItem from "@/components/poi/POIListItem";
 import type { ActiveRouteData, DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
@@ -50,8 +51,11 @@ export default function POITabContent({ activeData }: POITabContentProps) {
   const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const routePoints = activeData?.points ?? null;
   const segments = activeData?.segments ?? null;
-  const currentDist = snappedPosition?.distanceAlongRouteMeters ?? null;
-  const currentIdx = snappedPosition?.pointIndex ?? null;
+  const activeRouteProgress = useMemo(
+    () => resolveActiveRouteProgress(activeData, snappedPosition),
+    [activeData, snappedPosition],
+  );
+  const currentDist = activeRouteProgress?.distanceAlongRouteMeters ?? null;
 
   const starredUpcoming = useMemo(() => {
     if (routeIds.length === 0) return [];
@@ -66,14 +70,8 @@ export default function POITabContent({ activeData }: POITabContentProps) {
     for (const poi of displayed) {
       const effectiveDist = poi.effectiveDistanceMeters;
       let ridingTime: number | null = null;
-      if (
-        currentIdx != null &&
-        cumulativeTime &&
-        routePoints &&
-        currentDist != null &&
-        effectiveDist > currentDist
-      ) {
-        const eta = resolveETAToDistance(cumulativeTime, routePoints, currentIdx, effectiveDist);
+      if (cumulativeTime && routePoints && currentDist != null && effectiveDist > currentDist) {
+        const eta = resolveETAToDistance(cumulativeTime, routePoints, currentDist, effectiveDist);
         if (eta && eta.ridingTimeSeconds > 0) ridingTime = eta.ridingTimeSeconds;
       }
       allStarred.push({ ...poi, ridingTimeSeconds: ridingTime });
@@ -85,16 +83,7 @@ export default function POITabContent({ activeData }: POITabContentProps) {
     );
     // starredPOIIds is a reactivity trigger: getStarredPOIs reads from store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    routeIds,
-    segments,
-    getStarredPOIs,
-    starredPOIIds,
-    currentDist,
-    currentIdx,
-    cumulativeTime,
-    routePoints,
-  ]);
+  }, [routeIds, segments, getStarredPOIs, starredPOIIds, currentDist, cumulativeTime, routePoints]);
 
   const totalPOICount = usePoiStore((s) => {
     let count = 0;
@@ -144,7 +133,12 @@ export default function POITabContent({ activeData }: POITabContentProps) {
   // Show inline detail when a POI is selected
   if (selectedPOI) {
     return (
-      <InlinePOIDetail poi={selectedPOI} segments={segments} onBack={() => setSelectedPOI(null)} />
+      <InlinePOIDetail
+        poi={selectedPOI}
+        segments={segments}
+        currentDist={currentDist}
+        onBack={() => setSelectedPOI(null)}
+      />
     );
   }
 
@@ -319,15 +313,16 @@ function CompactPOIRow({
 function InlinePOIDetail({
   poi,
   segments,
+  currentDist,
   onBack,
 }: {
   poi: DisplayPOI;
   segments: StitchedSegmentInfo[] | null;
+  currentDist: number | null;
   onBack: () => void;
 }) {
   const colors = useThemeColors();
   const units = useSettingsStore((s) => s.units);
-  const snappedPosition = useRouteStore((s) => s.snappedPosition);
   const toggleStarred = usePoiStore((s) => s.toggleStarred);
   const isStarred = usePoiStore((s) => s.starredPOIIds.has(poi.id));
   const getETAToPOI = useEtaStore((s) => s.getETAToPOI);
@@ -337,9 +332,9 @@ function InlinePOIDetail({
   const displayPOI = useMemo(() => toDisplayPOIForSegments(poi, segments), [poi, segments]);
 
   const distAhead = useMemo(() => {
-    if (!snappedPosition || !displayPOI) return null;
-    return displayPOI.effectiveDistanceMeters - snappedPosition.distanceAlongRouteMeters;
-  }, [displayPOI, snappedPosition]);
+    if (currentDist == null || !displayPOI) return null;
+    return displayPOI.effectiveDistanceMeters - currentDist;
+  }, [displayPOI, currentDist]);
 
   const etaResult = useMemo(
     () => (displayPOI ? getETAToPOI(displayPOI) : null),

--- a/components/map/ProfileTabContent.tsx
+++ b/components/map/ProfileTabContent.tsx
@@ -10,11 +10,13 @@ import { usePoiStore } from "@/store/poiStore";
 import { useClimbStore } from "@/store/climbStore";
 import { PANEL_MODES } from "@/constants";
 import {
-  computeSliceAscent,
-  computeSliceDescent,
+  computeSliceAscentFromDistance,
+  computeSliceDescentFromDistance,
   extractRouteSlice,
   findFirstPointAtOrAfterDistance,
+  findNearestPointIndexAtDistance,
 } from "@/utils/geo";
+import { resolveRouteProgress } from "@/utils/routeProgress";
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import { climbDifficultyColor } from "@/constants/climbHelpers";
 import { stitchPOIs } from "@/services/stitchingService";
@@ -23,7 +25,6 @@ import UpcomingElevation from "./UpcomingElevation";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import type { PanelMode, POI, ActiveRouteData, DisplayClimb } from "@/types";
 
-const MAX_SNAP_DISTANCE_M = 1000;
 const HEADER_HEIGHT = 44;
 const STATS_HEIGHT = 28;
 const CLIMB_ROW_HEIGHT = 36;
@@ -62,11 +63,12 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
   const units = useSettingsStore((s) => s.units);
   const setSelectedPOI = usePoiStore((s) => s.setSelectedPOI);
 
-  const isSnapped =
-    snappedPosition &&
-    activeId &&
-    snappedPosition.routeId === activeId &&
-    snappedPosition.distanceFromRouteMeters <= MAX_SNAP_DISTANCE_M;
+  const activeRouteProgress = useMemo(
+    () => resolveRouteProgress(snappedPosition, activeId, activeRoutePoints),
+    [snappedPosition, activeId, activeRoutePoints],
+  );
+  const isSnapped = activeRouteProgress != null;
+  const currentDistanceMeters = activeRouteProgress?.distanceAlongRouteMeters ?? null;
 
   const getStarredPOIs = usePoiStore((s) => s.getStarredPOIs);
   const starredPOIIds = usePoiStore((s) => s.starredPOIIds);
@@ -116,52 +118,56 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
       activeRoutePoints[startIdx].distanceFromStartMeters;
     const sliced = extractRouteSlice(activeRoutePoints, startIdx, totalSliceM);
     let currentIdxInSlice: number | undefined;
-    if (isSnapped) {
-      currentIdxInSlice = snappedPosition!.pointIndex - startIdx;
-      if (currentIdxInSlice < 0 || currentIdxInSlice >= sliced.length) {
-        currentIdxInSlice = undefined;
+    let currentDistanceInSliceMeters: number | undefined;
+    if (currentDistanceMeters != null) {
+      const relativeDistanceMeters =
+        currentDistanceMeters - activeRoutePoints[startIdx].distanceFromStartMeters;
+      const sliceEndMeters = sliced[sliced.length - 1]?.distanceFromStartMeters ?? 0;
+      if (relativeDistanceMeters >= 0 && relativeDistanceMeters <= sliceEndMeters) {
+        currentIdxInSlice = findNearestPointIndexAtDistance(sliced, relativeDistanceMeters);
+        currentDistanceInSliceMeters = relativeDistanceMeters;
       }
     }
     return {
       points: sliced,
       currentIdxInSlice,
+      currentDistanceInSliceMeters,
       offsetMeters: activeRoutePoints[startIdx].distanceFromStartMeters,
     };
-  }, [currentClimb, activeRoutePoints, isSnapped, snappedPosition]);
+  }, [currentClimb, activeRoutePoints, currentDistanceMeters]);
 
   const climbProgressText = useMemo(() => {
-    if (!currentClimb || !isSnapped || !snappedPosition || !activeRoutePoints?.length) return null;
-    const currentDist = snappedPosition.distanceAlongRouteMeters;
+    if (!currentClimb || !activeRouteProgress || !activeRoutePoints?.length) return null;
+    const currentDist = activeRouteProgress.distanceAlongRouteMeters;
     const distToTop = currentClimb.effectiveEndDistanceMeters - currentDist;
     if (distToTop <= 0) return null;
-    const ascentRemaining = computeSliceAscent(
+    const ascentRemaining = computeSliceAscentFromDistance(
       activeRoutePoints,
-      snappedPosition.pointIndex,
+      currentDist,
       currentClimb.effectiveEndDistanceMeters,
     );
     return `↑ ${formatElevation(ascentRemaining, units)} remaining  ·  ${formatDistance(distToTop, units)} to top  ·  ${currentClimb.averageGradientPercent}% avg`;
-  }, [currentClimb, isSnapped, snappedPosition, activeRoutePoints, units]);
+  }, [currentClimb, activeRouteProgress, activeRoutePoints, units]);
 
   const showClimbZoom = isClimbZoomed && currentClimb && climbSlice && climbSlice.points.length > 1;
 
   // Slice bounds (matches UpcomingElevation's window)
-  const { windowStartDist, windowEndDist, riderIdx } = useMemo(() => {
-    if (!isSnapped || !activeRoutePoints?.length) {
-      return { windowStartDist: 0, windowEndDist: 0, riderIdx: 0 };
+  const { windowStartDist, windowEndDist } = useMemo(() => {
+    if (currentDistanceMeters == null || !activeRoutePoints?.length) {
+      return { windowStartDist: 0, windowEndDist: 0 };
     }
-    const idx = snappedPosition!.pointIndex;
-    const distDone = activeRoutePoints[idx]?.distanceFromStartMeters ?? 0;
+    const distDone = currentDistanceMeters;
     const la = lookAheadForMode(panelMode);
     const endDist = Math.min(distDone + la, activeTotalDistance);
-    return { windowStartDist: distDone, windowEndDist: endDist, riderIdx: idx };
-  }, [isSnapped, snappedPosition, activeRoutePoints, panelMode, activeTotalDistance]);
+    return { windowStartDist: distDone, windowEndDist: endDist };
+  }, [currentDistanceMeters, activeRoutePoints, panelMode, activeTotalDistance]);
 
   const statsText = useMemo(() => {
     if (!isSnapped || !activeRoutePoints?.length) return null;
-    const asc = computeSliceAscent(activeRoutePoints, riderIdx, windowEndDist);
-    const desc = computeSliceDescent(activeRoutePoints, riderIdx, windowEndDist);
+    const asc = computeSliceAscentFromDistance(activeRoutePoints, windowStartDist, windowEndDist);
+    const desc = computeSliceDescentFromDistance(activeRoutePoints, windowStartDist, windowEndDist);
     return `↑ ${formatElevation(asc, units)}  ·  ↓ ${formatElevation(desc, units)}`;
-  }, [isSnapped, activeRoutePoints, riderIdx, windowEndDist, units]);
+  }, [isSnapped, activeRoutePoints, windowStartDist, windowEndDist, units]);
 
   const climbsAhead = useMemo<DisplayClimb[]>(() => {
     if (climbsForChart.length === 0) return [];
@@ -183,7 +189,6 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
     );
   }
 
-  const effectivePointIndex = isSnapped ? snappedPosition!.pointIndex : 0;
   const lookAhead = lookAheadForMode(panelMode);
 
   const showHeader = !showClimbZoom;
@@ -272,6 +277,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
             width={chartWidth}
             height={chartHeight}
             currentPointIndex={climbSlice!.currentIdxInSlice}
+            currentDistanceMeters={climbSlice!.currentDistanceInSliceMeters}
             showLegend={false}
             distanceOffsetMeters={climbSlice!.offsetMeters}
             climbs={climbsForChart}
@@ -280,7 +286,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
         ) : (
           <UpcomingElevation
             points={activeRoutePoints}
-            currentPointIndex={effectivePointIndex}
+            currentDistanceMeters={currentDistanceMeters}
             lookAhead={lookAhead}
             units={units}
             width={chartWidth}

--- a/components/map/UpcomingElevation.tsx
+++ b/components/map/UpcomingElevation.tsx
@@ -2,13 +2,17 @@ import React, { useMemo } from "react";
 import { View } from "react-native";
 import { Text } from "@/components/ui/text";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
-import { extractRouteSlice, findFirstPointAtOrAfterDistance } from "@/utils/geo";
+import {
+  extractRouteSlice,
+  findFirstPointAtOrAfterDistance,
+  findNearestPointIndexAtDistance,
+} from "@/utils/geo";
 import { LOOK_BACK_RATIO } from "@/constants";
 import type { RoutePoint, UnitSystem, DisplayPOI, DisplayClimb } from "@/types";
 
 interface UpcomingElevationProps {
   points: RoutePoint[];
-  currentPointIndex: number;
+  currentDistanceMeters: number | null;
   /** Look-ahead distance in meters */
   lookAhead: number;
   units: UnitSystem;
@@ -26,7 +30,7 @@ interface UpcomingElevationProps {
 
 export default function UpcomingElevation({
   points,
-  currentPointIndex,
+  currentDistanceMeters,
   lookAhead,
   units,
   width,
@@ -36,16 +40,27 @@ export default function UpcomingElevation({
   climbs,
   fitToWidth,
 }: UpcomingElevationProps) {
-  const { slicedPoints, currentIdxInSlice, offsetMeters, sliceEndDist } = useMemo(() => {
+  const {
+    slicedPoints,
+    currentIdxInSlice,
+    currentDistanceInSliceMeters,
+    offsetMeters,
+    sliceEndDist,
+  } = useMemo(() => {
     if (points.length < 2)
       return {
         slicedPoints: [] as RoutePoint[],
-        currentIdxInSlice: 0,
+        currentIdxInSlice: undefined as number | undefined,
+        currentDistanceInSliceMeters: undefined as number | undefined,
         offsetMeters: 0,
         sliceEndDist: 0,
       };
 
-    const currentDist = points[currentPointIndex].distanceFromStartMeters;
+    const hasCurrentDistance = currentDistanceMeters != null;
+    const currentDist = Math.max(
+      0,
+      Math.min(points[points.length - 1].distanceFromStartMeters, currentDistanceMeters ?? 0),
+    );
     const totalDist = points[points.length - 1].distanceFromStartMeters;
 
     // Window is the selected range total, split 25/75 behind/ahead of the rider.
@@ -73,15 +88,20 @@ export default function UpcomingElevation({
     const sliceOffsetMeters = points[startIdx].distanceFromStartMeters;
     const totalSliceM = totalWindow;
     const sliced = extractRouteSlice(points, startIdx, totalSliceM);
-    const idxInSlice = currentPointIndex - startIdx;
+    const distanceInSliceMeters = hasCurrentDistance ? currentDist - sliceOffsetMeters : undefined;
+    const idxInSlice =
+      distanceInSliceMeters != null
+        ? findNearestPointIndexAtDistance(sliced, distanceInSliceMeters)
+        : undefined;
 
     return {
       slicedPoints: sliced,
       currentIdxInSlice: idxInSlice,
+      currentDistanceInSliceMeters: distanceInSliceMeters,
       offsetMeters: sliceOffsetMeters,
       sliceEndDist: sliceOffsetMeters + totalSliceM,
     };
-  }, [points, currentPointIndex, lookAhead]);
+  }, [points, currentDistanceMeters, lookAhead]);
 
   // Filter POIs to visible slice range
   const visiblePOIs = useMemo(() => {
@@ -116,6 +136,7 @@ export default function UpcomingElevation({
       width={width}
       height={height}
       currentPointIndex={currentIdxInSlice}
+      currentDistanceMeters={currentDistanceInSliceMeters}
       showLegend={false}
       distanceOffsetMeters={offsetMeters}
       pois={visiblePOIs}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,12 @@ OSM opening hours are often missing or wrong for gas stations and groceries — 
 
 Routes are stored individually. Collections reference routes via `collection_segments` table with position-based slots. At display time, selected segments are stitched (points concatenated with distance offsets). `RoutePoint[]` consumers (snapping, ETA cumulative time, weather, elevation rendering) receive the stitched array unchanged — their input is already in "stitched coords".
 
+### Route Progress
+
+`SnappedPosition.distanceAlongRouteMeters` is the authoritative rider progress value. Route snapping computes it from segment projection, so it may fall between imported route points. `SnappedPosition.pointIndex` is still returned as the nearest route point for geometry anchoring and array-based helpers, but consumers should derive indexes from `distanceAlongRouteMeters` when they need an index for slicing, ETA, weather, or elevation rendering.
+
+Raw `SnappedPosition` is an internal store value. UI and service call sites should first resolve it through `utils/routeProgress.ts`, which returns branded `ActiveRouteProgress` only when the snap belongs to the active route or collection, is within the snap-distance threshold, and falls inside the active route's distance bounds. Active route/collection switches clear route progress (`snappedPosition` and snap history together) so stale progress cannot be reused while waiting for a fresh GPS fix.
+
 **Two coordinate systems for POIs and climbs.** POIs and climbs are stored per-route with `distanceAlongRouteMeters` / `startDistanceMeters` relative to **their own route** ("raw coords"). When a collection is active, snapped position, `RoutePoint.distanceFromStartMeters`, and ETA `cumulativeTime` live in **stitched coords** (raw + `segment.distanceOffsetMeters`).
 
 Displayed POIs and climbs use explicit display types:

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -109,7 +109,8 @@ We use **Vitest** for pure-logic tests. It runs in a Node environment and avoids
 ### `services/routeSnapping.ts:snapToRoute`
 
 - Point exactly on route → returns that point's index, `distanceAlongRouteMeters` = its `distanceFromStartMeters`.
-- Point off route → returns nearest point (not interpolated — codify current behaviour).
+- Point off route → returns projected segment progress as authoritative `distanceAlongRouteMeters` while still carrying nearest `pointIndex`.
+- Out-and-back / self-crossing route → recent local snap history keeps progress on the intended leg.
 - Empty route → returns `null`.
 
 ## Not in scope (for now)

--- a/services/etaCalculator.ts
+++ b/services/etaCalculator.ts
@@ -39,8 +39,59 @@ export function getETABetweenIndices(
   return cumulativeTime[toIndex] - cumulativeTime[fromIndex];
 }
 
+function getTimeAtDistance(
+  cumulativeTime: number[],
+  points: RoutePoint[],
+  distanceAlongRouteM: number,
+): number | null {
+  if (points.length === 0 || cumulativeTime.length === 0) return null;
+  if (points.length !== cumulativeTime.length) return null;
+
+  if (points.length === 1) return cumulativeTime[0];
+
+  const hi = Math.min(
+    findFirstPointAtOrAfterDistance(points, distanceAlongRouteM),
+    points.length - 1,
+  );
+  const lo = Math.max(0, hi - 1);
+
+  const loTime = cumulativeTime[lo];
+  const hiTime = cumulativeTime[hi];
+  const loDist = points[lo].distanceFromStartMeters;
+  const hiDist = points[hi].distanceFromStartMeters;
+
+  if (hiDist - loDist <= 0) return loTime;
+
+  const t = (distanceAlongRouteM - loDist) / (hiDist - loDist);
+  return loTime + t * (hiTime - loTime);
+}
+
 /**
- * Get ETA to a specific distance along the route, interpolating between points.
+ * Get ETA between two route distances, interpolating between points.
+ */
+export function getETAToDistanceFromDistance(
+  cumulativeTime: number[],
+  points: RoutePoint[],
+  fromDistanceAlongRouteM: number,
+  targetDistanceAlongRouteM: number,
+): ETAResult | null {
+  if (points.length === 0 || cumulativeTime.length === 0) return null;
+
+  const distanceMeters = targetDistanceAlongRouteM - fromDistanceAlongRouteM;
+  if (distanceMeters < 0) return null;
+
+  const fromTime = getTimeAtDistance(cumulativeTime, points, fromDistanceAlongRouteM);
+  const targetTime = getTimeAtDistance(cumulativeTime, points, targetDistanceAlongRouteM);
+  if (fromTime == null || targetTime == null) return null;
+
+  const ridingTimeSeconds = targetTime - fromTime;
+  const eta = new Date(Date.now() + ridingTimeSeconds * 1000);
+
+  return { distanceMeters, ridingTimeSeconds, eta };
+}
+
+/**
+ * Get ETA from a route point index to a specific distance along the route.
  */
 export function getETAToDistance(
   cumulativeTime: number[],
@@ -48,34 +99,11 @@ export function getETAToDistance(
   fromIndex: number,
   targetDistanceAlongRouteM: number,
 ): ETAResult | null {
-  if (points.length === 0 || cumulativeTime.length === 0) return null;
   if (fromIndex < 0 || fromIndex >= points.length) return null;
-
-  const fromDist = points[fromIndex].distanceFromStartMeters;
-  const distanceMeters = targetDistanceAlongRouteM - fromDist;
-  if (distanceMeters < 0) return null;
-
-  // Find the two points bracketing the target distance.
-  const targetIndex = findFirstPointAtOrAfterDistance(points, targetDistanceAlongRouteM, fromIndex);
-  const hi = targetIndex < points.length ? targetIndex : points.length - 1;
-  const lo = Math.max(fromIndex, hi - 1);
-
-  // Interpolate time between lo and hi
-  const loTime = cumulativeTime[lo];
-  const hiTime = cumulativeTime[hi];
-  const loDist = points[lo].distanceFromStartMeters;
-  const hiDist = points[hi].distanceFromStartMeters;
-
-  let interpolatedTime: number;
-  if (hiDist - loDist > 0) {
-    const t = (targetDistanceAlongRouteM - loDist) / (hiDist - loDist);
-    interpolatedTime = loTime + t * (hiTime - loTime);
-  } else {
-    interpolatedTime = loTime;
-  }
-
-  const ridingTimeSeconds = interpolatedTime - cumulativeTime[fromIndex];
-  const eta = new Date(Date.now() + ridingTimeSeconds * 1000);
-
-  return { distanceMeters, ridingTimeSeconds, eta };
+  return getETAToDistanceFromDistance(
+    cumulativeTime,
+    points,
+    points[fromIndex].distanceFromStartMeters,
+    targetDistanceAlongRouteM,
+  );
 }

--- a/services/routeSnapping.ts
+++ b/services/routeSnapping.ts
@@ -1,86 +1,271 @@
-import { findNearestPointOnRoute } from "@/utils/geo";
-import type { RoutePoint, SnappedPosition } from "@/types";
+import {
+  buildRouteSegmentSpatialIndex,
+  computeBearing,
+  findRouteSegmentCandidates,
+  haversineDistance,
+} from "@/utils/geo";
+import type {
+  RoutePoint,
+  RouteSnapCandidate,
+  RouteSnapConfidence,
+  RouteSnapHistorySample,
+  RouteSnapResult,
+  SnappedPosition,
+} from "@/types";
+import type { RouteSegmentSpatialIndex } from "@/utils/geo";
 
 const MAX_SNAP_DISTANCE_M = 1000; // Don't snap if >1km from route
-const LOCAL_SEARCH_WINDOW_POINTS = 500;
-const LOCAL_EDGE_GUARD_POINTS = 25;
-const TRUST_LOCAL_DISTANCE_M = 50;
-const SPATIAL_CELL_SIZE_DEG = 0.01; // ~1.1km latitude; checked with a 2-cell radius below.
-const SPATIAL_QUERY_RADIUS_CELLS = 2;
+const MAX_SEGMENT_CANDIDATES = 96;
+const MOVEMENT_BEARING_MIN_DISTANCE_M = 8;
+const TRUST_HEADING_MIN_SPEED_MPS = 1;
+const ROUTE_PROGRESS_SCORE_CAP_M = 2000;
+const ROUTE_PROGRESS_WEIGHT = 0.03;
+const BACKTRACK_TOLERANCE_M = 25;
+const BACKTRACK_WEIGHT = 0.06;
+const BACKTRACK_BASE_PENALTY = 20;
+const HEADING_PENALTY_M = 80;
+const DISTINCT_ROUTE_PROGRESS_M = 100;
 
-interface RoutePointSpatialIndex {
-  cells: Map<string, number[]>;
+interface SnapToRouteOptions {
+  previousPointIndex?: number | null;
+  previousDistanceAlongRouteMeters?: number | null;
+  history?: RouteSnapHistorySample[];
+  headingDegrees?: number | null;
+  speedMetersPerSecond?: number | null;
+  timestamp?: number | null;
 }
 
-const routePointIndexCache = new WeakMap<RoutePoint[], RoutePointSpatialIndex>();
+type ScoredRouteSnapCandidate = RouteSnapCandidate & { score: number };
 
-function cellKey(latCell: number, lonCell: number): string {
-  return `${latCell}:${lonCell}`;
-}
+const routeSegmentIndexCache = new WeakMap<RoutePoint[], RouteSegmentSpatialIndex | null>();
 
-function buildSpatialIndex(points: RoutePoint[]): RoutePointSpatialIndex {
-  const cached = routePointIndexCache.get(points);
-  if (cached) return cached;
-
-  const cells = new Map<string, number[]>();
-  for (let i = 0; i < points.length; i++) {
-    const latCell = Math.floor(points[i].latitude / SPATIAL_CELL_SIZE_DEG);
-    const lonCell = Math.floor(points[i].longitude / SPATIAL_CELL_SIZE_DEG);
-    const key = cellKey(latCell, lonCell);
-    const bucket = cells.get(key);
-    if (bucket) bucket.push(i);
-    else cells.set(key, [i]);
-  }
-
-  const index = { cells };
-  routePointIndexCache.set(points, index);
+function getRouteSegmentIndex(points: RoutePoint[]): RouteSegmentSpatialIndex | null {
+  if (routeSegmentIndexCache.has(points)) return routeSegmentIndexCache.get(points) ?? null;
+  const index = buildRouteSegmentSpatialIndex(points, MAX_SNAP_DISTANCE_M);
+  routeSegmentIndexCache.set(points, index);
   return index;
 }
 
-function findNearestPointWithSpatialIndex(
-  lat: number,
-  lon: number,
-  points: RoutePoint[],
-): { index: number; distanceMeters: number } {
-  const index = buildSpatialIndex(points);
-  const latCell = Math.floor(lat / SPATIAL_CELL_SIZE_DEG);
-  const lonCell = Math.floor(lon / SPATIAL_CELL_SIZE_DEG);
-  const candidateIndexes = new Set<number>();
-
-  for (let dLat = -SPATIAL_QUERY_RADIUS_CELLS; dLat <= SPATIAL_QUERY_RADIUS_CELLS; dLat++) {
-    for (let dLon = -SPATIAL_QUERY_RADIUS_CELLS; dLon <= SPATIAL_QUERY_RADIUS_CELLS; dLon++) {
-      const bucket = index.cells.get(cellKey(latCell + dLat, lonCell + dLon));
-      if (!bucket) continue;
-      for (const pointIndex of bucket) candidateIndexes.add(pointIndex);
-    }
-  }
-
-  if (candidateIndexes.size === 0) {
-    return findNearestPointOnRoute(lat, lon, points);
-  }
-
-  let nearest: { index: number; distanceMeters: number } | null = null;
-  for (const pointIndex of candidateIndexes) {
-    const candidate = findNearestPointOnRoute(lat, lon, points, {
-      startIndex: pointIndex,
-      endIndex: pointIndex,
-    });
-    if (!nearest || candidate.distanceMeters < nearest.distanceMeters) {
-      nearest = candidate;
-    }
-  }
-  return nearest!;
+function normalizeDegrees(degrees: number): number {
+  return ((degrees % 360) + 360) % 360;
 }
 
-function isTrustedLocalSnap(
-  nearest: { index: number; distanceMeters: number },
-  startIndex: number,
-  endIndex: number,
-): boolean {
-  if (nearest.distanceMeters > TRUST_LOCAL_DISTANCE_M) return false;
-  if (nearest.index - startIndex <= LOCAL_EDGE_GUARD_POINTS) return false;
-  if (endIndex - nearest.index <= LOCAL_EDGE_GUARD_POINTS) return false;
-  return true;
+function isValidHeadingDegrees(heading: number | null | undefined): heading is number {
+  return heading != null && Number.isFinite(heading) && heading >= 0 && heading < 360;
+}
+
+function angularDifferenceDegrees(a: number, b: number): number {
+  const diff = Math.abs(normalizeDegrees(a) - normalizeDegrees(b));
+  return Math.min(diff, 360 - diff);
+}
+
+function getLastHistorySample(
+  routeId: string,
+  history?: RouteSnapHistorySample[],
+): RouteSnapHistorySample | null {
+  if (!history) return null;
+  for (let i = history.length - 1; i >= 0; i--) {
+    if (history[i].routeId === routeId) return history[i];
+  }
+  return null;
+}
+
+function getPreviousDistanceAlongRoute(
+  routeId: string,
+  points: RoutePoint[],
+  options?: SnapToRouteOptions,
+): number | null {
+  const lastHistory = getLastHistorySample(routeId, options?.history);
+  if (lastHistory) return lastHistory.selectedCandidate.distanceAlongRouteMeters;
+
+  if (options?.previousDistanceAlongRouteMeters != null) {
+    return options.previousDistanceAlongRouteMeters;
+  }
+
+  const previousPointIndex = options?.previousPointIndex;
+  if (previousPointIndex != null && previousPointIndex >= 0 && previousPointIndex < points.length) {
+    return points[previousPointIndex].distanceFromStartMeters;
+  }
+
+  return null;
+}
+
+function getTrustedBearing(
+  lat: number,
+  lon: number,
+  routeId: string,
+  options?: SnapToRouteOptions,
+): number | null {
+  const heading = options?.headingDegrees;
+  const speed = options?.speedMetersPerSecond;
+  if (
+    isValidHeadingDegrees(heading) &&
+    speed != null &&
+    Number.isFinite(speed) &&
+    speed >= TRUST_HEADING_MIN_SPEED_MPS
+  ) {
+    return normalizeDegrees(heading);
+  }
+
+  const lastHistory = getLastHistorySample(routeId, options?.history);
+  if (!lastHistory) return null;
+
+  const movementDistance = haversineDistance(lastHistory.latitude, lastHistory.longitude, lat, lon);
+  if (movementDistance < MOVEMENT_BEARING_MIN_DISTANCE_M) return null;
+
+  return computeBearing(lastHistory.latitude, lastHistory.longitude, lat, lon);
+}
+
+function getExpectedForwardDistance(routeId: string, options?: SnapToRouteOptions): number | null {
+  const lastHistory = getLastHistorySample(routeId, options?.history);
+  if (!lastHistory || options?.timestamp == null || options.timestamp <= lastHistory.timestamp) {
+    return null;
+  }
+
+  const speed = options.speedMetersPerSecond ?? lastHistory.speed;
+  if (speed == null || speed <= 0) return null;
+
+  const elapsedSeconds = (options.timestamp - lastHistory.timestamp) / 1000;
+  return Math.max(250, Math.min(5000, speed * elapsedSeconds * 2 + 100));
+}
+
+function scoreCandidate(
+  candidate: RouteSnapCandidate,
+  previousDistanceAlongRoute: number | null,
+  trustedBearing: number | null,
+  expectedForwardDistance: number | null,
+): number {
+  let score = candidate.distanceFromRouteMeters;
+
+  if (previousDistanceAlongRoute != null) {
+    const routeDelta = candidate.distanceAlongRouteMeters - previousDistanceAlongRoute;
+    score += Math.min(Math.abs(routeDelta), ROUTE_PROGRESS_SCORE_CAP_M) * ROUTE_PROGRESS_WEIGHT;
+
+    if (routeDelta < -BACKTRACK_TOLERANCE_M) {
+      score +=
+        BACKTRACK_BASE_PENALTY +
+        Math.min(Math.abs(routeDelta) - BACKTRACK_TOLERANCE_M, ROUTE_PROGRESS_SCORE_CAP_M) *
+          BACKTRACK_WEIGHT;
+    }
+
+    if (expectedForwardDistance != null && routeDelta > expectedForwardDistance) {
+      score += Math.min(routeDelta - expectedForwardDistance, ROUTE_PROGRESS_SCORE_CAP_M) * 0.02;
+    }
+  }
+
+  if (trustedBearing != null) {
+    score +=
+      (angularDifferenceDegrees(trustedBearing, candidate.segmentBearingDegrees) / 180) *
+      HEADING_PENALTY_M;
+  }
+
+  return score;
+}
+
+function computeConfidence(scoredCandidates: ScoredRouteSnapCandidate[]): RouteSnapConfidence {
+  if (scoredCandidates.length <= 1) return "high";
+
+  const selected = scoredCandidates[0];
+  const secondDistinct = scoredCandidates.find(
+    (candidate) =>
+      Math.abs(candidate.distanceAlongRouteMeters - selected.distanceAlongRouteMeters) >=
+      DISTINCT_ROUTE_PROGRESS_M,
+  );
+  if (!secondDistinct) return "high";
+
+  const scoreDelta = secondDistinct.score - selected.score;
+  if (scoreDelta < 12) return "low";
+  if (scoreDelta < 35) return "medium";
+  return "high";
+}
+
+export function snapToRouteDetailed(
+  lat: number,
+  lon: number,
+  routeId: string,
+  points: RoutePoint[],
+  options?: SnapToRouteOptions,
+): RouteSnapResult | null {
+  if (points.length === 0) return null;
+
+  const previousDistanceAlongRoute = getPreviousDistanceAlongRoute(routeId, points, options);
+  const trustedBearing = getTrustedBearing(lat, lon, routeId, options);
+  const expectedForwardDistance = getExpectedForwardDistance(routeId, options);
+  const spatialIndex = getRouteSegmentIndex(points);
+
+  const candidates = findRouteSegmentCandidates(lat, lon, points, {
+    spatialIndex,
+    maxDistanceMeters: MAX_SNAP_DISTANCE_M,
+    maxCandidates: MAX_SEGMENT_CANDIDATES,
+  }).map<RouteSnapCandidate>((candidate) => ({
+    pointIndex: candidate.nearestPointIndex,
+    segmentIndex: candidate.segmentIndex,
+    projectedFraction: candidate.fraction,
+    distanceAlongRouteMeters: candidate.distanceAlongRouteMeters,
+    distanceFromRouteMeters: candidate.distanceMeters,
+    segmentBearingDegrees: candidate.bearingDegrees,
+  }));
+
+  if (candidates.length === 0) return null;
+
+  const scoredCandidates = candidates
+    .map(
+      (candidate): ScoredRouteSnapCandidate => ({
+        pointIndex: candidate.pointIndex,
+        segmentIndex: candidate.segmentIndex,
+        projectedFraction: candidate.projectedFraction,
+        distanceAlongRouteMeters: candidate.distanceAlongRouteMeters,
+        distanceFromRouteMeters: candidate.distanceFromRouteMeters,
+        segmentBearingDegrees: candidate.segmentBearingDegrees,
+        score: scoreCandidate(
+          candidate,
+          previousDistanceAlongRoute,
+          trustedBearing,
+          expectedForwardDistance,
+        ),
+      }),
+    )
+    .sort((a, b) => {
+      if (a.score !== b.score) return a.score - b.score;
+      if (a.distanceFromRouteMeters !== b.distanceFromRouteMeters) {
+        return a.distanceFromRouteMeters - b.distanceFromRouteMeters;
+      }
+      return a.distanceAlongRouteMeters - b.distanceAlongRouteMeters;
+    });
+
+  const selected = scoredCandidates[0];
+  if (selected.distanceFromRouteMeters > MAX_SNAP_DISTANCE_M) return null;
+
+  const confidence = computeConfidence(scoredCandidates);
+  const snappedPosition: SnappedPosition = {
+    routeId,
+    pointIndex: selected.pointIndex,
+    distanceAlongRouteMeters: selected.distanceAlongRouteMeters,
+    distanceFromRouteMeters: selected.distanceFromRouteMeters,
+  };
+
+  return {
+    routeId,
+    selectedCandidate: {
+      pointIndex: selected.pointIndex,
+      segmentIndex: selected.segmentIndex,
+      projectedFraction: selected.projectedFraction,
+      distanceAlongRouteMeters: selected.distanceAlongRouteMeters,
+      distanceFromRouteMeters: selected.distanceFromRouteMeters,
+      segmentBearingDegrees: selected.segmentBearingDegrees,
+    },
+    candidates: scoredCandidates.map((candidate) => ({
+      pointIndex: candidate.pointIndex,
+      segmentIndex: candidate.segmentIndex,
+      projectedFraction: candidate.projectedFraction,
+      distanceAlongRouteMeters: candidate.distanceAlongRouteMeters,
+      distanceFromRouteMeters: candidate.distanceFromRouteMeters,
+      segmentBearingDegrees: candidate.segmentBearingDegrees,
+    })),
+    confidence,
+    isAmbiguous: confidence === "low",
+    snappedPosition,
+  };
 }
 
 export function snapToRoute(
@@ -88,37 +273,7 @@ export function snapToRoute(
   lon: number,
   routeId: string,
   points: RoutePoint[],
-  options?: { previousPointIndex?: number | null },
+  options?: SnapToRouteOptions,
 ): SnappedPosition | null {
-  if (points.length === 0) return null;
-
-  let nearest: { index: number; distanceMeters: number } | null = null;
-  const previousPointIndex = options?.previousPointIndex;
-  if (previousPointIndex != null && previousPointIndex >= 0 && previousPointIndex < points.length) {
-    const startIndex = Math.max(0, previousPointIndex - LOCAL_SEARCH_WINDOW_POINTS);
-    const endIndex = Math.min(points.length - 1, previousPointIndex + LOCAL_SEARCH_WINDOW_POINTS);
-    nearest = findNearestPointOnRoute(lat, lon, points, {
-      startIndex,
-      endIndex,
-    });
-
-    if (!isTrustedLocalSnap(nearest, startIndex, endIndex)) {
-      nearest = findNearestPointWithSpatialIndex(lat, lon, points);
-    }
-  }
-
-  if (!nearest) {
-    nearest = findNearestPointWithSpatialIndex(lat, lon, points);
-  }
-
-  const { index, distanceMeters } = nearest;
-
-  if (distanceMeters > MAX_SNAP_DISTANCE_M) return null;
-
-  return {
-    routeId,
-    pointIndex: index,
-    distanceAlongRouteMeters: points[index].distanceFromStartMeters,
-    distanceFromRouteMeters: distanceMeters,
-  };
+  return snapToRouteDetailed(lat, lon, routeId, points, options)?.snappedPosition ?? null;
 }

--- a/services/weatherService.ts
+++ b/services/weatherService.ts
@@ -5,54 +5,74 @@ import {
   WEATHER_TIMELINE_HOURS,
 } from "@/constants";
 import { fetchForecasts, type HourlyForecast } from "./weatherClient";
-import { getETAToDistance } from "./etaCalculator";
-import { computeBearing } from "@/utils/geo";
+import { getETAToDistanceFromDistance } from "./etaCalculator";
+import { computeBearing, interpolateRoutePointAtDistance } from "@/utils/geo";
+
+function validRouteStartDistance(points: RoutePoint[], distanceMeters: number): number | null {
+  if (points.length === 0) return null;
+  if (!Number.isFinite(distanceMeters)) return null;
+  const routeEndMeters = points[points.length - 1].distanceFromStartMeters;
+  if (distanceMeters < 0 || distanceMeters > routeEndMeters) return null;
+  return distanceMeters;
+}
 
 export function sampleWaypoints(
   points: RoutePoint[],
-  fromIndex: number,
-): { latitude: number; longitude: number; distanceAlongRouteM: number; index: number }[] {
-  if (points.length === 0 || fromIndex < 0 || fromIndex >= points.length) return [];
+  fromDistanceAlongRouteM: number,
+): {
+  latitude: number;
+  longitude: number;
+  distanceAlongRouteM: number;
+  index: number;
+  segmentIndex: number;
+}[] {
+  const startDist = validRouteStartDistance(points, fromDistanceAlongRouteM);
+  if (startDist == null) return [];
 
-  const startDist = points[fromIndex].distanceFromStartMeters;
   const maxDist = startDist + WEATHER_LOOKAHEAD_M;
+  const start = interpolateRoutePointAtDistance(points, startDist);
+  if (!start) return [];
+
   const waypoints: {
     latitude: number;
     longitude: number;
     distanceAlongRouteM: number;
     index: number;
+    segmentIndex: number;
   }[] = [
     {
-      latitude: points[fromIndex].latitude,
-      longitude: points[fromIndex].longitude,
+      latitude: start.latitude,
+      longitude: start.longitude,
       distanceAlongRouteM: 0,
-      index: fromIndex,
+      index: start.nearestIndex,
+      segmentIndex: start.segmentIndex,
     },
   ];
 
   let nextThreshold = startDist + WEATHER_WAYPOINT_INTERVAL_M;
-  for (let i = fromIndex + 1; i < points.length; i++) {
-    const dist = points[i].distanceFromStartMeters;
-    if (dist > maxDist) break;
-    if (dist >= nextThreshold) {
-      waypoints.push({
-        latitude: points[i].latitude,
-        longitude: points[i].longitude,
-        distanceAlongRouteM: dist - startDist,
-        index: i,
-      });
-      nextThreshold = dist + WEATHER_WAYPOINT_INTERVAL_M;
-    }
+  while (
+    nextThreshold <= maxDist &&
+    nextThreshold <= points[points.length - 1].distanceFromStartMeters
+  ) {
+    const waypoint = interpolateRoutePointAtDistance(points, nextThreshold);
+    if (!waypoint) break;
+    waypoints.push({
+      latitude: waypoint.latitude,
+      longitude: waypoint.longitude,
+      distanceAlongRouteM: nextThreshold - startDist,
+      index: waypoint.nearestIndex,
+      segmentIndex: waypoint.segmentIndex,
+    });
+    nextThreshold += WEATHER_WAYPOINT_INTERVAL_M;
   }
 
   return waypoints;
 }
 
-function getBearingAtIndex(points: RoutePoint[], index: number): number | null {
+function getBearingAtSegment(points: RoutePoint[], segmentIndex: number): number | null {
   if (points.length < 2) return null;
-  const next = Math.min(index + 1, points.length - 1);
-  const prev = Math.max(index - 1, 0);
-  if (prev === next) return null;
+  const prev = Math.max(0, Math.min(segmentIndex, points.length - 2));
+  const next = prev + 1;
   return computeBearing(
     points[prev].latitude,
     points[prev].longitude,
@@ -79,10 +99,13 @@ export function classifyWind(windDirectionDeg: number, routeBearingDeg: number):
  */
 export async function buildWeatherTimeline(
   points: RoutePoint[],
-  fromIndex: number,
+  fromDistanceAlongRouteM: number,
   cumulativeTime: number[],
 ): Promise<WeatherPoint[]> {
-  const waypoints = sampleWaypoints(points, fromIndex);
+  const startDist = validRouteStartDistance(points, fromDistanceAlongRouteM);
+  if (startDist == null) return [];
+
+  const waypoints = sampleWaypoints(points, fromDistanceAlongRouteM);
   if (waypoints.length === 0) return [];
 
   const forecasts = await fetchForecasts(
@@ -96,12 +119,10 @@ export async function buildWeatherTimeline(
     return { waypoint: wp, forecast: match };
   });
 
-  const startDist = points[fromIndex].distanceFromStartMeters;
-
   // Precompute riding time to each waypoint (avoids repeated linear scans in the hourly loop)
   const waypointETAs = waypointForecasts.map((wpf) => {
     const targetDist = startDist + wpf.waypoint.distanceAlongRouteM;
-    const eta = getETAToDistance(cumulativeTime, points, fromIndex, targetDist);
+    const eta = getETAToDistanceFromDistance(cumulativeTime, points, startDist, targetDist);
     return {
       waypoint: wpf.waypoint,
       forecast: wpf.forecast,
@@ -149,7 +170,7 @@ export async function buildWeatherTimeline(
     const hourData = findClosestHour(parsed, hourTime.getTime());
     if (!hourData) continue;
 
-    const bearing = getBearingAtIndex(points, bestWp.waypoint.index);
+    const bearing = getBearingAtSegment(points, bestWp.waypoint.segmentIndex);
 
     timeline.push({
       hourOffset: h,

--- a/store/collectionStore.ts
+++ b/store/collectionStore.ts
@@ -242,8 +242,10 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
     await setRoutesVisible(selectedRouteIds);
     // Reload route store to clear route isActive flags and pick up visibility changes
     const { useRouteStore } = await import("@/store/routeStore");
-    await useRouteStore.getState().loadRouteMetadata();
-    await useRouteStore.getState().loadRoutePoints([], { prune: true });
+    const routeStore = useRouteStore.getState();
+    routeStore.clearRouteProgress();
+    await routeStore.loadRouteMetadata();
+    await routeStore.loadRoutePoints([], { prune: true });
     await get().loadCollections();
     set({ isLoading: false });
   },

--- a/store/etaStore.ts
+++ b/store/etaStore.ts
@@ -8,8 +8,9 @@ import type {
   DisplayPOI,
 } from "@/types";
 import { DEFAULT_POWER_CONFIG } from "@/constants";
-import { computeRouteETA, getETAToDistance } from "@/services/etaCalculator";
+import { computeRouteETA, getETAToDistanceFromDistance } from "@/services/etaCalculator";
 import { toDisplayPOIForSegments } from "@/services/displayDistance";
+import { resolveRouteProgress } from "@/utils/routeProgress";
 import { useRouteStore } from "./routeStore";
 import { useCollectionStore } from "./collectionStore";
 
@@ -96,7 +97,14 @@ export const useEtaStore = create<ETAState>((set, get) => ({
 
     const routePoints = cachedPoints ?? useRouteStore.getState().visibleRoutePoints[routeId];
     if (!routePoints?.length) return null;
+    const routeProgress = resolveRouteProgress(snapped, routeId, routePoints);
+    if (!routeProgress) return null;
 
-    return getETAToDistance(cumulativeTime, routePoints, snapped.pointIndex, targetDistM);
+    return getETAToDistanceFromDistance(
+      cumulativeTime,
+      routePoints,
+      routeProgress.distanceAlongRouteMeters,
+      targetDistM,
+    );
   },
 }));

--- a/store/routeStore.ts
+++ b/store/routeStore.ts
@@ -14,7 +14,15 @@ import { parseGPX } from "@/services/gpxParser";
 import { parseKML } from "@/services/kmlParser";
 import { INACTIVE_ROUTE_COLOR } from "@/constants";
 import { generateId } from "@/utils/generateId";
-import type { Route, RouteWithPoints, RoutePoint, SnappedPosition } from "@/types";
+import type {
+  Route,
+  RouteWithPoints,
+  RoutePoint,
+  SnappedPosition,
+  RouteSnapHistorySample,
+} from "@/types";
+
+const MAX_SNAP_HISTORY_SAMPLES = 5;
 
 interface RouteState {
   routes: Route[];
@@ -24,6 +32,7 @@ interface RouteState {
   visibleRoutePoints: Record<string, RoutePoint[]>;
   // Snapped position on active route
   snappedPosition: SnappedPosition | null;
+  snapHistory: RouteSnapHistorySample[];
 
   /** Fetch route metadata only. Cheap; safe to call on every tab mount. */
   loadRouteMetadata: () => Promise<void>;
@@ -44,6 +53,8 @@ interface RouteState {
   setActiveRoute: (id: string) => Promise<void>;
   getRouteDetail: (id: string) => Promise<RouteWithPoints | null>;
   setSnappedPosition: (pos: SnappedPosition | null) => void;
+  recordSnapHistory: (sample: RouteSnapHistorySample) => void;
+  clearRouteProgress: () => void;
   clearError: () => void;
 }
 
@@ -53,6 +64,7 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   error: null,
   visibleRoutePoints: {},
   snappedPosition: null,
+  snapHistory: [],
 
   loadRouteMetadata: async () => {
     try {
@@ -213,6 +225,7 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   },
 
   setActiveRoute: async (id) => {
+    set({ snappedPosition: null, snapHistory: [] });
     await dbSetActiveRoute(id);
     // Clear active collection in collectionStore
     const { useCollectionStore } = await import("@/store/collectionStore");
@@ -239,11 +252,24 @@ export const useRouteStore = create<RouteState>((set, get) => ({
     const prev = get().snappedPosition;
     if (
       prev?.pointIndex === snappedPosition?.pointIndex &&
-      prev?.routeId === snappedPosition?.routeId
+      prev?.routeId === snappedPosition?.routeId &&
+      Math.abs(
+        (prev?.distanceAlongRouteMeters ?? 0) - (snappedPosition?.distanceAlongRouteMeters ?? 0),
+      ) < 1 &&
+      Math.abs(
+        (prev?.distanceFromRouteMeters ?? 0) - (snappedPosition?.distanceFromRouteMeters ?? 0),
+      ) < 1
     )
       return;
     set({ snappedPosition });
   },
+
+  recordSnapHistory: (sample) => {
+    const sameRouteHistory = get().snapHistory.filter((entry) => entry.routeId === sample.routeId);
+    set({ snapHistory: [...sameRouteHistory, sample].slice(-MAX_SNAP_HISTORY_SAMPLES) });
+  },
+
+  clearRouteProgress: () => set({ snappedPosition: null, snapHistory: [] }),
 
   clearError: () => set({ error: null }),
 }));

--- a/store/weatherStore.ts
+++ b/store/weatherStore.ts
@@ -50,7 +50,7 @@ interface WeatherState {
   fetchWeather: (
     routeId: string,
     points: RoutePoint[],
-    fromIndex: number,
+    fromDistanceAlongRouteMeters: number,
     cumulativeTime: number[],
   ) => Promise<void>;
   clearWeather: () => void;
@@ -68,7 +68,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
     fetchStatus: cacheIsFresh && cached?.timeline?.length ? "done" : "idle",
     error: null,
 
-    fetchWeather: async (routeId, points, fromIndex, cumulativeTime) => {
+    fetchWeather: async (routeId, points, fromDistanceAlongRouteMeters, cumulativeTime) => {
       const state = get();
 
       // Skip if already fetching
@@ -90,7 +90,11 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
       set({ fetchStatus: "fetching", error: null });
 
       try {
-        const timeline = await buildWeatherTimeline(points, fromIndex, cumulativeTime);
+        const timeline = await buildWeatherTimeline(
+          points,
+          fromDistanceAlongRouteMeters,
+          cumulativeTime,
+        );
 
         const cache: CachedWeather = {
           timeline,

--- a/tests/mocks/routeStore.ts
+++ b/tests/mocks/routeStore.ts
@@ -1,7 +1,7 @@
 import type { RoutePoint, SnappedPosition } from "@/types";
 
 export interface MockRouteStoreState {
-  snappedPosition: Pick<SnappedPosition, "pointIndex"> | null;
+  snappedPosition: SnappedPosition | null;
   visibleRoutePoints: Record<string, RoutePoint[]>;
 }
 

--- a/tests/services/etaCalculator.test.ts
+++ b/tests/services/etaCalculator.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { computeRouteETA, getETABetweenIndices, getETAToDistance } from "@/services/etaCalculator";
+import {
+  computeRouteETA,
+  getETABetweenIndices,
+  getETAToDistance,
+  getETAToDistanceFromDistance,
+} from "@/services/etaCalculator";
 import { DEFAULT_POWER_CONFIG } from "@/constants";
 import type { RoutePoint } from "@/types";
 
@@ -61,6 +66,16 @@ describe("etaCalculator", () => {
     expect(result?.eta.toISOString()).toBe("2026-01-01T00:02:30.000Z");
 
     vi.useRealTimers();
+  });
+
+  it("getETAToDistanceFromDistance uses projected route progress as the start", () => {
+    const points = [basePoint(0, 100, 0), basePoint(1_000, 100, 1), basePoint(2_000, 100, 2)];
+    const cumulative = [0, 100, 200];
+
+    const result = getETAToDistanceFromDistance(cumulative, points, 250, 1_500);
+
+    expect(result?.distanceMeters).toBe(1_250);
+    expect(result?.ridingTimeSeconds).toBe(125);
   });
 
   it("getETAToDistance returns null for invalid cases and extrapolates after final point", () => {

--- a/tests/services/routeSnapping.test.ts
+++ b/tests/services/routeSnapping.test.ts
@@ -1,36 +1,290 @@
 import { describe, expect, it } from "vitest";
-import { snapToRoute } from "@/services/routeSnapping";
-import type { RoutePoint } from "@/types";
+import { snapToRoute, snapToRouteDetailed } from "@/services/routeSnapping";
+import type { RoutePoint, RouteSnapCandidate, RouteSnapHistorySample } from "@/types";
 
-function point(idx: number, latitude: number): RoutePoint {
+const DEG_PER_METER = 1 / 111_320;
+
+function coord(xMeters: number, yMeters = 0): { latitude: number; longitude: number } {
   return {
-    latitude,
-    longitude: 0,
+    latitude: yMeters * DEG_PER_METER,
+    longitude: xMeters * DEG_PER_METER,
+  };
+}
+
+function point(
+  idx: number,
+  xMeters: number,
+  yMeters: number,
+  distanceFromStartMeters: number,
+): RoutePoint {
+  const position = coord(xMeters, yMeters);
+  return {
+    ...position,
     elevationMeters: 0,
-    distanceFromStartMeters: idx * 100,
+    distanceFromStartMeters,
     idx,
+  };
+}
+
+function linePoint(idx: number): RoutePoint {
+  return point(idx, 0, idx * 100, idx * 100);
+}
+
+function snapAndRecord(
+  xMeters: number,
+  yMeters: number,
+  routeId: string,
+  points: RoutePoint[],
+  history: RouteSnapHistorySample[],
+  timestamp: number,
+  options?: { headingDegrees?: number; speedMetersPerSecond?: number },
+) {
+  const position = coord(xMeters, yMeters);
+  const result = snapToRouteDetailed(position.latitude, position.longitude, routeId, points, {
+    history,
+    headingDegrees: options?.headingDegrees,
+    speedMetersPerSecond: options?.speedMetersPerSecond,
+    timestamp,
+  });
+  if (!result) throw new Error("Expected position to snap to route");
+
+  history.push({
+    routeId,
+    latitude: position.latitude,
+    longitude: position.longitude,
+    timestamp,
+    heading: options?.headingDegrees ?? null,
+    speed: options?.speedMetersPerSecond ?? null,
+    selectedCandidate: result.selectedCandidate,
+  });
+
+  return result;
+}
+
+function candidate(
+  segmentIndex: number,
+  pointIndex: number,
+  distanceAlongRouteMeters: number,
+  segmentBearingDegrees: number,
+): RouteSnapCandidate {
+  return {
+    segmentIndex,
+    pointIndex,
+    projectedFraction: 0,
+    distanceAlongRouteMeters,
+    distanceFromRouteMeters: 0,
+    segmentBearingDegrees,
   };
 }
 
 describe("routeSnapping", () => {
   it("uses previous snap locality but falls back when the position jumps beyond the window", () => {
-    const points = Array.from({ length: 1_200 }, (_, idx) => point(idx, idx * 0.001));
+    const points = Array.from({ length: 1_200 }, (_, idx) => linePoint(idx));
 
-    const local = snapToRoute(0.01, 0, "r1", points, { previousPointIndex: 9 });
-    const jumped = snapToRoute(1.1, 0, "r1", points, { previousPointIndex: 9 });
+    const localPosition = coord(0, 1_000);
+    const jumpedPosition = coord(0, 110_000);
+    const local = snapToRoute(localPosition.latitude, localPosition.longitude, "r1", points, {
+      previousPointIndex: 9,
+    });
+    const jumped = snapToRoute(jumpedPosition.latitude, jumpedPosition.longitude, "r1", points, {
+      previousPointIndex: 9,
+    });
 
     expect(local?.pointIndex).toBe(10);
     expect(jumped?.pointIndex).toBe(1_100);
   });
 
   it("falls back globally when a stale local window has a plausible but wrong candidate", () => {
-    const points = Array.from({ length: 1_200 }, (_, idx) => point(idx, 5 + idx * 0.001));
-    points[10] = point(10, 0.005); // ~556m away, inside the old local window.
-    points[900] = point(900, 0); // True current position, outside the old local window.
+    const points = Array.from({ length: 1_200 }, (_, idx) =>
+      point(idx, 0, 500_000 + idx * 100, idx * 100),
+    );
+    points[10] = point(10, 0, 556, 1_000);
+    points[900] = point(900, 0, 0, 90_000);
 
     const snapped = snapToRoute(0, 0, "r1", points, { previousPointIndex: 10 });
 
     expect(snapped?.pointIndex).toBe(900);
     expect(snapped?.distanceAlongRouteMeters).toBe(90_000);
+  });
+
+  it("uses projected segment progress as authoritative route progress", () => {
+    const points = [point(0, 0, 0, 0), point(1, 1_000, 0, 1_000)];
+    const position = coord(250, 100);
+
+    const snapped = snapToRouteDetailed(position.latitude, position.longitude, "r1", points);
+
+    expect(snapped?.snappedPosition.pointIndex).toBe(0);
+    expect(snapped?.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(250, 1);
+    expect(snapped?.selectedCandidate.distanceAlongRouteMeters).toBeCloseTo(250, 1);
+    expect(snapped?.snappedPosition.distanceFromRouteMeters).toBeCloseTo(100, 0);
+  });
+
+  it("keeps out-and-back progress on the outbound leg before the turnaround", () => {
+    const points = [
+      point(0, 0, 0, 0),
+      point(1, 1_000, 0, 1_000),
+      point(2, 2_000, 0, 2_000),
+      point(3, 3_000, 0, 3_000),
+      point(4, 2_000, 0, 4_000),
+      point(5, 1_000, 0, 5_000),
+      point(6, 0, 0, 6_000),
+    ];
+    const history: RouteSnapHistorySample[] = [];
+
+    const first = snapAndRecord(500, 0, "out-back", points, history, 0, {
+      headingDegrees: 90,
+      speedMetersPerSecond: 5,
+    });
+    const second = snapAndRecord(1_000, 0, "out-back", points, history, 60_000, {
+      headingDegrees: 90,
+      speedMetersPerSecond: 5,
+    });
+    const third = snapAndRecord(2_000, 0, "out-back", points, history, 120_000, {
+      headingDegrees: 90,
+      speedMetersPerSecond: 5,
+    });
+
+    expect(first.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(500, 1);
+    expect(second.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(1_000, 1);
+    expect(third.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(2_000, 1);
+  });
+
+  it("moves out-and-back progress onto the return leg after the turnaround", () => {
+    const points = [
+      point(0, 0, 0, 0),
+      point(1, 1_000, 0, 1_000),
+      point(2, 2_000, 0, 2_000),
+      point(3, 3_000, 0, 3_000),
+      point(4, 2_000, 0, 4_000),
+      point(5, 1_000, 0, 5_000),
+      point(6, 0, 0, 6_000),
+    ];
+    const history: RouteSnapHistorySample[] = [];
+
+    snapAndRecord(2_000, 0, "out-back", points, history, 0, {
+      headingDegrees: 90,
+      speedMetersPerSecond: 5,
+    });
+    snapAndRecord(3_000, 0, "out-back", points, history, 60_000, {
+      headingDegrees: 90,
+      speedMetersPerSecond: 5,
+    });
+    const returnLeg = snapAndRecord(2_500, 0, "out-back", points, history, 120_000, {
+      headingDegrees: 270,
+      speedMetersPerSecond: 5,
+    });
+    const laterReturnLeg = snapAndRecord(1_000, 0, "out-back", points, history, 180_000, {
+      headingDegrees: 270,
+      speedMetersPerSecond: 5,
+    });
+
+    expect(returnLeg.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(3_500, 1);
+    expect(laterReturnLeg.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(5_000, 1);
+  });
+
+  it("ignores reported heading when speed is unknown", () => {
+    const points = [
+      point(0, 0, 0, 0),
+      point(1, 1_000, 0, 1_000),
+      point(2, 2_000, 0, 2_000),
+      point(3, 3_000, 0, 3_000),
+      point(4, 2_000, 0, 4_000),
+      point(5, 1_000, 0, 5_000),
+      point(6, 0, 0, 6_000),
+    ];
+    const history: RouteSnapHistorySample[] = [];
+    snapAndRecord(2_000, 0, "out-back", points, history, 0, {
+      headingDegrees: 90,
+      speedMetersPerSecond: 5,
+    });
+    const position = coord(2_500, 0);
+
+    const snapped = snapToRouteDetailed(position.latitude, position.longitude, "out-back", points, {
+      history,
+      headingDegrees: 270,
+      speedMetersPerSecond: null,
+      timestamp: 60_000,
+    });
+
+    expect(snapped?.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(2_500, 1);
+  });
+
+  it("ignores invalid negative headings", () => {
+    const points = [
+      point(0, 0, 0, 0),
+      point(1, 1_000, 0, 1_000),
+      point(2, 2_000, 0, 2_000),
+      point(3, 3_000, 0, 3_000),
+      point(4, 2_000, 0, 4_000),
+      point(5, 1_000, 0, 5_000),
+      point(6, 0, 0, 6_000),
+    ];
+    const history: RouteSnapHistorySample[] = [];
+    snapAndRecord(2_000, 0, "out-back", points, history, 0, {
+      headingDegrees: 90,
+      speedMetersPerSecond: 5,
+    });
+    const position = coord(2_500, 0);
+
+    const snapped = snapToRouteDetailed(position.latitude, position.longitude, "out-back", points, {
+      history,
+      headingDegrees: -90,
+      speedMetersPerSecond: 5,
+      timestamp: 60_000,
+    });
+
+    expect(snapped?.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(2_500, 1);
+  });
+
+  it("prefers the self-crossing leg consistent with recent movement", () => {
+    const points = [
+      point(0, -1_000, -1_000, 0),
+      point(1, 0, 0, 1_414),
+      point(2, 1_000, -1_000, 2_828),
+      point(3, 1_000, 1_000, 4_828),
+      point(4, 0, 0, 6_242),
+      point(5, -1_000, 1_000, 7_656),
+    ];
+    const history: RouteSnapHistorySample[] = [];
+
+    snapAndRecord(900, 900, "figure-eight", points, history, 0, {
+      headingDegrees: 225,
+      speedMetersPerSecond: 5,
+    });
+    const crossing = snapAndRecord(0, 0, "figure-eight", points, history, 60_000, {
+      headingDegrees: 225,
+      speedMetersPerSecond: 5,
+    });
+
+    expect(crossing.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(6_242, 0);
+  });
+
+  it("disambiguates overlapping stitched collection segments with route progress history", () => {
+    const points = [
+      point(0, 0, 0, 0),
+      point(1, 1_000, 0, 1_000),
+      point(2, 2_000, 0, 2_000),
+      point(3, 1_000, 0, 3_000),
+      point(4, 2_000, 0, 4_000),
+    ];
+    const seed = coord(1_200, 0);
+    const history: RouteSnapHistorySample[] = [
+      {
+        routeId: "collection",
+        latitude: seed.latitude,
+        longitude: seed.longitude,
+        timestamp: 0,
+        heading: 90,
+        speed: 5,
+        selectedCandidate: candidate(3, 3, 3_200, 90),
+      },
+    ];
+
+    const snapped = snapAndRecord(1_500, 0, "collection", points, history, 60_000, {
+      headingDegrees: 90,
+      speedMetersPerSecond: 5,
+    });
+
+    expect(snapped.snappedPosition.distanceAlongRouteMeters).toBeCloseTo(3_500, 1);
   });
 });

--- a/tests/services/weatherService.test.ts
+++ b/tests/services/weatherService.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { sampleWaypoints } from "@/services/weatherService";
+import type { RoutePoint } from "@/types";
+
+const DEG_PER_METER = 1 / 111_320;
+
+function point(idx: number, distanceFromStartMeters: number, latitude = 0): RoutePoint {
+  return {
+    latitude,
+    longitude: distanceFromStartMeters * DEG_PER_METER,
+    elevationMeters: 0,
+    distanceFromStartMeters,
+    idx,
+  };
+}
+
+describe("weatherService", () => {
+  it("samples the first weather waypoint from projected route progress", () => {
+    const points = [point(0, 0), point(1, 1_000), point(2, 2_000)];
+
+    const waypoints = sampleWaypoints(points, 250);
+
+    expect(waypoints[0]).toMatchObject({
+      distanceAlongRouteM: 0,
+      index: 0,
+    });
+    expect(waypoints[0].longitude).toBeCloseTo(250 * DEG_PER_METER, 8);
+  });
+
+  it("samples exact collection joins from the forward segment", () => {
+    const points = [point(0, 0, 0), point(1, 1_000, 0), point(2, 1_000, 1), point(3, 2_000, 2)];
+
+    const waypoints = sampleWaypoints(points, 1_000);
+
+    expect(waypoints[0]).toMatchObject({
+      index: 2,
+      segmentIndex: 2,
+      latitude: 1,
+    });
+  });
+
+  it("returns no weather waypoints for out-of-range progress", () => {
+    const points = [point(0, 0), point(1, 1_000), point(2, 2_000)];
+
+    expect(sampleWaypoints(points, -1)).toEqual([]);
+    expect(sampleWaypoints(points, 2_001)).toEqual([]);
+  });
+});

--- a/tests/store/etaAndClimbCollectionBehavior.test.ts
+++ b/tests/store/etaAndClimbCollectionBehavior.test.ts
@@ -71,7 +71,12 @@ describe("stitched collection coordinate behavior", () => {
       cachedPoints: stitchedPoints,
     });
 
-    stitchedHarness.routeState.snappedPosition = { pointIndex: 0 };
+    stitchedHarness.routeState.snappedPosition = {
+      routeId: "c1",
+      pointIndex: 0,
+      distanceAlongRouteMeters: 0,
+      distanceFromRouteMeters: 0,
+    };
     stitchedHarness.routeState.visibleRoutePoints = { c1: stitchedPoints };
     stitchedHarness.collectionState.activeStitchedCollection = buildStitchedCollection({
       points: stitchedPoints,
@@ -98,7 +103,12 @@ describe("stitched collection coordinate behavior", () => {
       cachedPoints: stitchedPoints,
     });
 
-    stitchedHarness.routeState.snappedPosition = { pointIndex: 0 };
+    stitchedHarness.routeState.snappedPosition = {
+      routeId: "c1",
+      pointIndex: 0,
+      distanceAlongRouteMeters: 0,
+      distanceFromRouteMeters: 0,
+    };
     stitchedHarness.routeState.visibleRoutePoints = { c1: stitchedPoints };
     stitchedHarness.collectionState.activeStitchedCollection = buildStitchedCollection({
       points: stitchedPoints,
@@ -111,6 +121,62 @@ describe("stitched collection coordinate behavior", () => {
     const eta = useEtaStore.getState().getETAToPOI(preStitched);
 
     expect(eta?.ridingTimeSeconds).toBe(120);
+  });
+
+  it("uses projected snapped distance rather than point index for POI ETA", () => {
+    const stitchedPoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+    ];
+
+    useEtaStore.setState({
+      routeId: "c1",
+      cumulativeTime: [0, 100, 200],
+      cachedPoints: stitchedPoints,
+    });
+
+    stitchedHarness.routeState.snappedPosition = {
+      routeId: "c1",
+      pointIndex: 0,
+      distanceAlongRouteMeters: 250,
+      distanceFromRouteMeters: 0,
+    };
+    stitchedHarness.routeState.visibleRoutePoints = { c1: stitchedPoints };
+    stitchedHarness.collectionState.activeStitchedCollection = buildStitchedCollection({
+      points: stitchedPoints,
+    });
+
+    const eta = useEtaStore.getState().getETAToPOI(toDisplayPOI(buildPoi("p0", "r1", 900)));
+
+    expect(eta?.distanceMeters).toBe(650);
+    expect(eta?.ridingTimeSeconds).toBe(65);
+  });
+
+  it("does not resolve ETA from stale snap progress for another route", () => {
+    const stitchedPoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+    ];
+
+    useEtaStore.setState({
+      routeId: "c1",
+      cumulativeTime: [0, 100, 200],
+      cachedPoints: stitchedPoints,
+    });
+
+    stitchedHarness.routeState.snappedPosition = {
+      routeId: "old-route",
+      pointIndex: 0,
+      distanceAlongRouteMeters: 250,
+      distanceFromRouteMeters: 0,
+    };
+    stitchedHarness.routeState.visibleRoutePoints = { c1: stitchedPoints };
+
+    const eta = useEtaStore.getState().getETAToPOI(toDisplayPOI(buildPoi("p0", "r1", 900)));
+
+    expect(eta).toBeNull();
   });
 
   it("recomputes ETA cache when collection variant swaps points array with same route id", () => {

--- a/tests/store/routeStore.test.ts
+++ b/tests/store/routeStore.test.ts
@@ -47,6 +47,7 @@ describe("routeStore", () => {
       error: null,
       visibleRoutePoints: {},
       snappedPosition: null,
+      snapHistory: [],
     });
   });
 
@@ -65,5 +66,39 @@ describe("routeStore", () => {
     expect(databaseMocks.getRoutePoints).toHaveBeenCalledWith("r1");
     expect(useRouteStore.getState().routes).toEqual([visibleActiveRoute]);
     expect(useRouteStore.getState().visibleRoutePoints).toEqual({ r1: points });
+  });
+
+  it("clears snapped position and snap history together", () => {
+    useRouteStore.setState({
+      snappedPosition: {
+        routeId: "r1",
+        pointIndex: 0,
+        distanceAlongRouteMeters: 100,
+        distanceFromRouteMeters: 5,
+      },
+      snapHistory: [
+        {
+          routeId: "r1",
+          latitude: 0,
+          longitude: 0,
+          timestamp: 1,
+          heading: null,
+          speed: null,
+          selectedCandidate: {
+            pointIndex: 0,
+            segmentIndex: 0,
+            projectedFraction: 0,
+            distanceAlongRouteMeters: 100,
+            distanceFromRouteMeters: 5,
+            segmentBearingDegrees: 0,
+          },
+        },
+      ],
+    });
+
+    useRouteStore.getState().clearRouteProgress();
+
+    expect(useRouteStore.getState().snappedPosition).toBeNull();
+    expect(useRouteStore.getState().snapHistory).toEqual([]);
   });
 });

--- a/tests/utils/geo.test.ts
+++ b/tests/utils/geo.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   buildRouteSegmentSpatialIndex,
+  computeElevationProgressAtDistance,
+  computeSliceAscentFromDistance,
   computePOIRouteAssociation,
   findFirstPointAtOrAfterDistance,
   findLastPointAtOrBeforeDistance,
+  findNearestPointIndexAtDistance,
+  interpolateRoutePointAtDistance,
   routeToMapGeoJSON,
   simplifyRoutePointsForMap,
 } from "@/utils/geo";
@@ -21,13 +25,47 @@ function point(idx: number, distanceFromStartMeters: number, latitude = 0): Rout
 
 describe("geo route performance helpers", () => {
   it("finds distance boundaries with binary search semantics", () => {
-    const points = [point(0, 0), point(1, 100), point(2, 200), point(3, 400)];
+    const points = [point(0, 0), point(1, 100), point(2, 100), point(3, 200), point(4, 400)];
 
-    expect(findFirstPointAtOrAfterDistance(points, 150)).toBe(2);
-    expect(findFirstPointAtOrAfterDistance(points, 400)).toBe(3);
-    expect(findFirstPointAtOrAfterDistance(points, 401)).toBe(4);
-    expect(findLastPointAtOrBeforeDistance(points, 150)).toBe(1);
+    expect(findFirstPointAtOrAfterDistance(points, 150)).toBe(3);
+    expect(findFirstPointAtOrAfterDistance(points, 400)).toBe(4);
+    expect(findFirstPointAtOrAfterDistance(points, 401)).toBe(5);
+    expect(findLastPointAtOrBeforeDistance(points, 100)).toBe(2);
+    expect(findLastPointAtOrBeforeDistance(points, 150)).toBe(2);
     expect(findLastPointAtOrBeforeDistance(points, 50, 1)).toBe(0);
+    expect(findNearestPointIndexAtDistance(points, 100)).toBe(2);
+    expect(findNearestPointIndexAtDistance(points, 160)).toBe(3);
+  });
+
+  it("interpolates progress-derived route positions and elevation totals", () => {
+    const points = [
+      { ...point(0, 0), elevationMeters: 100 },
+      { ...point(1, 100), elevationMeters: 200 },
+      { ...point(2, 200), elevationMeters: 150 },
+    ];
+
+    const interpolated = interpolateRoutePointAtDistance(points, 50);
+    const progress = computeElevationProgressAtDistance(points, 50);
+
+    expect(interpolated?.distanceFromStartMeters).toBe(50);
+    expect(interpolated?.elevationMeters).toBe(150);
+    expect(progress.ascentDone).toBe(50);
+    expect(progress.ascentRemaining).toBe(50);
+    expect(progress.descentRemaining).toBe(50);
+    expect(computeSliceAscentFromDistance(points, 50, 150)).toBe(50);
+  });
+
+  it("interpolates exact duplicate-distance joins from the forward segment", () => {
+    const points = [point(0, 0, 0), point(1, 100, 0), point(2, 100, 1), point(3, 200, 2)];
+
+    const atJoin = interpolateRoutePointAtDistance(points, 100);
+    const afterJoin = interpolateRoutePointAtDistance(points, 150);
+
+    expect(atJoin?.nearestIndex).toBe(2);
+    expect(atJoin?.segmentIndex).toBe(2);
+    expect(atJoin?.latitude).toBe(1);
+    expect(afterJoin?.segmentIndex).toBe(2);
+    expect(afterJoin?.latitude).toBe(1.5);
   });
 
   it("simplifies map geometry while preserving useful route shape", () => {

--- a/tests/utils/routeProgress.test.ts
+++ b/tests/utils/routeProgress.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { resolveRouteProgress } from "@/utils/routeProgress";
+import type { RoutePoint, SnappedPosition } from "@/types";
+
+function point(idx: number, distanceFromStartMeters: number): RoutePoint {
+  return {
+    latitude: 0,
+    longitude: 0,
+    elevationMeters: 0,
+    distanceFromStartMeters,
+    idx,
+  };
+}
+
+function snap(overrides: Partial<SnappedPosition> = {}): SnappedPosition {
+  return {
+    routeId: "r1",
+    pointIndex: 0,
+    distanceAlongRouteMeters: 500,
+    distanceFromRouteMeters: 10,
+    ...overrides,
+  };
+}
+
+describe("routeProgress", () => {
+  const points = [point(0, 0), point(1, 1_000)];
+
+  it("accepts only snapped progress that belongs to the route and its bounds", () => {
+    expect(resolveRouteProgress(snap(), "r1", points)?.distanceAlongRouteMeters).toBe(500);
+    expect(resolveRouteProgress(snap({ routeId: "old-route" }), "r1", points)).toBeNull();
+    expect(resolveRouteProgress(snap({ distanceAlongRouteMeters: -1 }), "r1", points)).toBeNull();
+    expect(
+      resolveRouteProgress(snap({ distanceAlongRouteMeters: 1_001 }), "r1", points),
+    ).toBeNull();
+    expect(resolveRouteProgress(snap({ distanceFromRouteMeters: 1_001 }), "r1", points)).toBeNull();
+    expect(
+      resolveRouteProgress(snap({ distanceAlongRouteMeters: Number.NaN }), "r1", points),
+    ).toBeNull();
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -46,6 +46,41 @@ export interface SnappedPosition {
   distanceFromRouteMeters: number;
 }
 
+declare const ActiveRouteProgressBrand: unique symbol;
+export type ActiveRouteProgress = SnappedPosition & {
+  readonly [ActiveRouteProgressBrand]: true;
+};
+
+export type RouteSnapConfidence = "high" | "medium" | "low";
+
+export interface RouteSnapCandidate {
+  pointIndex: number;
+  segmentIndex: number;
+  projectedFraction: number;
+  distanceAlongRouteMeters: number;
+  distanceFromRouteMeters: number;
+  segmentBearingDegrees: number;
+}
+
+export interface RouteSnapResult {
+  routeId: string;
+  selectedCandidate: RouteSnapCandidate;
+  candidates: RouteSnapCandidate[];
+  confidence: RouteSnapConfidence;
+  isAmbiguous: boolean;
+  snappedPosition: SnappedPosition;
+}
+
+export interface RouteSnapHistorySample {
+  routeId: string;
+  latitude: number;
+  longitude: number;
+  timestamp: number;
+  heading: number | null;
+  speed: number | null;
+  selectedCandidate: RouteSnapCandidate;
+}
+
 declare const DisplayDistanceMetersBrand: unique symbol;
 export type DisplayDistanceMeters = number & {
   readonly [DisplayDistanceMetersBrand]: true;

--- a/utils/geo.ts
+++ b/utils/geo.ts
@@ -128,10 +128,132 @@ export function findLastPointAtOrBeforeDistance(
   targetDistanceMeters: number,
   startIndex = 0,
 ): number {
-  const firstAfter = findFirstPointAtOrAfterDistance(points, targetDistanceMeters, startIndex);
-  if (firstAfter >= points.length) return points.length - 1;
-  if (points[firstAfter].distanceFromStartMeters <= targetDistanceMeters) return firstAfter;
-  return firstAfter - 1;
+  let lo = Math.max(0, startIndex);
+  let hi = points.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (points[mid].distanceFromStartMeters <= targetDistanceMeters) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo - 1;
+}
+
+export function findPointIndexAtOrAfterDistance(
+  points: RoutePoint[],
+  targetDistanceMeters: number,
+  startIndex = 0,
+): number {
+  if (points.length === 0) return 0;
+  return Math.min(
+    points.length - 1,
+    Math.max(0, findFirstPointAtOrAfterDistance(points, targetDistanceMeters, startIndex)),
+  );
+}
+
+export function findPointIndexAtOrBeforeDistance(
+  points: RoutePoint[],
+  targetDistanceMeters: number,
+  startIndex = 0,
+): number {
+  if (points.length === 0) return 0;
+  return Math.max(
+    0,
+    Math.min(
+      points.length - 1,
+      findLastPointAtOrBeforeDistance(points, targetDistanceMeters, startIndex),
+    ),
+  );
+}
+
+export function findNearestPointIndexAtDistance(
+  points: RoutePoint[],
+  targetDistanceMeters: number,
+): number {
+  if (points.length === 0) return 0;
+  const hi = findPointIndexAtOrAfterDistance(points, targetDistanceMeters);
+  if (points[hi].distanceFromStartMeters === targetDistanceMeters) {
+    return findPointIndexAtOrBeforeDistance(points, targetDistanceMeters, hi);
+  }
+  const lo = findPointIndexAtOrBeforeDistance(points, targetDistanceMeters);
+  const hiDelta = Math.abs(points[hi].distanceFromStartMeters - targetDistanceMeters);
+  const loDelta = Math.abs(targetDistanceMeters - points[lo].distanceFromStartMeters);
+  return hiDelta < loDelta ? hi : lo;
+}
+
+export interface InterpolatedRoutePoint {
+  latitude: number;
+  longitude: number;
+  elevationMeters: number | null;
+  distanceFromStartMeters: number;
+  nearestIndex: number;
+  segmentIndex: number;
+}
+
+export function interpolateRoutePointAtDistance(
+  points: RoutePoint[],
+  targetDistanceMeters: number,
+): InterpolatedRoutePoint | null {
+  if (points.length === 0) return null;
+  if (points.length === 1 || targetDistanceMeters <= points[0].distanceFromStartMeters) {
+    const first = points[0];
+    return {
+      latitude: first.latitude,
+      longitude: first.longitude,
+      elevationMeters: first.elevationMeters,
+      distanceFromStartMeters: first.distanceFromStartMeters,
+      nearestIndex: 0,
+      segmentIndex: 0,
+    };
+  }
+
+  if (targetDistanceMeters >= points[points.length - 1].distanceFromStartMeters) {
+    const lastIndex = points.length - 1;
+    const segmentIndex = Math.max(0, lastIndex - 1);
+    const last = points[lastIndex];
+    return {
+      latitude: last.latitude,
+      longitude: last.longitude,
+      elevationMeters: last.elevationMeters,
+      distanceFromStartMeters: last.distanceFromStartMeters,
+      nearestIndex: lastIndex,
+      segmentIndex,
+    };
+  }
+
+  const lo = findPointIndexAtOrBeforeDistance(points, targetDistanceMeters);
+  if (points[lo].distanceFromStartMeters === targetDistanceMeters) {
+    const exactIndex = lo;
+    const segmentIndex = Math.min(exactIndex, points.length - 2);
+    const exact = points[exactIndex];
+    return {
+      latitude: exact.latitude,
+      longitude: exact.longitude,
+      elevationMeters: exact.elevationMeters,
+      distanceFromStartMeters: exact.distanceFromStartMeters,
+      nearestIndex: exactIndex,
+      segmentIndex,
+    };
+  }
+
+  const hi = lo + 1;
+  const a = points[lo];
+  const b = points[hi];
+  const segmentMeters = b.distanceFromStartMeters - a.distanceFromStartMeters;
+  const t =
+    segmentMeters > 0 ? (targetDistanceMeters - a.distanceFromStartMeters) / segmentMeters : 0;
+  const elevationMeters =
+    a.elevationMeters != null && b.elevationMeters != null
+      ? a.elevationMeters + t * (b.elevationMeters - a.elevationMeters)
+      : null;
+
+  return {
+    latitude: a.latitude + t * (b.latitude - a.latitude),
+    longitude: a.longitude + t * (b.longitude - a.longitude),
+    elevationMeters,
+    distanceFromStartMeters: targetDistanceMeters,
+    nearestIndex: t < 0.5 ? lo : hi,
+    segmentIndex: lo,
+  };
 }
 
 /** Downsample an array to at most maxPoints using Ramer-Douglas-Peucker on elevation vs distance */
@@ -179,6 +301,57 @@ export function computeElevationProgress(
   }
 
   return { ascentDone, descentDone, ascentRemaining, descentRemaining };
+}
+
+function addElevationDelta(
+  fromElevation: number,
+  toElevation: number,
+  bucket: { ascent: number; descent: number },
+): void {
+  const diff = toElevation - fromElevation;
+  if (diff > 0) bucket.ascent += diff;
+  else bucket.descent += Math.abs(diff);
+}
+
+export function computeElevationProgressAtDistance(
+  points: RoutePoint[],
+  currentDistanceMeters: number,
+): {
+  ascentDone: number;
+  descentDone: number;
+  ascentRemaining: number;
+  descentRemaining: number;
+} {
+  const done = { ascent: 0, descent: 0 };
+  const remaining = { ascent: 0, descent: 0 };
+
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    if (prev.elevationMeters == null || curr.elevationMeters == null) continue;
+
+    const startDist = prev.distanceFromStartMeters;
+    const endDist = curr.distanceFromStartMeters;
+
+    if (currentDistanceMeters >= endDist) {
+      addElevationDelta(prev.elevationMeters, curr.elevationMeters, done);
+    } else if (currentDistanceMeters <= startDist) {
+      addElevationDelta(prev.elevationMeters, curr.elevationMeters, remaining);
+    } else {
+      const t = (currentDistanceMeters - startDist) / (endDist - startDist);
+      const currentElevation =
+        prev.elevationMeters + t * (curr.elevationMeters - prev.elevationMeters);
+      addElevationDelta(prev.elevationMeters, currentElevation, done);
+      addElevationDelta(currentElevation, curr.elevationMeters, remaining);
+    }
+  }
+
+  return {
+    ascentDone: done.ascent,
+    descentDone: done.descent,
+    ascentRemaining: remaining.ascent,
+    descentRemaining: remaining.descent,
+  };
 }
 
 /**
@@ -248,6 +421,48 @@ export function computeSliceAscent(
   return ascent;
 }
 
+function computeSliceElevationTotals(
+  points: RoutePoint[],
+  startDistanceMeters: number,
+  endDistanceMeters: number,
+): { ascent: number; descent: number } {
+  const totals = { ascent: 0, descent: 0 };
+  if (endDistanceMeters <= startDistanceMeters) return totals;
+
+  for (let i = 1; i < points.length; i++) {
+    const prev = points[i - 1];
+    const curr = points[i];
+    if (prev.elevationMeters == null || curr.elevationMeters == null) continue;
+
+    const segStart = prev.distanceFromStartMeters;
+    const segEnd = curr.distanceFromStartMeters;
+    if (segEnd <= startDistanceMeters) continue;
+    if (segStart >= endDistanceMeters) break;
+    if (segEnd <= segStart) continue;
+
+    const fromDistance = Math.max(startDistanceMeters, segStart);
+    const toDistance = Math.min(endDistanceMeters, segEnd);
+    if (toDistance <= fromDistance) continue;
+
+    const fromT = (fromDistance - segStart) / (segEnd - segStart);
+    const toT = (toDistance - segStart) / (segEnd - segStart);
+    const fromElevation =
+      prev.elevationMeters + fromT * (curr.elevationMeters - prev.elevationMeters);
+    const toElevation = prev.elevationMeters + toT * (curr.elevationMeters - prev.elevationMeters);
+    addElevationDelta(fromElevation, toElevation, totals);
+  }
+
+  return totals;
+}
+
+export function computeSliceAscentFromDistance(
+  points: RoutePoint[],
+  startDistanceMeters: number,
+  endDistanceMeters: number,
+): number {
+  return computeSliceElevationTotals(points, startDistanceMeters, endDistanceMeters).ascent;
+}
+
 /** Compute descent within a distance-bounded slice starting at a given index */
 export function computeSliceDescent(
   points: RoutePoint[],
@@ -262,6 +477,14 @@ export function computeSliceDescent(
     if (prev != null && curr != null && curr < prev) descent += prev - curr;
   }
   return descent;
+}
+
+export function computeSliceDescentFromDistance(
+  points: RoutePoint[],
+  startDistanceMeters: number,
+  endDistanceMeters: number,
+): number {
+  return computeSliceElevationTotals(points, startDistanceMeters, endDistanceMeters).descent;
 }
 
 // --- Phase 3: POI-to-route association ---
@@ -303,6 +526,15 @@ export function pointToSegmentDistance(
     distanceMeters: haversineDistance(pLat, pLon, projLat, projLon),
     fraction,
   };
+}
+
+export interface RouteSegmentProjectionCandidate {
+  segmentIndex: number;
+  nearestPointIndex: number;
+  fraction: number;
+  distanceMeters: number;
+  distanceAlongRouteMeters: number;
+  bearingDegrees: number;
 }
 
 export interface RouteSegmentSpatialIndex {
@@ -378,6 +610,95 @@ function getCandidateSegmentIndexes(
   }
 
   return candidates.size > 0 ? [...candidates] : null;
+}
+
+export function findRouteSegmentCandidates(
+  lat: number,
+  lon: number,
+  routePoints: RoutePoint[],
+  options?: {
+    spatialIndex?: RouteSegmentSpatialIndex | null;
+    maxDistanceMeters?: number;
+    maxCandidates?: number;
+    startSegmentIndex?: number;
+    endSegmentIndex?: number;
+  },
+): RouteSegmentProjectionCandidate[] {
+  if (routePoints.length === 0) return [];
+
+  if (routePoints.length === 1) {
+    return [
+      {
+        segmentIndex: 0,
+        nearestPointIndex: 0,
+        fraction: 0,
+        distanceMeters: haversineDistance(
+          lat,
+          lon,
+          routePoints[0].latitude,
+          routePoints[0].longitude,
+        ),
+        distanceAlongRouteMeters: routePoints[0].distanceFromStartMeters,
+        bearingDegrees: 0,
+      },
+    ];
+  }
+
+  const startSegmentIndex = Math.max(0, options?.startSegmentIndex ?? 0);
+  const endSegmentIndex = Math.min(
+    routePoints.length - 2,
+    options?.endSegmentIndex ?? routePoints.length - 2,
+  );
+  const indexedCandidates = getCandidateSegmentIndexes(lat, lon, options?.spatialIndex);
+  const segmentIndexes =
+    indexedCandidates ??
+    Array.from(
+      { length: endSegmentIndex - startSegmentIndex + 1 },
+      (_, i) => i + startSegmentIndex,
+    );
+
+  const candidates: RouteSegmentProjectionCandidate[] = [];
+  let nearestOutsideRange: RouteSegmentProjectionCandidate | null = null;
+
+  for (const segmentIndex of segmentIndexes) {
+    if (segmentIndex < startSegmentIndex || segmentIndex > endSegmentIndex) continue;
+
+    const a = routePoints[segmentIndex];
+    const b = routePoints[segmentIndex + 1];
+    const { distanceMeters, fraction } = pointToSegmentDistance(
+      lat,
+      lon,
+      a.latitude,
+      a.longitude,
+      b.latitude,
+      b.longitude,
+    );
+    const candidate = {
+      segmentIndex,
+      nearestPointIndex: fraction < 0.5 ? segmentIndex : segmentIndex + 1,
+      fraction,
+      distanceMeters,
+      distanceAlongRouteMeters:
+        a.distanceFromStartMeters +
+        fraction * (b.distanceFromStartMeters - a.distanceFromStartMeters),
+      bearingDegrees: computeBearing(a.latitude, a.longitude, b.latitude, b.longitude),
+    };
+
+    if (options?.maxDistanceMeters == null || distanceMeters <= options.maxDistanceMeters) {
+      candidates.push(candidate);
+    } else if (!nearestOutsideRange || distanceMeters < nearestOutsideRange.distanceMeters) {
+      nearestOutsideRange = candidate;
+    }
+  }
+
+  const sorted = candidates.sort((a, b) => {
+    if (a.distanceMeters !== b.distanceMeters) return a.distanceMeters - b.distanceMeters;
+    return a.distanceAlongRouteMeters - b.distanceAlongRouteMeters;
+  });
+
+  if (sorted.length === 0 && nearestOutsideRange) return [nearestOutsideRange];
+
+  return sorted.slice(0, options?.maxCandidates ?? 80);
 }
 
 /**

--- a/utils/routeProgress.ts
+++ b/utils/routeProgress.ts
@@ -1,0 +1,41 @@
+import type { ActiveRouteData, ActiveRouteProgress, RoutePoint, SnappedPosition } from "@/types";
+
+export const MAX_ACTIVE_ROUTE_PROGRESS_DISTANCE_M = 1000;
+
+const ROUTE_DISTANCE_EPSILON_M = 1e-6;
+
+export function resolveRouteProgress(
+  snappedPosition: SnappedPosition | null | undefined,
+  routeId: string | null | undefined,
+  points: RoutePoint[] | null | undefined,
+): ActiveRouteProgress | null {
+  if (!snappedPosition || !routeId || snappedPosition.routeId !== routeId) return null;
+  if (!points?.length) return null;
+  if (
+    !Number.isFinite(snappedPosition.distanceAlongRouteMeters) ||
+    !Number.isFinite(snappedPosition.distanceFromRouteMeters)
+  ) {
+    return null;
+  }
+  if (snappedPosition.distanceFromRouteMeters > MAX_ACTIVE_ROUTE_PROGRESS_DISTANCE_M) {
+    return null;
+  }
+
+  const routeStartMeters = points[0].distanceFromStartMeters;
+  const routeEndMeters = points[points.length - 1].distanceFromStartMeters;
+  if (
+    snappedPosition.distanceAlongRouteMeters < routeStartMeters - ROUTE_DISTANCE_EPSILON_M ||
+    snappedPosition.distanceAlongRouteMeters > routeEndMeters + ROUTE_DISTANCE_EPSILON_M
+  ) {
+    return null;
+  }
+
+  return snappedPosition as ActiveRouteProgress;
+}
+
+export function resolveActiveRouteProgress(
+  activeData: ActiveRouteData | null | undefined,
+  snappedPosition: SnappedPosition | null | undefined,
+): ActiveRouteProgress | null {
+  return resolveRouteProgress(snappedPosition, activeData?.id, activeData?.points);
+}


### PR DESCRIPTION
## Summary

- Replace nearest-point-only snapping with segment projection candidates and confidence metadata while keeping `SnappedPosition` stable for downstream consumers.
- Make `SnappedPosition.distanceAlongRouteMeters` the authoritative projected route progress value; `pointIndex` remains available as the nearest geometry anchor.
- Update ETA, weather waypoints, POI ETA, elevation/profile/climb panels, and route detail progress to derive from snapped distance instead of treating `pointIndex` as progress.
- Record snap history from existing on-demand GPS refreshes only and add synthetic route/progress regression tests for ambiguous cases.

Fixes #10

## Verification

- `npm test -- tests/services/routeSnapping.test.ts tests/services/etaCalculator.test.ts tests/services/weatherService.test.ts tests/store/etaAndClimbCollectionBehavior.test.ts tests/utils/geo.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- `npm test`