### PR TITLE
[codex] Add zoom-sensitive route geometry

### DIFF
--- a/app/collection/[id].tsx
+++ b/app/collection/[id].tsx
@@ -12,6 +12,7 @@ import { useClimbStore } from "@/store/climbStore";
 import { usePoiStore } from "@/store/poiStore";
 import type { Collection, CollectionSegmentWithRoute, POI, StitchedCollection } from "@/types";
 import { useMapStyle } from "@/hooks/useMapStyle";
+import { useRouteGeometryZoom } from "@/hooks/useRouteGeometryZoom";
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import { computeBounds } from "@/utils/geo";
 import { stitchCollection, stitchPOIs } from "@/services/stitchingService";
@@ -31,6 +32,7 @@ export default function CollectionDetailScreen() {
   const cameraRef = useRef<Camera>(null);
   const colors = useThemeColors();
   const mapStyle = useMapStyle();
+  const { routeGeometryZoom, updateRouteGeometryZoom } = useRouteGeometryZoom();
 
   const [collection, setCollection] = useState<Collection | null>(null);
   const [segmentsWithRoutes, setSegmentsWithRoutes] = useState<CollectionSegmentWithRoute[]>([]);
@@ -116,6 +118,13 @@ export default function CollectionDetailScreen() {
       animationDuration: 300,
     });
   }, [bounds]);
+
+  const handleCameraChanged = useCallback(
+    (state: { properties: { zoom: number } }) => {
+      updateRouteGeometryZoom(state.properties.zoom);
+    },
+    [updateRouteGeometryZoom],
+  );
 
   // Get route points for each selected segment (for mini map RouteLayer)
   const selectedSegmentRoutes = useMemo(() => {
@@ -294,6 +303,7 @@ export default function CollectionDetailScreen() {
               rotateEnabled={false}
               scrollEnabled={true}
               zoomEnabled={true}
+              onCameraChanged={handleCameraChanged}
             >
               <Camera
                 ref={cameraRef}
@@ -320,6 +330,7 @@ export default function CollectionDetailScreen() {
                     key={`${route.id}-${mapStyle.styleKey}`}
                     route={{ ...route, isActive: true }}
                     points={points}
+                    zoomLevel={routeGeometryZoom}
                   />
                 );
               })}

--- a/app/route/[id].tsx
+++ b/app/route/[id].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useState, useMemo, useRef } from "react";
 import { View, ScrollView, useWindowDimensions, ActivityIndicator } from "react-native";
 import { useLocalSearchParams, Stack } from "expo-router";
 import { Camera, MapView as MapboxMapView } from "@rnmapbox/maps";
@@ -11,6 +11,7 @@ import { usePoiStore } from "@/store/poiStore";
 import { useClimbStore } from "@/store/climbStore";
 import type { RouteWithPoints, Climb } from "@/types";
 import { useMapStyle } from "@/hooks/useMapStyle";
+import { useRouteGeometryZoom } from "@/hooks/useRouteGeometryZoom";
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import {
   computeBounds,
@@ -34,6 +35,7 @@ export default function RouteDetailScreen() {
   const cameraRef = useRef<Camera>(null);
   const colors = useThemeColors();
   const mapStyle = useMapStyle();
+  const { routeGeometryZoom, updateRouteGeometryZoom } = useRouteGeometryZoom();
 
   const [route, setRoute] = useState<RouteWithPoints | null>(null);
   const [loading, setLoading] = useState(true);
@@ -103,6 +105,13 @@ export default function RouteDetailScreen() {
     return [{ routeId: route.id, routeName: route.name, points: route.points }];
   }, [route]);
 
+  const handleCameraChanged = useCallback(
+    (state: { properties: { zoom: number } }) => {
+      updateRouteGeometryZoom(state.properties.zoom);
+    },
+    [updateRouteGeometryZoom],
+  );
+
   if (loading) {
     return (
       <View className="flex-1 items-center justify-center bg-background">
@@ -136,6 +145,7 @@ export default function RouteDetailScreen() {
             rotateEnabled={false}
             scrollEnabled={true}
             zoomEnabled={true}
+            onCameraChanged={handleCameraChanged}
           >
             <Camera
               ref={cameraRef}
@@ -158,6 +168,7 @@ export default function RouteDetailScreen() {
               key={mapStyle.styleKey}
               route={{ ...route, isActive: true }}
               points={route.points}
+              zoomLevel={routeGeometryZoom}
             />
           </MapboxMapView>
         </View>

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -10,6 +10,7 @@ import { usePanelStore } from "@/store/panelStore";
 import { SHEET_COMPACT_RATIO, SHEET_EXPANDED_RATIO } from "@/constants";
 import { useThemeColors } from "@/theme";
 import { useMapStyle } from "@/hooks/useMapStyle";
+import { useRouteGeometryZoom } from "@/hooks/useRouteGeometryZoom";
 import { GPS_STALE_THRESHOLD_MS } from "@/constants";
 import MapControls from "./MapControls";
 import RouteLayer from "./RouteLayer";
@@ -63,6 +64,9 @@ export default function MapScreen() {
     zoom: useMapStore.getState().zoom,
   });
   const lastCamera = useRef(initialCamera.current);
+  const { routeGeometryZoom, updateRouteGeometryZoom } = useRouteGeometryZoom(
+    initialCamera.current.zoom,
+  );
   const panelTab = usePanelStore((s) => s.panelTab);
   const isPanelExpanded = usePanelStore((s) => s.isExpanded);
   const { bottom: safeBottom } = useSafeAreaInsets();
@@ -314,9 +318,11 @@ export default function MapScreen() {
   const handleCameraChanged = useCallback(
     (state: { properties: { center: number[]; zoom: number } }) => {
       const c = state.properties.center;
-      lastCamera.current = { center: [c[0], c[1]], zoom: state.properties.zoom };
+      const zoom = state.properties.zoom;
+      lastCamera.current = { center: [c[0], c[1]], zoom };
+      updateRouteGeometryZoom(zoom);
     },
-    [],
+    [updateRouteGeometryZoom],
   );
 
   // Persist camera to MMKV when app goes to background
@@ -477,6 +483,7 @@ export default function MapScreen() {
               key={`${route.id}-${mapStyle.styleKey}`}
               route={styledRoute}
               points={visibleRoutePoints[route.id]}
+              zoomLevel={routeGeometryZoom}
               dimmed={highlightedClimb != null}
             />
           );
@@ -486,6 +493,7 @@ export default function MapScreen() {
             key={`${activeCollectionRoute.id}-${mapStyle.styleKey}`}
             route={activeCollectionRoute}
             points={activeRoutePoints}
+            zoomLevel={routeGeometryZoom}
             dimmed={highlightedClimb != null}
           />
         )}

--- a/components/map/RouteLayer.tsx
+++ b/components/map/RouteLayer.tsx
@@ -8,13 +8,14 @@ import type { Route, RoutePoint } from "@/types";
 interface RouteLayerProps {
   route: Route;
   points: RoutePoint[];
+  zoomLevel?: number;
   /** Dim the route line (e.g. when a climb highlight is shown on top) */
   dimmed?: boolean;
 }
 
-export default function RouteLayer({ route, points, dimmed }: RouteLayerProps) {
+export default function RouteLayer({ route, points, zoomLevel, dimmed }: RouteLayerProps) {
   const colors = useThemeColors();
-  const geoJSON = useMemo(() => routeToMapGeoJSON(points), [points]);
+  const geoJSON = useMemo(() => routeToMapGeoJSON(points, zoomLevel), [points, zoomLevel]);
 
   const outlineStyle = useMemo(
     () => ({

--- a/docs/performance-notes.md
+++ b/docs/performance-notes.md
@@ -30,6 +30,6 @@ Representative 3 × 100k-point collection:
 - ETA-to-distance lookup now uses binary search over cumulative route distance instead of scanning forward from the current point.
 - Upcoming elevation and climb slice boundaries use binary distance lookups before slicing.
 - Snapping first checks a local window around the previous snapped index and falls back to a full-route scan only when the position jumps or the local result is too far from the route.
-- Mapbox route layers receive cached, Ramer-Douglas-Peucker simplified geometry with a 20 m tolerance instead of full GPX/KML precision.
+- Mapbox route layers receive cached, zoom-sensitive Ramer-Douglas-Peucker simplified geometry: coarser at overview zooms, the previous 20 m tolerance around normal riding zoom, and finer detail when zoomed in.
 - POI map rendering is route-distance windowed during ordinary riding, while the expanded POI list preserves full-list behavior.
 - Offline POI association builds a route-segment grid once per fetch so each candidate POI checks nearby route segments first, with full-route fallback for sparse/out-of-window cases.

--- a/hooks/useRouteGeometryZoom.ts
+++ b/hooks/useRouteGeometryZoom.ts
@@ -1,0 +1,23 @@
+import { useCallback, useRef, useState } from "react";
+import { getMapSimplifyToleranceForZoom } from "@/utils/geo";
+
+export function useRouteGeometryZoom(initialZoom?: number): {
+  routeGeometryZoom: number | undefined;
+  updateRouteGeometryZoom: (zoom: number) => void;
+} {
+  const zoomRef = useRef(initialZoom);
+  const [routeGeometryZoom, setRouteGeometryZoom] = useState(initialZoom);
+
+  const updateRouteGeometryZoom = useCallback((zoom: number) => {
+    if (!Number.isFinite(zoom)) return;
+
+    const currentTolerance = getMapSimplifyToleranceForZoom(zoomRef.current);
+    const nextTolerance = getMapSimplifyToleranceForZoom(zoom);
+    if (nextTolerance === currentTolerance) return;
+
+    zoomRef.current = zoom;
+    setRouteGeometryZoom(zoom);
+  }, []);
+
+  return { routeGeometryZoom, updateRouteGeometryZoom };
+}

--- a/tests/utils/geo.test.ts
+++ b/tests/utils/geo.test.ts
@@ -9,6 +9,7 @@ import {
   findFirstPointAtOrAfterDistance,
   findLastPointAtOrBeforeDistance,
   findNearestPointIndexAtDistance,
+  getMapSimplifyToleranceForZoom,
   interpolateRoutePointAtDistance,
   routeToMapGeoJSON,
   simplifyRoutePointsForMap,
@@ -182,6 +183,41 @@ describe("geo route performance helpers", () => {
     const points = [point(0, 0), point(1, 100), point(2, 200)];
 
     expect(routeToMapGeoJSON(points)).toBe(routeToMapGeoJSON(points));
+  });
+
+  it("chooses map simplification tolerance from zoom buckets", () => {
+    expect(getMapSimplifyToleranceForZoom()).toBe(20);
+    expect(getMapSimplifyToleranceForZoom(8)).toBe(180);
+    expect(getMapSimplifyToleranceForZoom(10)).toBe(60);
+    expect(getMapSimplifyToleranceForZoom(12)).toBe(20);
+    expect(getMapSimplifyToleranceForZoom(14)).toBe(8);
+    expect(getMapSimplifyToleranceForZoom(16)).toBe(3);
+  });
+
+  it("returns more detailed route geometry at high map zoom", () => {
+    const points = [
+      point(0, 0, 0),
+      point(1, 100, 0),
+      point(2, 200, 0),
+      point(3, 300, 0.0001),
+      point(4, 400, 0),
+      point(5, 500, 0),
+    ];
+
+    const midZoom = routeToMapGeoJSON(points, 12);
+    const highZoom = routeToMapGeoJSON(points, 14);
+
+    expect(highZoom.geometry.coordinates.length).toBeGreaterThan(
+      midZoom.geometry.coordinates.length,
+    );
+    expect(highZoom.geometry.coordinates).toContainEqual([points[3].longitude, points[3].latitude]);
+  });
+
+  it("caches map GeoJSON per route point reference and zoom bucket", () => {
+    const points = [point(0, 0), point(1, 100), point(2, 200)];
+
+    expect(routeToMapGeoJSON(points, 12)).toBe(routeToMapGeoJSON(points, 12.5));
+    expect(routeToMapGeoJSON(points, 12)).not.toBe(routeToMapGeoJSON(points, 14));
   });
 
   it("matches full POI route association when using a segment spatial index", () => {

--- a/utils/geo.ts
+++ b/utils/geo.ts
@@ -3,7 +3,17 @@ import type { RoutePoint } from "@/types";
 const EARTH_RADIUS_M = 6_371_000;
 const METERS_PER_LAT_DEGREE = 111_320;
 const MAP_SIMPLIFY_TOLERANCE_M = 20;
-const mapGeoJSONCache = new WeakMap<RoutePoint[], GeoJSON.Feature<GeoJSON.LineString>>();
+const MAP_SIMPLIFY_TOLERANCE_BY_ZOOM = [
+  { minZoom: 15, toleranceMeters: 3 },
+  { minZoom: 13, toleranceMeters: 8 },
+  { minZoom: 11, toleranceMeters: MAP_SIMPLIFY_TOLERANCE_M },
+  { minZoom: 9, toleranceMeters: 60 },
+  { minZoom: 0, toleranceMeters: 180 },
+] as const;
+const mapGeoJSONCache = new WeakMap<
+  RoutePoint[],
+  Map<number, GeoJSON.Feature<GeoJSON.LineString>>
+>();
 
 export function toRad(deg: number): number {
   return (deg * Math.PI) / 180;
@@ -869,6 +879,16 @@ export function routeToGeoJSON(points: RoutePoint[]): GeoJSON.Feature<GeoJSON.Li
   };
 }
 
+export function getMapSimplifyToleranceForZoom(zoomLevel?: number): number {
+  if (zoomLevel == null || !Number.isFinite(zoomLevel)) return MAP_SIMPLIFY_TOLERANCE_M;
+
+  for (const bucket of MAP_SIMPLIFY_TOLERANCE_BY_ZOOM) {
+    if (zoomLevel >= bucket.minZoom) return bucket.toleranceMeters;
+  }
+
+  return MAP_SIMPLIFY_TOLERANCE_M;
+}
+
 function projectedPoint(point: RoutePoint, origin: RoutePoint): { x: number; y: number } {
   const cosLat = Math.cos(toRad(origin.latitude));
   return {
@@ -936,12 +956,23 @@ export function simplifyRoutePointsForMap(
   return simplified;
 }
 
-/** Convert route points to simplified, cached GeoJSON for Mapbox rendering. */
-export function routeToMapGeoJSON(points: RoutePoint[]): GeoJSON.Feature<GeoJSON.LineString> {
-  const cached = mapGeoJSONCache.get(points);
+/** Convert route points to zoom-sensitive, simplified, cached GeoJSON for Mapbox rendering. */
+export function routeToMapGeoJSON(
+  points: RoutePoint[],
+  zoomLevel?: number,
+): GeoJSON.Feature<GeoJSON.LineString> {
+  const toleranceMeters = getMapSimplifyToleranceForZoom(zoomLevel);
+  let cachedByTolerance = mapGeoJSONCache.get(points);
+  if (!cachedByTolerance) {
+    cachedByTolerance = new Map();
+    mapGeoJSONCache.set(points, cachedByTolerance);
+  }
+
+  const cached = cachedByTolerance.get(toleranceMeters);
   if (cached) return cached;
-  const simplified = simplifyRoutePointsForMap(points);
+
+  const simplified = simplifyRoutePointsForMap(points, toleranceMeters);
   const geoJSON = routeToGeoJSON(simplified);
-  mapGeoJSONCache.set(points, geoJSON);
+  cachedByTolerance.set(toleranceMeters, geoJSON);
   return geoJSON;
 }


### PR DESCRIPTION
## Summary

- Add zoom-bucketed route simplification so overview maps keep coarse geometry while high zooms render finer route detail.
- Thread current map camera zoom into `RouteLayer` for the main riding map and route/collection mini maps.
- Cache generated Mapbox GeoJSON per route point array and simplification bucket.
- Document the behavior and cover zoom bucket/detail behavior with geo utility tests.

## Validation

- `npm test`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- Commit hook also ran `oxfmt`, `oxlint --fix`, and `tsc --noEmit` successfully.