### PR TITLE
Consolidate route sampling utilities

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,7 +54,7 @@ When priorities change, update both:
    Useful polish, but less urgent than trust, prep, ETA, and descent awareness.
 
 10. [#18 Optimize long route and collection performance](https://github.com/conqeror/ultra-companion/issues/18)
-   Promote earlier if real long routes are already sluggish. Otherwise optimize after workflows stabilize.
+    Promote earlier if real long routes are already sluggish. Otherwise optimize after workflows stabilize.
 
 11. [#19 Add route surface type data from OSM](https://github.com/conqeror/ultra-companion/issues/19)
     Excellent planning feature, but it is a larger milestone touching offline fetch, storage, map, profile, and collections.

--- a/services/googlePlacesClient.ts
+++ b/services/googlePlacesClient.ts
@@ -1,4 +1,5 @@
 import type { RoutePoint, POICategory } from "@/types";
+import { downsampleRoutePointsByDistance, splitRoutePointsByDistance } from "@/utils/geo";
 import type { ClassifiedPOI } from "./poiClassifier";
 
 // --- Google Places API response types ---
@@ -53,30 +54,6 @@ function encodeSignedValue(value: number): string {
   }
   encoded += String.fromCharCode(v + 63);
   return encoded;
-}
-
-/** Downsample route to ~1 point per km for a compact polyline */
-function downsampleForPolyline(points: RoutePoint[]): { latitude: number; longitude: number }[] {
-  if (points.length === 0) return [];
-
-  const result = [{ latitude: points[0].latitude, longitude: points[0].longitude }];
-  let lastDist = points[0].distanceFromStartMeters;
-
-  for (let i = 1; i < points.length; i++) {
-    if (points[i].distanceFromStartMeters - lastDist >= 1000) {
-      result.push({ latitude: points[i].latitude, longitude: points[i].longitude });
-      lastDist = points[i].distanceFromStartMeters;
-    }
-  }
-
-  // Always include last point
-  const last = points[points.length - 1];
-  const lastResult = result[result.length - 1];
-  if (last.latitude !== lastResult.latitude || last.longitude !== lastResult.longitude) {
-    result.push({ latitude: last.latitude, longitude: last.longitude });
-  }
-
-  return result;
 }
 
 // --- Tags ---
@@ -174,35 +151,13 @@ async function searchAlongRoute(
 // --- Route segmentation ---
 
 const MAX_SEGMENT_M = 50_000;
+const POLYLINE_POINT_INTERVAL_M = 1_000;
 
-/** Split route points into even segments of at most MAX_SEGMENT_M, with 1-point overlap */
-function splitRoute(points: RoutePoint[]): RoutePoint[][] {
-  if (points.length < 2) return [points];
-
-  const totalDist =
-    points[points.length - 1].distanceFromStartMeters - points[0].distanceFromStartMeters;
-  if (totalDist <= MAX_SEGMENT_M) return [points];
-
-  const numSegments = Math.ceil(totalDist / MAX_SEGMENT_M);
-  const segmentLength = totalDist / numSegments;
-  const segments: RoutePoint[][] = [];
-  let segStart = 0;
-  let segStartDist = points[0].distanceFromStartMeters;
-
-  for (let i = 1; i < points.length; i++) {
-    if (points[i].distanceFromStartMeters - segStartDist >= segmentLength) {
-      segments.push(points.slice(segStart, i + 1)); // overlap by 1 point
-      segStart = i;
-      segStartDist = points[i].distanceFromStartMeters;
-    }
-  }
-
-  // Remaining points
-  if (segStart < points.length - 1) {
-    segments.push(points.slice(segStart));
-  }
-
-  return segments;
+function samePolylinePoint(
+  a: { latitude: number; longitude: number },
+  b: { latitude: number; longitude: number },
+): boolean {
+  return a.latitude === b.latitude && a.longitude === b.longitude;
 }
 
 // --- Main orchestrator ---
@@ -212,7 +167,11 @@ export async function fetchGooglePlacesPOIs(
   apiKey: string,
   onProgress?: (done: number, total: number) => void,
 ): Promise<ClassifiedPOI[]> {
-  const segments = splitRoute(routePoints);
+  const segments = splitRoutePointsByDistance(routePoints, {
+    maxSegmentLengthMeters: MAX_SEGMENT_M,
+    balanceSegments: true,
+    includeShortRoute: true,
+  });
   const totalSteps = segments.length * SEARCHES.length;
   let step = 0;
 
@@ -220,7 +179,11 @@ export async function fetchGooglePlacesPOIs(
   const results: ClassifiedPOI[] = [];
 
   for (const segment of segments) {
-    const downsampled = downsampleForPolyline(segment);
+    const downsampled = downsampleRoutePointsByDistance(segment, {
+      intervalMeters: POLYLINE_POINT_INTERVAL_M,
+      mapPoint: (point) => ({ latitude: point.latitude, longitude: point.longitude }),
+      isSameOutput: samePolylinePoint,
+    });
     const encodedPolyline = encodePolyline(downsampled);
 
     onProgress?.(step, totalSteps);

--- a/services/offlineTiles.ts
+++ b/services/offlineTiles.ts
@@ -8,6 +8,7 @@ import {
 } from "@/modules/offline-tiles";
 import type { RoutePoint } from "@/types";
 import { MAP_STYLE_URL } from "@/types";
+import { downsampleRoutePointsByDistance } from "@/utils/geo";
 import {
   OFFLINE_MIN_ZOOM,
   OFFLINE_MAX_ZOOM,
@@ -24,26 +25,7 @@ function extractRouteId(id: string): string | null {
   return id.slice(OFFLINE_PACK_PREFIX.length);
 }
 
-/**
- * Downsample route points to ~1 per 200m.
- * Returns [[lng, lat], ...] for the native module.
- */
-function downsampleCoords(points: RoutePoint[]): number[][] {
-  if (points.length === 0) return [];
-
-  const MIN_GAP_M = 200;
-  const coords: number[][] = [[points[0].longitude, points[0].latitude]];
-  let lastDist = points[0].distanceFromStartMeters;
-
-  for (let i = 1; i < points.length; i++) {
-    if (points[i].distanceFromStartMeters - lastDist >= MIN_GAP_M || i === points.length - 1) {
-      coords.push([points[i].longitude, points[i].latitude]);
-      lastDist = points[i].distanceFromStartMeters;
-    }
-  }
-
-  return coords;
-}
+const TILE_ROUTE_POINT_INTERVAL_M = 200;
 
 /**
  * Estimate download size based on route length.
@@ -66,7 +48,10 @@ export async function downloadRouteTiles(
 ): Promise<void> {
   const id = packId(routeId);
   const styleURL = MAP_STYLE_URL;
-  const coords = downsampleCoords(points);
+  const coords = downsampleRoutePointsByDistance(points, {
+    intervalMeters: TILE_ROUTE_POINT_INTERVAL_M,
+    mapPoint: (point) => [point.longitude, point.latitude],
+  });
 
   if (coords.length < 2) {
     onError("Route too short for offline download");

--- a/services/overpassClient.ts
+++ b/services/overpassClient.ts
@@ -1,5 +1,6 @@
 import type { RoutePoint } from "@/types";
 import { OVERPASS_API_URLS, OVERPASS_SEGMENT_LENGTH_M, OVERPASS_RETRY_DELAYS } from "@/constants";
+import { downsampleRoutePointsByDistance, splitRoutePointsByDistance } from "@/utils/geo";
 
 let _nextServerIndex = 0;
 
@@ -25,59 +26,10 @@ interface OverpassResponse {
   elements: OverpassElement[];
 }
 
-// --- Route downsampling for queries ---
+const QUERY_POINT_INTERVAL_M = 1_000;
 
-/** Downsample route points to ~1 point per intervalM meters */
-function downsampleByDistance(
-  points: RoutePoint[],
-  intervalM: number,
-): { lat: number; lon: number }[] {
-  if (points.length === 0) return [];
-
-  const result: { lat: number; lon: number }[] = [
-    { lat: points[0].latitude, lon: points[0].longitude },
-  ];
-  let lastDist = points[0].distanceFromStartMeters;
-
-  for (let i = 1; i < points.length; i++) {
-    if (points[i].distanceFromStartMeters - lastDist >= intervalM) {
-      result.push({ lat: points[i].latitude, lon: points[i].longitude });
-      lastDist = points[i].distanceFromStartMeters;
-    }
-  }
-
-  // Always include the last point
-  const last = points[points.length - 1];
-  const lastResult = result[result.length - 1];
-  if (last.latitude !== lastResult.lat || last.longitude !== lastResult.lon) {
-    result.push({ lat: last.latitude, lon: last.longitude });
-  }
-
-  return result;
-}
-
-/** Split route points into segments of approximately segmentLengthM */
-function segmentRoute(points: RoutePoint[], segmentLengthM: number): RoutePoint[][] {
-  if (points.length === 0) return [];
-
-  const segments: RoutePoint[][] = [];
-  let segStart = 0;
-  let segStartDist = points[0].distanceFromStartMeters;
-
-  for (let i = 1; i < points.length; i++) {
-    if (points[i].distanceFromStartMeters - segStartDist >= segmentLengthM) {
-      segments.push(points.slice(segStart, i + 1)); // overlap by 1 point
-      segStart = i;
-      segStartDist = points[i].distanceFromStartMeters;
-    }
-  }
-
-  // Remaining points
-  if (segStart < points.length - 1) {
-    segments.push(points.slice(segStart));
-  }
-
-  return segments;
+function sameQueryPoint(a: { lat: number; lon: number }, b: { lat: number; lon: number }): boolean {
+  return a.lat === b.lat && a.lon === b.lon;
 }
 
 // --- Overpass QL query building ---
@@ -186,7 +138,9 @@ export async function fetchAllPOIs(
   corridorWidthM: number,
   onProgress?: (done: number, total: number) => void,
 ): Promise<OverpassElement[]> {
-  const segments = segmentRoute(routePoints, OVERPASS_SEGMENT_LENGTH_M);
+  const segments = splitRoutePointsByDistance(routePoints, {
+    maxSegmentLengthMeters: OVERPASS_SEGMENT_LENGTH_M,
+  });
   const allElements: OverpassElement[] = [];
   const seen = new Set<number>(); // deduplicate by OSM id
 
@@ -194,7 +148,11 @@ export async function fetchAllPOIs(
     onProgress?.(i, segments.length);
 
     // Downsample segment points to ~1 per km for the query
-    const downsampled = downsampleByDistance(segments[i], 1000);
+    const downsampled = downsampleRoutePointsByDistance(segments[i], {
+      intervalMeters: QUERY_POINT_INTERVAL_M,
+      mapPoint: (point) => ({ lat: point.latitude, lon: point.longitude }),
+      isSameOutput: sameQueryPoint,
+    });
     const query = buildOverpassQuery(downsampled, corridorWidthM);
     const elements = await fetchOverpassSegment(query);
 

--- a/tests/utils/geo.test.ts
+++ b/tests/utils/geo.test.ts
@@ -4,12 +4,14 @@ import {
   computeElevationProgressAtDistance,
   computeSliceAscentFromDistance,
   computePOIRouteAssociation,
+  downsampleRoutePointsByDistance,
   findFirstPointAtOrAfterDistance,
   findLastPointAtOrBeforeDistance,
   findNearestPointIndexAtDistance,
   interpolateRoutePointAtDistance,
   routeToMapGeoJSON,
   simplifyRoutePointsForMap,
+  splitRoutePointsByDistance,
 } from "@/utils/geo";
 import type { RoutePoint } from "@/types";
 
@@ -24,6 +26,91 @@ function point(idx: number, distanceFromStartMeters: number, latitude = 0): Rout
 }
 
 describe("geo route performance helpers", () => {
+  it("downsamples route points by distance with caller-defined output shape", () => {
+    const points = [point(0, 0), point(1, 400), point(2, 1_000), point(3, 1_600), point(4, 2_100)];
+
+    const sampled = downsampleRoutePointsByDistance(points, {
+      intervalMeters: 1_000,
+      mapPoint: (routePoint) => ({
+        lat: routePoint.latitude,
+        lon: routePoint.longitude,
+      }),
+    });
+
+    expect(sampled).toEqual([
+      { lat: 0, lon: 0 },
+      { lat: 0, lon: 0.01 },
+      { lat: 0, lon: 0.021 },
+    ]);
+  });
+
+  it("allows callers to decide whether duplicate endpoint coordinates are retained", () => {
+    const points = [
+      point(0, 0, 0),
+      { ...point(1, 1_000, 1), longitude: 1 },
+      { ...point(2, 1_500, 1), longitude: 1 },
+    ];
+
+    const withoutEndpointComparator = downsampleRoutePointsByDistance(points, {
+      intervalMeters: 1_000,
+      mapPoint: (routePoint) => [routePoint.longitude, routePoint.latitude],
+    });
+    const withEndpointComparator = downsampleRoutePointsByDistance(points, {
+      intervalMeters: 1_000,
+      mapPoint: (routePoint) => ({
+        lat: routePoint.latitude,
+        lon: routePoint.longitude,
+      }),
+      isSameOutput: (a, b) => a.lat === b.lat && a.lon === b.lon,
+    });
+
+    expect(withoutEndpointComparator).toEqual([
+      [0, 0],
+      [1, 1],
+      [1, 1],
+    ]);
+    expect(withEndpointComparator).toEqual([
+      { lat: 0, lon: 0 },
+      { lat: 1, lon: 1 },
+    ]);
+  });
+
+  it("splits route points by distance with one-point overlap", () => {
+    const points = [0, 30, 60, 90, 120].map((distance, idx) => point(idx, distance));
+
+    const segments = splitRoutePointsByDistance(points, { maxSegmentLengthMeters: 50 });
+
+    expect(segments.map((segment) => segment.map((routePoint) => routePoint.idx))).toEqual([
+      [0, 1, 2],
+      [2, 3, 4],
+    ]);
+  });
+
+  it("can balance route point segments and preserve short routes when requested", () => {
+    const points = [0, 40, 80, 120].map((distance, idx) => point(idx, distance));
+    const singlePointRoute = [point(0, 0)];
+
+    const balanced = splitRoutePointsByDistance(points, {
+      maxSegmentLengthMeters: 50,
+      balanceSegments: true,
+    });
+
+    expect(balanced.map((segment) => segment.map((routePoint) => routePoint.idx))).toEqual([
+      [0, 1],
+      [1, 2],
+      [2, 3],
+    ]);
+    expect(splitRoutePointsByDistance(singlePointRoute, { maxSegmentLengthMeters: 50 })).toEqual(
+      [],
+    );
+    expect(
+      splitRoutePointsByDistance(singlePointRoute, {
+        maxSegmentLengthMeters: 50,
+        includeShortRoute: true,
+      }),
+    ).toEqual([singlePointRoute]);
+  });
+
   it("finds distance boundaries with binary search semantics", () => {
     const points = [point(0, 0), point(1, 100), point(2, 100), point(3, 200), point(4, 400)];
 

--- a/utils/geo.ts
+++ b/utils/geo.ts
@@ -106,6 +106,82 @@ export function findNearestPointOnRoute(
   return { index: minIndex, distanceMeters: minDist };
 }
 
+export interface DownsampleRoutePointsOptions<TOutput> {
+  intervalMeters: number;
+  mapPoint: (point: RoutePoint) => TOutput;
+  isSameOutput?: (a: TOutput, b: TOutput) => boolean;
+}
+
+/** Downsample route points by route distance while preserving first and last points. */
+export function downsampleRoutePointsByDistance<TOutput>(
+  points: RoutePoint[],
+  options: DownsampleRoutePointsOptions<TOutput>,
+): TOutput[] {
+  if (points.length === 0) return [];
+
+  const { intervalMeters, mapPoint, isSameOutput } = options;
+  const result: TOutput[] = [mapPoint(points[0])];
+  let lastIncludedDistance = points[0].distanceFromStartMeters;
+  let lastIncludedIndex = 0;
+
+  for (let i = 1; i < points.length; i++) {
+    if (points[i].distanceFromStartMeters - lastIncludedDistance >= intervalMeters) {
+      result.push(mapPoint(points[i]));
+      lastIncludedDistance = points[i].distanceFromStartMeters;
+      lastIncludedIndex = i;
+    }
+  }
+
+  if (lastIncludedIndex !== points.length - 1) {
+    const endpoint = mapPoint(points[points.length - 1]);
+    const previous = result[result.length - 1];
+    if (!isSameOutput || !isSameOutput(endpoint, previous)) {
+      result.push(endpoint);
+    }
+  }
+
+  return result;
+}
+
+export interface SplitRoutePointsOptions {
+  maxSegmentLengthMeters: number;
+  balanceSegments?: boolean;
+  includeShortRoute?: boolean;
+}
+
+/** Split route points by distance with a one-point overlap between adjacent segments. */
+export function splitRoutePointsByDistance(
+  points: RoutePoint[],
+  options: SplitRoutePointsOptions,
+): RoutePoint[][] {
+  if (points.length < 2) return options.includeShortRoute ? [points] : [];
+
+  const totalDistance =
+    points[points.length - 1].distanceFromStartMeters - points[0].distanceFromStartMeters;
+  if (totalDistance <= options.maxSegmentLengthMeters) return [points];
+
+  const segmentLength = options.balanceSegments
+    ? totalDistance / Math.ceil(totalDistance / options.maxSegmentLengthMeters)
+    : options.maxSegmentLengthMeters;
+  const segments: RoutePoint[][] = [];
+  let segmentStart = 0;
+  let segmentStartDistance = points[0].distanceFromStartMeters;
+
+  for (let i = 1; i < points.length; i++) {
+    if (points[i].distanceFromStartMeters - segmentStartDistance >= segmentLength) {
+      segments.push(points.slice(segmentStart, i + 1));
+      segmentStart = i;
+      segmentStartDistance = points[i].distanceFromStartMeters;
+    }
+  }
+
+  if (segmentStart < points.length - 1) {
+    segments.push(points.slice(segmentStart));
+  }
+
+  return segments;
+}
+
 /** First point index with distance >= targetDistanceMeters. Returns points.length if none. */
 export function findFirstPointAtOrAfterDistance(
   points: RoutePoint[],


### PR DESCRIPTION
## Summary
- Add shared route downsampling and route splitting helpers in `utils/geo.ts`.
- Replace duplicated sampling/splitting logic in Google Places, Overpass, and offline tile downloads while preserving caller-specific coordinate shapes.
- Add Vitest coverage for interval sampling, endpoint handling, fixed/overlapped splitting, and balanced splitting.
- Normalize an existing `docs/roadmap.md` indentation issue so the repo-wide formatter check passes.

Fixes #5

## Verification
- `npx vitest run tests/utils/geo.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`