### PR TITLE
Support bulk route import

### DIFF
--- a/app/(tabs)/routes.tsx
+++ b/app/(tabs)/routes.tsx
@@ -6,6 +6,7 @@ import {
   Alert,
   ActivityIndicator,
   StyleSheet,
+  type AlertButton,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { Text } from "@/components/ui/text";
@@ -20,9 +21,45 @@ import { useOfflineStore } from "@/store/offlineStore";
 import { ACTIVE_ROUTE_COLOR, INACTIVE_ROUTE_COLOR } from "@/constants";
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import { useThemeColors } from "@/theme";
-import type { Route, Collection } from "@/types";
+import type { Route, Collection, RouteImportSummary } from "@/types";
 
 type SectionItem = { type: "collection"; data: Collection } | { type: "route"; data: Route };
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return fallback;
+}
+
+function routeLabel(count: number): string {
+  return count === 1 ? "route" : "routes";
+}
+
+function fileLabel(count: number): string {
+  return count === 1 ? "file" : "files";
+}
+
+function buildImportSummaryMessage(summary: RouteImportSummary): string {
+  const importedCount = summary.imported.length;
+  const failedCount = summary.failed.length;
+  const lines = [
+    `Imported ${importedCount} ${routeLabel(importedCount)} from ${summary.total} ${fileLabel(
+      summary.total,
+    )}.`,
+  ];
+
+  if (failedCount > 0) {
+    lines.push("", `Failed ${failedCount} ${fileLabel(failedCount)}:`);
+    for (const failure of summary.failed.slice(0, 3)) {
+      lines.push(`${failure.fileName}: ${failure.reason}`);
+    }
+    if (failedCount > 3) {
+      lines.push(`And ${failedCount - 3} more.`);
+    }
+  }
+
+  return lines.join("\n");
+}
 
 export default function RoutesScreen() {
   const router = useRouter();
@@ -31,6 +68,7 @@ export default function RoutesScreen() {
     routes,
     isLoading,
     error,
+    importProgress,
     loadRouteMetadata,
     importRoute,
     deleteRoute,
@@ -43,6 +81,7 @@ export default function RoutesScreen() {
   const loadCollections = useCollectionStore((s) => s.loadCollections);
   const createCollection = useCollectionStore((s) => s.createCollection);
   const deleteCollection = useCollectionStore((s) => s.deleteCollection);
+  const addSegment = useCollectionStore((s) => s.addSegment);
   const setActiveCollection = useCollectionStore((s) => s.setActiveCollection);
   const activeStitchedCollection = useCollectionStore((s) => s.activeStitchedCollection);
   const assignedRouteIds = useCollectionStore((s) => s.assignedRouteIds);
@@ -110,6 +149,67 @@ export default function RoutesScreen() {
       "plain-text",
     );
   }, [createCollection, router]);
+
+  const promptCreateCollectionFromRoutes = useCallback(
+    (importedRoutes: Route[]) => {
+      Alert.prompt(
+        "New Collection",
+        "Name this collection",
+        [
+          { text: "Cancel", style: "cancel" },
+          {
+            text: "Create",
+            onPress: async (name?: string) => {
+              const trimmed = name?.trim();
+              if (!trimmed) return;
+
+              try {
+                const id = await createCollection(trimmed);
+                for (const route of importedRoutes) {
+                  await addSegment(id, route.id);
+                }
+                await loadCollections();
+                router.push(`/collection/${id}` as any);
+              } catch (e: unknown) {
+                Alert.alert(
+                  "Collection Failed",
+                  getErrorMessage(e, "Could not create collection."),
+                );
+              }
+            },
+          },
+        ],
+        "plain-text",
+      );
+    },
+    [addSegment, createCollection, loadCollections, router],
+  );
+
+  const handleImportRoute = useCallback(async () => {
+    const summary = await importRoute();
+    if (!summary || summary.total === 0) return;
+
+    if (summary.total === 1 && summary.failed.length === 0) return;
+
+    if (summary.total === 1 && summary.failed.length === 1) {
+      Alert.alert("Import Failed", summary.failed[0].reason);
+      return;
+    }
+
+    const buttons: AlertButton[] = [{ text: "OK", style: "cancel" }];
+    if (summary.imported.length > 0) {
+      buttons.unshift({
+        text: "New Collection",
+        onPress: () => promptCreateCollectionFromRoutes(summary.imported),
+      });
+    }
+
+    Alert.alert(
+      summary.failed.length > 0 ? "Import Finished" : "Import Complete",
+      buildImportSummaryMessage(summary),
+      buttons,
+    );
+  }, [importRoute, promptCreateCollectionFromRoutes]);
 
   const borderColor = colors.border;
 
@@ -353,11 +453,20 @@ export default function RoutesScreen() {
         />
         <Button
           className="flex-1"
-          onPress={importRoute}
+          onPress={handleImportRoute}
           disabled={isLoading}
           label={isLoading ? undefined : "Import Route"}
         >
-          {isLoading && <ActivityIndicator color="#fff" />}
+          {isLoading && (
+            <View className="flex-row items-center justify-center gap-2">
+              <ActivityIndicator color="#fff" />
+              {importProgress && (
+                <Text className="text-primary-foreground text-[15px] font-barlow-semibold">
+                  {importProgress.current}/{importProgress.total}
+                </Text>
+              )}
+            </View>
+          )}
         </Button>
       </View>
     </View>

--- a/docs/features.md
+++ b/docs/features.md
@@ -12,7 +12,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 
 ## Routes
 
-- Import GPX/KML via file picker, share sheet, or URL
+- Import GPX/KML via single or multi-select file picker, share sheet, or URL
 - Multiple routes with distinct colors
 - Route list with toggle visibility, set active, delete
 - Route metadata: total distance, ascent, descent

--- a/store/routeStore.ts
+++ b/store/routeStore.ts
@@ -20,14 +20,27 @@ import type {
   RoutePoint,
   SnappedPosition,
   RouteSnapHistorySample,
+  RouteImportProgress,
+  RouteImportSummary,
 } from "@/types";
 
 const MAX_SNAP_HISTORY_SAMPLES = 5;
+
+interface ImportFromUriOptions {
+  createdAt?: string;
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return fallback;
+}
 
 interface RouteState {
   routes: Route[];
   isLoading: boolean;
   error: string | null;
+  importProgress: RouteImportProgress | null;
   // Lazily cached point arrays for routes that currently need full geometry.
   visibleRoutePoints: Record<string, RoutePoint[]>;
   // Snapped position on active route
@@ -46,8 +59,8 @@ interface RouteState {
   loadVisibleRoutePoints: () => Promise<void>;
   /** Load metadata, then visible points. Use when both are needed. */
   loadRoutesAndPoints: () => Promise<void>;
-  importRoute: () => Promise<void>;
-  importFromUri: (uri: string, fileName: string) => Promise<Route>;
+  importRoute: () => Promise<RouteImportSummary | null>;
+  importFromUri: (uri: string, fileName: string, options?: ImportFromUriOptions) => Promise<Route>;
   deleteRoute: (id: string) => Promise<void>;
   toggleVisibility: (id: string) => Promise<void>;
   setActiveRoute: (id: string) => Promise<void>;
@@ -62,6 +75,7 @@ export const useRouteStore = create<RouteState>((set, get) => ({
   routes: [],
   isLoading: false,
   error: null,
+  importProgress: null,
   visibleRoutePoints: {},
   snappedPosition: null,
   snapHistory: [],
@@ -113,7 +127,7 @@ export const useRouteStore = create<RouteState>((set, get) => ({
     set({ visibleRoutePoints: next });
   },
 
-  importFromUri: async (uri: string, fileName: string) => {
+  importFromUri: async (uri: string, fileName: string, options?: ImportFromUriOptions) => {
     const ext = fileName.toLowerCase().split(".").pop();
 
     if (!["gpx", "kml"].includes(ext || "")) {
@@ -146,7 +160,7 @@ export const useRouteStore = create<RouteState>((set, get) => ({
       totalAscentMeters: parsed.totalAscentMeters,
       totalDescentMeters: parsed.totalDescentMeters,
       pointCount: parsed.points.length,
-      createdAt: new Date().toISOString(),
+      createdAt: options?.createdAt ?? new Date().toISOString(),
     };
 
     await insertRoute(route, parsed.points);
@@ -161,25 +175,54 @@ export const useRouteStore = create<RouteState>((set, get) => ({
 
   importRoute: async () => {
     try {
-      set({ isLoading: true, error: null });
+      set({ isLoading: true, error: null, importProgress: null });
 
       const result = await DocumentPicker.getDocumentAsync({
         type: ["application/gpx+xml", "application/vnd.google-earth.kml+xml", "*/*"],
         copyToCacheDirectory: true,
+        multiple: true,
       });
 
-      if (result.canceled || !result.assets?.[0]) {
-        set({ isLoading: false });
-        return;
+      if (result.canceled || !result.assets?.length) {
+        set({ isLoading: false, importProgress: null });
+        return null;
       }
 
-      const asset = result.assets[0];
-      const fileName = asset.name || "route";
+      const imported: Route[] = [];
+      const failed: RouteImportSummary["failed"] = [];
+      const total = result.assets.length;
+      const batchCreatedAt = Date.now();
 
-      await get().importFromUri(asset.uri, fileName);
-      set({ isLoading: false });
+      for (let i = 0; i < result.assets.length; i++) {
+        const asset = result.assets[i];
+        const fileName =
+          asset.name || decodeURIComponent(asset.uri.split("/").pop() || "") || `route-${i + 1}`;
+
+        set({ importProgress: total > 1 ? { current: i + 1, total, fileName } : null });
+
+        try {
+          // The routes query sorts newest-first; stagger batch timestamps so
+          // selected-file order remains visible in the list and collection flow.
+          const createdAt = total > 1 ? new Date(batchCreatedAt - i).toISOString() : undefined;
+          const route = await get().importFromUri(asset.uri, fileName, { createdAt });
+          imported.push(route);
+        } catch (error) {
+          failed.push({
+            fileName,
+            reason: getErrorMessage(error, "Failed to import route"),
+          });
+        }
+      }
+
+      set({ isLoading: false, importProgress: null });
+      return { imported, failed, total };
     } catch (e: any) {
-      set({ isLoading: false, error: e.message || "Failed to import route" });
+      set({
+        isLoading: false,
+        importProgress: null,
+        error: getErrorMessage(e, "Failed to import route"),
+      });
+      return null;
     }
   },
 

--- a/store/routeStore.ts
+++ b/store/routeStore.ts
@@ -195,12 +195,15 @@ export const useRouteStore = create<RouteState>((set, get) => ({
 
       for (let i = 0; i < result.assets.length; i++) {
         const asset = result.assets[i];
-        const fileName =
-          asset.name || decodeURIComponent(asset.uri.split("/").pop() || "") || `route-${i + 1}`;
-
+        const fallbackFileName = `route-${i + 1}`;
+        let fileName = fallbackFileName;
         set({ importProgress: total > 1 ? { current: i + 1, total, fileName } : null });
 
         try {
+          fileName =
+            asset.name || decodeURIComponent(asset.uri.split("/").pop() || "") || fallbackFileName;
+          set({ importProgress: total > 1 ? { current: i + 1, total, fileName } : null });
+
           // The routes query sorts newest-first; stagger batch timestamps so
           // selected-file order remains visible in the list and collection flow.
           const createdAt = total > 1 ? new Date(batchCreatedAt - i).toISOString() : undefined;

--- a/tests/store/routeStore.test.ts
+++ b/tests/store/routeStore.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as DocumentPicker from "expo-document-picker";
 import { databaseMocks } from "@/tests/mocks/database";
 import type { Route, RoutePoint } from "@/types";
 
@@ -15,6 +16,9 @@ vi.mock("expo-file-system", () => ({
 }));
 
 import { useRouteStore } from "@/store/routeStore";
+
+const initialImportRoute = useRouteStore.getState().importRoute;
+const initialImportFromUri = useRouteStore.getState().importFromUri;
 
 const route = (overrides: Partial<Route> = {}): Route => ({
   id: "r1",
@@ -41,14 +45,74 @@ const point = (idx: number): RoutePoint => ({
 
 describe("routeStore", () => {
   beforeEach(() => {
+    vi.mocked(DocumentPicker.getDocumentAsync).mockReset();
     useRouteStore.setState({
       routes: [],
       isLoading: false,
       error: null,
+      importProgress: null,
       visibleRoutePoints: {},
       snappedPosition: null,
       snapHistory: [],
+      importRoute: initialImportRoute,
+      importFromUri: initialImportFromUri,
     });
+  });
+
+  it("imports every selected route file and isolates per-file failures", async () => {
+    const importedA = route({ id: "r1", name: "Segment 1", fileName: "segment-1.gpx" });
+    const importedB = route({ id: "r2", name: "Segment 2", fileName: "segment-2.kml" });
+    const importFromUri = vi
+      .fn()
+      .mockResolvedValueOnce(importedA)
+      .mockRejectedValueOnce(new Error("Invalid GPX: missing <gpx> root element"))
+      .mockResolvedValueOnce(importedB);
+
+    vi.mocked(DocumentPicker.getDocumentAsync).mockResolvedValue({
+      canceled: false,
+      assets: [
+        { uri: "file://segment-1.gpx", name: "segment-1.gpx", lastModified: 0 },
+        { uri: "file://bad.gpx", name: "bad.gpx", lastModified: 0 },
+        { uri: "file://segment-2.kml", name: "segment-2.kml", lastModified: 0 },
+      ],
+    });
+    useRouteStore.setState({ importFromUri });
+
+    const summary = await useRouteStore.getState().importRoute();
+
+    expect(DocumentPicker.getDocumentAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ multiple: true }),
+    );
+    expect(importFromUri).toHaveBeenNthCalledWith(
+      1,
+      "file://segment-1.gpx",
+      "segment-1.gpx",
+      expect.objectContaining({ createdAt: expect.any(String) }),
+    );
+    expect(importFromUri).toHaveBeenNthCalledWith(
+      2,
+      "file://bad.gpx",
+      "bad.gpx",
+      expect.objectContaining({ createdAt: expect.any(String) }),
+    );
+    expect(importFromUri).toHaveBeenNthCalledWith(
+      3,
+      "file://segment-2.kml",
+      "segment-2.kml",
+      expect.objectContaining({ createdAt: expect.any(String) }),
+    );
+    expect(summary).toEqual({
+      imported: [importedA, importedB],
+      failed: [
+        {
+          fileName: "bad.gpx",
+          reason: "Invalid GPX: missing <gpx> root element",
+        },
+      ],
+      total: 3,
+    });
+    expect(useRouteStore.getState().isLoading).toBe(false);
+    expect(useRouteStore.getState().importProgress).toBeNull();
   });
 
   it("reloads active route points when visibility is turned back on", async () => {

--- a/tests/store/routeStore.test.ts
+++ b/tests/store/routeStore.test.ts
@@ -115,6 +115,50 @@ describe("routeStore", () => {
     expect(useRouteStore.getState().importProgress).toBeNull();
   });
 
+  it("keeps importing remaining files when unnamed asset URI decoding fails", async () => {
+    const importedA = route({ id: "r1", name: "Segment 1", fileName: "segment-1.gpx" });
+    const importedB = route({ id: "r2", name: "Segment 2", fileName: "segment-2.kml" });
+    const importFromUri = vi.fn().mockResolvedValueOnce(importedA).mockResolvedValueOnce(importedB);
+
+    vi.mocked(DocumentPicker.getDocumentAsync).mockResolvedValue({
+      canceled: false,
+      assets: [
+        { uri: "file://segment-1.gpx", name: "segment-1.gpx", lastModified: 0 },
+        { uri: "file://bad%ZZ.gpx", name: "", lastModified: 0 },
+        { uri: "file://segment-2.kml", name: "segment-2.kml", lastModified: 0 },
+      ],
+    });
+    useRouteStore.setState({ importFromUri });
+
+    const summary = await useRouteStore.getState().importRoute();
+
+    expect(importFromUri).toHaveBeenCalledTimes(2);
+    expect(importFromUri).toHaveBeenNthCalledWith(
+      1,
+      "file://segment-1.gpx",
+      "segment-1.gpx",
+      expect.objectContaining({ createdAt: expect.any(String) }),
+    );
+    expect(importFromUri).toHaveBeenNthCalledWith(
+      2,
+      "file://segment-2.kml",
+      "segment-2.kml",
+      expect.objectContaining({ createdAt: expect.any(String) }),
+    );
+    expect(summary).toEqual({
+      imported: [importedA, importedB],
+      failed: [
+        {
+          fileName: "route-2",
+          reason: "URI malformed",
+        },
+      ],
+      total: 3,
+    });
+    expect(useRouteStore.getState().isLoading).toBe(false);
+    expect(useRouteStore.getState().importProgress).toBeNull();
+  });
+
   it("reloads active route points when visibility is turned back on", async () => {
     const hiddenActiveRoute = route();
     const visibleActiveRoute = route({ isVisible: true });

--- a/types/index.ts
+++ b/types/index.ts
@@ -39,6 +39,23 @@ export interface RouteWithPoints extends Route {
   points: RoutePoint[];
 }
 
+export interface RouteImportFailure {
+  fileName: string;
+  reason: string;
+}
+
+export interface RouteImportProgress {
+  current: number;
+  total: number;
+  fileName: string;
+}
+
+export interface RouteImportSummary {
+  imported: Route[];
+  failed: RouteImportFailure[];
+  total: number;
+}
+
 export interface SnappedPosition {
   routeId: string;
   pointIndex: number;


### PR DESCRIPTION
## Summary

- Enable multi-select GPX/KML picking and import selected files sequentially.
- Keep per-file failures isolated, preserve selected-file ordering for route list and collection creation, and surface import progress/count.
- Add a bulk-import summary with a one-tap path to create a collection from imported routes.
- Cover the route-store bulk import path with a focused test and update the feature docs.

## Verification

- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`
- `./scripts/smoke-test.sh` blocked: no booted iOS simulator was available, so the script exited while selecting the default UDID (`StopIteration`).

Fixes #15