### PR TITLE
[codex] Implement global riding horizon selector

### DIFF
--- a/components/map/ClimbTabContent.tsx
+++ b/components/map/ClimbTabContent.tsx
@@ -28,8 +28,8 @@ import { formatDistance, formatElevation } from "@/utils/formatters";
 import {
   createRidingHorizonWindow,
   filterClimbsToRidingHorizon,
-  ridingHorizonKmLabelForMode,
   ridingHorizonMetersForMode,
+  ridingHorizonScopeLabelForMode,
 } from "@/utils/ridingHorizon";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import ClimbListItem from "@/components/climb/ClimbListItem";
@@ -107,7 +107,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
       }),
     [currentDist, ridingHorizonMeters, activeTotalDistance],
   );
-  const horizonLabel = `${ridingHorizonKmLabelForMode(panelMode)} km`;
+  const horizonScopeLabel = ridingHorizonScopeLabelForMode(panelMode);
 
   const displayedClimbs = useMemo(
     () => getClimbsForDisplay(routeIds, segments),
@@ -262,8 +262,8 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
           <Mountain size={24} color={colors.textTertiary} />
           <Text className="text-[13px] text-muted-foreground font-barlow-medium mt-2 text-center">
             {sortedClimbs.length === 0
-              ? `No climbs in the next ${horizonLabel}`
-              : `No climbs match this filter in the next ${horizonLabel}`}
+              ? `No climbs in ${horizonScopeLabel}`
+              : `No climbs match this filter in ${horizonScopeLabel}`}
           </Text>
         </View>
       </View>
@@ -421,7 +421,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
             ListEmptyComponent={
               <View className="items-center justify-center py-8 px-4">
                 <Text className="text-[13px] text-muted-foreground font-barlow-medium">
-                  No climbs match this difficulty in the next {horizonLabel}
+                  No climbs match this difficulty in {horizonScopeLabel}
                 </Text>
               </View>
             }

--- a/components/map/ClimbTabContent.tsx
+++ b/components/map/ClimbTabContent.tsx
@@ -25,6 +25,12 @@ import {
 import { extractRouteSlice, findNearestPointIndexAtDistance } from "@/utils/geo";
 import { resolveActiveRouteProgress } from "@/utils/routeProgress";
 import { formatDistance, formatElevation } from "@/utils/formatters";
+import {
+  createRidingHorizonWindow,
+  filterClimbsToRidingHorizon,
+  ridingHorizonKmLabelForMode,
+  ridingHorizonMetersForMode,
+} from "@/utils/ridingHorizon";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import ClimbListItem from "@/components/climb/ClimbListItem";
 import { resolveActiveClimb } from "@/utils/climbSelect";
@@ -74,6 +80,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
   const setMinimumDifficulty = useClimbStore((s) => s.setMinimumDifficulty);
   const renameClimb = useClimbStore((s) => s.renameClimb);
   const isExpanded = usePanelStore((s) => s.isExpanded);
+  const panelMode = usePanelStore((s) => s.panelMode);
   // Reset to current/upcoming climb when tab mounts
   useEffect(() => {
     setSelectedClimb(null);
@@ -86,11 +93,21 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
 
   const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const segments = activeData?.segments ?? null;
+  const activeTotalDistance = activeData?.totalDistanceMeters;
   const activeRouteProgress = useMemo(
     () => resolveActiveRouteProgress(activeData, snappedPosition),
     [activeData, snappedPosition],
   );
   const currentDist = activeRouteProgress?.distanceAlongRouteMeters ?? null;
+  const ridingHorizonMeters = ridingHorizonMetersForMode(panelMode);
+  const horizonWindow = useMemo(
+    () =>
+      createRidingHorizonWindow(currentDist, ridingHorizonMeters, {
+        totalDistanceMeters: activeTotalDistance,
+      }),
+    [currentDist, ridingHorizonMeters, activeTotalDistance],
+  );
+  const horizonLabel = `${ridingHorizonKmLabelForMode(panelMode)} km`;
 
   const displayedClimbs = useMemo(
     () => getClimbsForDisplay(routeIds, segments),
@@ -101,10 +118,10 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
 
   const sortedClimbs = useMemo(
     () =>
-      [...displayedClimbs].sort(
+      filterClimbsToRidingHorizon(displayedClimbs, horizonWindow).sort(
         (a, b) => a.effectiveStartDistanceMeters - b.effectiveStartDistanceMeters,
       ),
-    [displayedClimbs],
+    [displayedClimbs, horizonWindow],
   );
 
   const filteredClimbs = useMemo(
@@ -124,9 +141,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
   }, [sortedClimbs]);
 
   const selectedClimbForFilter =
-    selectedClimb && isClimbAtLeastDifficulty(selectedClimb.difficultyScore, minimumDifficulty)
-      ? selectedClimb
-      : null;
+    selectedClimb && filteredClimbs.some((c) => c.id === selectedClimb.id) ? selectedClimb : null;
 
   const climb = useMemo(() => {
     if (editingClimb) return editingClimb;
@@ -246,7 +261,9 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
         <View className="flex-1 items-center justify-center px-4">
           <Mountain size={24} color={colors.textTertiary} />
           <Text className="text-[13px] text-muted-foreground font-barlow-medium mt-2 text-center">
-            No climbs match this filter
+            {sortedClimbs.length === 0
+              ? `No climbs in the next ${horizonLabel}`
+              : `No climbs match this filter in the next ${horizonLabel}`}
           </Text>
         </View>
       </View>
@@ -404,7 +421,7 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
             ListEmptyComponent={
               <View className="items-center justify-center py-8 px-4">
                 <Text className="text-[13px] text-muted-foreground font-barlow-medium">
-                  No climbs match this difficulty
+                  No climbs match this difficulty in the next {horizonLabel}
                 </Text>
               </View>
             }

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -21,6 +21,11 @@ import { resolveActiveClimb } from "@/utils/climbSelect";
 import { getClimbMapBounds, getZoomLevelToFitBounds } from "@/utils/climbGeometry";
 import { isClimbAtLeastDifficulty } from "@/constants/climbHelpers";
 import { resolveActiveRouteProgress } from "@/utils/routeProgress";
+import {
+  createRidingHorizonWindow,
+  filterClimbsToRidingHorizon,
+  ridingHorizonMetersForMode,
+} from "@/utils/ridingHorizon";
 import { snapToRouteDetailed } from "@/services/routeSnapping";
 import { useActiveRouteData, getActiveRouteDataImperative } from "@/hooks/useActiveRouteData";
 import { usePoiStore } from "@/store/poiStore";
@@ -68,6 +73,7 @@ export default function MapScreen() {
     initialCamera.current.zoom,
   );
   const panelTab = usePanelStore((s) => s.panelTab);
+  const panelMode = usePanelStore((s) => s.panelMode);
   const isPanelExpanded = usePanelStore((s) => s.isExpanded);
   const { bottom: safeBottom } = useSafeAreaInsets();
   const compactPanelHeight = Math.round(screenHeight * SHEET_COMPACT_RATIO) + safeBottom;
@@ -99,6 +105,15 @@ export default function MapScreen() {
     [activeData, snappedPosition],
   );
   const activeProgressDistanceMeters = activeRouteProgress?.distanceAlongRouteMeters ?? null;
+  const climbHorizonWindow = useMemo(
+    () =>
+      createRidingHorizonWindow(
+        activeProgressDistanceMeters,
+        ridingHorizonMetersForMode(panelMode),
+        { totalDistanceMeters: activeData?.totalDistanceMeters },
+      ),
+    [activeProgressDistanceMeters, panelMode, activeData?.totalDistanceMeters],
+  );
 
   useEffect(() => {
     loadRouteMetadata();
@@ -389,13 +404,12 @@ export default function MapScreen() {
   // Climb to highlight on the map — active when Climbs tab is selected
   const highlightedClimb = useMemo(() => {
     if (panelTab !== "climbs") return null;
-    const displayed = getClimbsForDisplay(activeRouteIds, activeData?.segments ?? null).filter(
-      (c) => isClimbAtLeastDifficulty(c.difficultyScore, minimumDifficulty),
-    );
+    const displayed = filterClimbsToRidingHorizon(
+      getClimbsForDisplay(activeRouteIds, activeData?.segments ?? null),
+      climbHorizonWindow,
+    ).filter((c) => isClimbAtLeastDifficulty(c.difficultyScore, minimumDifficulty));
     const selected =
-      selectedClimb && isClimbAtLeastDifficulty(selectedClimb.difficultyScore, minimumDifficulty)
-        ? selectedClimb
-        : null;
+      selectedClimb && displayed.some((c) => c.id === selectedClimb.id) ? selectedClimb : null;
     return resolveActiveClimb(displayed, activeProgressDistanceMeters, selected);
     // allClimbData is a reactivity trigger: getClimbsForDisplay reads store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -406,6 +420,7 @@ export default function MapScreen() {
     activeData?.segments,
     activeProgressDistanceMeters,
     minimumDifficulty,
+    climbHorizonWindow,
     allClimbData,
   ]);
 

--- a/components/map/POILayer.tsx
+++ b/components/map/POILayer.tsx
@@ -1,11 +1,17 @@
 import React, { useMemo, useCallback } from "react";
 import { ShapeSource, CircleLayer } from "@rnmapbox/maps";
 import { usePoiStore } from "@/store/poiStore";
+import { usePanelStore } from "@/store/panelStore";
 import { useThemeColors } from "@/theme";
-import { POI_BEHIND_THRESHOLD_M, POI_CATEGORIES, POI_MAP_LOOKAHEAD_M } from "@/constants";
+import { POI_BEHIND_THRESHOLD_M, POI_CATEGORIES } from "@/constants";
 import { haversineDistance } from "@/utils/geo";
 import { toDisplayPOIs } from "@/services/displayDistance";
 import { stitchPOIs } from "@/services/stitchingService";
+import {
+  createRidingHorizonWindow,
+  isDistanceInWindow,
+  ridingHorizonMetersForMode,
+} from "@/utils/ridingHorizon";
 import type { DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
 
 const categoryColorMap = Object.fromEntries(POI_CATEGORIES.map((c) => [c.key, c.color]));
@@ -22,16 +28,15 @@ export default function POILayer({ routeIds, segments, currentDistanceMeters }: 
   const starredPOIIds = usePoiStore((s) => s.starredPOIIds);
   const allPois = usePoiStore((s) => s.pois);
   const setSelectedPOI = usePoiStore((s) => s.setSelectedPOI);
+  const panelMode = usePanelStore((s) => s.panelMode);
   const colors = useThemeColors();
 
   const visiblePOIs = useMemo(() => {
-    const distanceWindow =
-      currentDistanceMeters == null
-        ? undefined
-        : {
-            startDistanceMeters: currentDistanceMeters - POI_BEHIND_THRESHOLD_M,
-            endDistanceMeters: currentDistanceMeters + POI_MAP_LOOKAHEAD_M,
-          };
+    const distanceWindow = createRidingHorizonWindow(
+      currentDistanceMeters,
+      ridingHorizonMetersForMode(panelMode),
+      { behindMeters: POI_BEHIND_THRESHOLD_M },
+    );
 
     if (segments) {
       const poisByRoute: Record<string, POI[]> = {};
@@ -43,18 +48,22 @@ export default function POILayer({ routeIds, segments, currentDistanceMeters }: 
 
     const combined: DisplayPOI[] = [];
     for (const routeId of routeIds) {
-      const routePois = getVisiblePOIs(routeId).filter((poi) => {
-        if (!distanceWindow) return true;
-        return (
-          poi.distanceAlongRouteMeters >= distanceWindow.startDistanceMeters &&
-          poi.distanceAlongRouteMeters <= distanceWindow.endDistanceMeters
-        );
-      });
+      const routePois = getVisiblePOIs(routeId).filter((poi) =>
+        isDistanceInWindow(poi.distanceAlongRouteMeters, distanceWindow),
+      );
       combined.push(...toDisplayPOIs(routePois));
     }
     return combined;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeIds, segments, currentDistanceMeters, allPois, enabledCategories, starredPOIIds]);
+  }, [
+    routeIds,
+    segments,
+    currentDistanceMeters,
+    panelMode,
+    allPois,
+    enabledCategories,
+    starredPOIIds,
+  ]);
 
   const geoJSON = useMemo(
     (): GeoJSON.FeatureCollection => ({

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -37,6 +37,12 @@ import { stitchPOIs } from "@/services/stitchingService";
 import { toDisplayPOIForSegments, toDisplayPOIs } from "@/services/displayDistance";
 import { getETAToDistanceFromDistance as resolveETAToDistance } from "@/services/etaCalculator";
 import { resolveActiveRouteProgress } from "@/utils/routeProgress";
+import {
+  createRidingHorizonWindow,
+  isDistanceInWindow,
+  ridingHorizonKmLabelForMode,
+  ridingHorizonMetersForMode,
+} from "@/utils/ridingHorizon";
 import POIFilterBar from "@/components/map/POIFilterBar";
 import POIListItem from "@/components/poi/POIListItem";
 import AddSavedPOISheet from "@/components/poi/AddSavedPOISheet";
@@ -76,21 +82,39 @@ export default function POITabContent({ activeData }: POITabContentProps) {
   const getVisiblePOIs = usePoiStore((s) => s.getVisiblePOIs);
   const allPois = usePoiStore((s) => s.pois);
   const enabledCategories = usePoiStore((s) => s.enabledCategories);
+  const showOpenOnly = usePoiStore((s) => s.showOpenOnly);
   const cumulativeTime = useEtaStore((s) => s.cumulativeTime);
   const isExpanded = usePanelStore((s) => s.isExpanded);
+  const panelMode = usePanelStore((s) => s.panelMode);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [showAddPOI, setShowAddPOI] = useState(false);
   const [loadedSavedPOITargets, setLoadedSavedPOITargets] = useState<SavedPOITarget[] | null>(null);
+  const [showFullRoutePOIs, setShowFullRoutePOIs] = useState(false);
 
   const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const routePoints = activeData?.points ?? null;
   const segments = activeData?.segments ?? null;
+  const activeTotalDistance = activeData?.totalDistanceMeters;
   const activeRouteProgress = useMemo(
     () => resolveActiveRouteProgress(activeData, snappedPosition),
     [activeData, snappedPosition],
   );
   const currentDist = activeRouteProgress?.distanceAlongRouteMeters ?? null;
+  const ridingHorizonMeters = ridingHorizonMetersForMode(panelMode);
+  const horizonWindow = useMemo(
+    () =>
+      createRidingHorizonWindow(currentDist, ridingHorizonMeters, {
+        behindMeters: POI_BEHIND_THRESHOLD_M,
+        totalDistanceMeters: activeTotalDistance,
+      }),
+    [currentDist, ridingHorizonMeters, activeTotalDistance],
+  );
+  const horizonLabel = `${ridingHorizonKmLabelForMode(panelMode)} km`;
+
+  useEffect(() => {
+    setShowFullRoutePOIs(false);
+  }, [activeData?.id, panelMode, isExpanded]);
 
   const savedPOITargets = useMemo<SavedPOITarget[]>(() => {
     if (!activeData) return [];
@@ -120,8 +144,14 @@ export default function POITabContent({ activeData }: POITabContentProps) {
       poisByRoute[routeId] = getStarredPOIs(routeId);
     }
     const displayed = segments
-      ? stitchPOIs(segments, poisByRoute)
-      : routeIds.flatMap((routeId) => toDisplayPOIs(poisByRoute[routeId] ?? []));
+      ? stitchPOIs(segments, poisByRoute, horizonWindow)
+      : routeIds.flatMap((routeId) =>
+          toDisplayPOIs(
+            (poisByRoute[routeId] ?? []).filter((poi) =>
+              isDistanceInWindow(poi.distanceAlongRouteMeters, horizonWindow),
+            ),
+          ),
+        );
     const allStarred: StarredDisplayPOI[] = [];
     for (const poi of displayed) {
       const effectiveDist = poi.effectiveDistanceMeters;
@@ -133,13 +163,19 @@ export default function POITabContent({ activeData }: POITabContentProps) {
       allStarred.push({ ...poi, ridingTimeSeconds: ridingTime });
     }
     allStarred.sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
-    if (currentDist == null) return allStarred;
-    return allStarred.filter(
-      (p) => p.effectiveDistanceMeters >= currentDist - POI_BEHIND_THRESHOLD_M,
-    );
+    return allStarred;
     // starredPOIIds is a reactivity trigger: getStarredPOIs reads from store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routeIds, segments, getStarredPOIs, starredPOIIds, currentDist, cumulativeTime, routePoints]);
+  }, [
+    routeIds,
+    segments,
+    getStarredPOIs,
+    starredPOIIds,
+    currentDist,
+    cumulativeTime,
+    routePoints,
+    horizonWindow,
+  ]);
 
   const totalPOICount = usePoiStore((s) => {
     let count = 0;
@@ -152,26 +188,38 @@ export default function POITabContent({ activeData }: POITabContentProps) {
   // --- Expanded: full POI list with search + filters ---
   const visiblePOIs = useMemo(() => {
     if (!isExpanded) return [];
+    const distanceWindow = showFullRoutePOIs ? undefined : horizonWindow;
     if (segments) {
       const poisByRoute: Record<string, POI[]> = {};
       for (const routeId of routeIds) {
         poisByRoute[routeId] = getVisiblePOIs(routeId);
       }
-      return stitchPOIs(segments, poisByRoute);
+      return stitchPOIs(segments, poisByRoute, distanceWindow);
     }
-    return routeIds.length > 0 ? toDisplayPOIs(getVisiblePOIs(routeIds[0])) : [];
+    return routeIds.flatMap((routeId) =>
+      toDisplayPOIs(
+        getVisiblePOIs(routeId).filter((poi) =>
+          isDistanceInWindow(poi.distanceAlongRouteMeters, distanceWindow),
+        ),
+      ),
+    );
     // allPois/enabledCategories/starredPOIIds are reactivity triggers: getVisiblePOIs reads store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isExpanded, routeIds, segments, allPois, enabledCategories, starredPOIIds]);
+  }, [
+    isExpanded,
+    routeIds,
+    segments,
+    allPois,
+    enabledCategories,
+    starredPOIIds,
+    showOpenOnly,
+    horizonWindow,
+    showFullRoutePOIs,
+  ]);
 
   const sortedAllPOIs = useMemo(() => {
-    if (currentDist == null) {
-      return [...visiblePOIs].sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
-    }
-    return visiblePOIs
-      .filter((p) => p.effectiveDistanceMeters >= currentDist - POI_BEHIND_THRESHOLD_M)
-      .sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
-  }, [visiblePOIs, currentDist]);
+    return [...visiblePOIs].sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
+  }, [visiblePOIs]);
 
   const filteredPOIs = useMemo(() => {
     if (!searchQuery.trim()) return sortedAllPOIs;
@@ -289,6 +337,16 @@ export default function POITabContent({ activeData }: POITabContentProps) {
 
   // --- Expanded mode: full POI list with search + filters ---
   if (isExpanded) {
+    const scopeLabel = showFullRoutePOIs ? "full route" : `next ${horizonLabel}`;
+    const emptyTitle = searchQuery.trim()
+      ? "No POIs match this search"
+      : showFullRoutePOIs
+        ? "No POIs match active filters"
+        : `No POIs in the next ${horizonLabel}`;
+    const emptyDetail = showFullRoutePOIs
+      ? "Category filters may still be hiding route POIs."
+      : "Use full-route planning to inspect POIs outside this riding horizon.";
+
     return (
       <View className="flex-1">
         {/* Search */}
@@ -323,7 +381,32 @@ export default function POITabContent({ activeData }: POITabContentProps) {
           <POIFilterBar routeIds={routeIds} />
         </View>
 
-        {/* Full POI list */}
+        <View
+          className="flex-row items-center justify-between px-3"
+          style={{
+            height: 52,
+            borderBottomWidth: 1,
+            borderBottomColor: colors.borderSubtle,
+          }}
+        >
+          <Text className="text-[11px] font-barlow-semibold text-muted-foreground">
+            {filteredPOIs.length} POIs · {scopeLabel}
+          </Text>
+          <TouchableOpacity
+            className="h-[44px] min-w-[104px] items-center justify-center rounded-full border border-border px-3"
+            onPress={() => setShowFullRoutePOIs((value) => !value)}
+            accessibilityRole="button"
+            accessibilityLabel={
+              showFullRoutePOIs ? "Use riding horizon for POIs" : "Show full route POIs"
+            }
+          >
+            <Text className="text-[12px] font-barlow-semibold text-foreground">
+              {showFullRoutePOIs ? "Use horizon" : "Full route"}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* POI list */}
         <FlatList
           data={filteredPOIs}
           keyExtractor={poiKeyExtractor}
@@ -336,7 +419,30 @@ export default function POITabContent({ activeData }: POITabContentProps) {
           windowSize={POI_LIST_WINDOW_SIZE}
           removeClippedSubviews
           keyboardShouldPersistTaps="handled"
-          extraData={currentDist}
+          extraData={`${currentDist ?? "none"}:${showFullRoutePOIs}`}
+          ListEmptyComponent={
+            <View className="items-center justify-center px-5 py-10">
+              <MapPin size={24} color={colors.textTertiary} />
+              <Text className="text-[13px] text-muted-foreground font-barlow-medium mt-2 text-center">
+                {emptyTitle}
+              </Text>
+              <Text className="text-[11px] text-muted-foreground mt-1 text-center">
+                {emptyDetail}
+              </Text>
+              {!showFullRoutePOIs && (
+                <TouchableOpacity
+                  className="mt-3 h-[44px] min-w-[140px] items-center justify-center rounded-full border border-border px-4"
+                  onPress={() => setShowFullRoutePOIs(true)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Show full route POIs"
+                >
+                  <Text className="text-[12px] font-barlow-semibold text-foreground">
+                    Full route POIs
+                  </Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          }
         />
         <AddSavedPOISheet
           visible={showAddPOI}
@@ -356,7 +462,7 @@ export default function POITabContent({ activeData }: POITabContentProps) {
           <>
             <View className="flex-row items-center justify-between px-3 py-1.5">
               <Text className="text-[11px] font-barlow-semibold text-muted-foreground">
-                {starredUpcoming.length} starred ahead
+                {starredUpcoming.length} starred · next {horizonLabel}
               </Text>
             </View>
             <FlatList
@@ -377,7 +483,10 @@ export default function POITabContent({ activeData }: POITabContentProps) {
           <View className="flex-1 items-center justify-center">
             <Star size={20} color={colors.textTertiary} />
             <Text className="text-[12px] text-muted-foreground font-barlow-medium mt-2">
-              No starred POIs ahead
+              No starred POIs in the next {horizonLabel}
+            </Text>
+            <Text className="text-[11px] text-muted-foreground mt-1 text-center px-5">
+              Starred places outside the riding horizon are available in full-route planning.
             </Text>
           </View>
         )}

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -40,8 +40,8 @@ import { resolveActiveRouteProgress } from "@/utils/routeProgress";
 import {
   createRidingHorizonWindow,
   isDistanceInWindow,
-  ridingHorizonKmLabelForMode,
   ridingHorizonMetersForMode,
+  ridingHorizonScopeLabelForMode,
 } from "@/utils/ridingHorizon";
 import POIFilterBar from "@/components/map/POIFilterBar";
 import POIListItem from "@/components/poi/POIListItem";
@@ -90,7 +90,6 @@ export default function POITabContent({ activeData }: POITabContentProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [showAddPOI, setShowAddPOI] = useState(false);
   const [loadedSavedPOITargets, setLoadedSavedPOITargets] = useState<SavedPOITarget[] | null>(null);
-  const [showFullRoutePOIs, setShowFullRoutePOIs] = useState(false);
 
   const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const routePoints = activeData?.points ?? null;
@@ -110,11 +109,7 @@ export default function POITabContent({ activeData }: POITabContentProps) {
       }),
     [currentDist, ridingHorizonMeters, activeTotalDistance],
   );
-  const horizonLabel = `${ridingHorizonKmLabelForMode(panelMode)} km`;
-
-  useEffect(() => {
-    setShowFullRoutePOIs(false);
-  }, [activeData?.id, panelMode, isExpanded]);
+  const horizonScopeLabel = ridingHorizonScopeLabelForMode(panelMode);
 
   const savedPOITargets = useMemo<SavedPOITarget[]>(() => {
     if (!activeData) return [];
@@ -188,18 +183,17 @@ export default function POITabContent({ activeData }: POITabContentProps) {
   // --- Expanded: full POI list with search + filters ---
   const visiblePOIs = useMemo(() => {
     if (!isExpanded) return [];
-    const distanceWindow = showFullRoutePOIs ? undefined : horizonWindow;
     if (segments) {
       const poisByRoute: Record<string, POI[]> = {};
       for (const routeId of routeIds) {
         poisByRoute[routeId] = getVisiblePOIs(routeId);
       }
-      return stitchPOIs(segments, poisByRoute, distanceWindow);
+      return stitchPOIs(segments, poisByRoute, horizonWindow);
     }
     return routeIds.flatMap((routeId) =>
       toDisplayPOIs(
         getVisiblePOIs(routeId).filter((poi) =>
-          isDistanceInWindow(poi.distanceAlongRouteMeters, distanceWindow),
+          isDistanceInWindow(poi.distanceAlongRouteMeters, horizonWindow),
         ),
       ),
     );
@@ -214,7 +208,6 @@ export default function POITabContent({ activeData }: POITabContentProps) {
     starredPOIIds,
     showOpenOnly,
     horizonWindow,
-    showFullRoutePOIs,
   ]);
 
   const sortedAllPOIs = useMemo(() => {
@@ -337,15 +330,15 @@ export default function POITabContent({ activeData }: POITabContentProps) {
 
   // --- Expanded mode: full POI list with search + filters ---
   if (isExpanded) {
-    const scopeLabel = showFullRoutePOIs ? "full route" : `next ${horizonLabel}`;
+    const scopeLabel = horizonScopeLabel;
     const emptyTitle = searchQuery.trim()
       ? "No POIs match this search"
-      : showFullRoutePOIs
+      : !horizonWindow
         ? "No POIs match active filters"
-        : `No POIs in the next ${horizonLabel}`;
-    const emptyDetail = showFullRoutePOIs
+        : `No POIs in ${horizonScopeLabel}`;
+    const emptyDetail = !horizonWindow
       ? "Category filters may still be hiding route POIs."
-      : "Use full-route planning to inspect POIs outside this riding horizon.";
+      : "Switch the riding horizon to FULL to inspect POIs outside this range.";
 
     return (
       <View className="flex-1">
@@ -392,18 +385,6 @@ export default function POITabContent({ activeData }: POITabContentProps) {
           <Text className="text-[11px] font-barlow-semibold text-muted-foreground">
             {filteredPOIs.length} POIs · {scopeLabel}
           </Text>
-          <TouchableOpacity
-            className="h-[44px] min-w-[104px] items-center justify-center rounded-full border border-border px-3"
-            onPress={() => setShowFullRoutePOIs((value) => !value)}
-            accessibilityRole="button"
-            accessibilityLabel={
-              showFullRoutePOIs ? "Use riding horizon for POIs" : "Show full route POIs"
-            }
-          >
-            <Text className="text-[12px] font-barlow-semibold text-foreground">
-              {showFullRoutePOIs ? "Use horizon" : "Full route"}
-            </Text>
-          </TouchableOpacity>
         </View>
 
         {/* POI list */}
@@ -419,7 +400,7 @@ export default function POITabContent({ activeData }: POITabContentProps) {
           windowSize={POI_LIST_WINDOW_SIZE}
           removeClippedSubviews
           keyboardShouldPersistTaps="handled"
-          extraData={`${currentDist ?? "none"}:${showFullRoutePOIs}`}
+          extraData={`${currentDist ?? "none"}:${panelMode}`}
           ListEmptyComponent={
             <View className="items-center justify-center px-5 py-10">
               <MapPin size={24} color={colors.textTertiary} />
@@ -429,18 +410,6 @@ export default function POITabContent({ activeData }: POITabContentProps) {
               <Text className="text-[11px] text-muted-foreground mt-1 text-center">
                 {emptyDetail}
               </Text>
-              {!showFullRoutePOIs && (
-                <TouchableOpacity
-                  className="mt-3 h-[44px] min-w-[140px] items-center justify-center rounded-full border border-border px-4"
-                  onPress={() => setShowFullRoutePOIs(true)}
-                  accessibilityRole="button"
-                  accessibilityLabel="Show full route POIs"
-                >
-                  <Text className="text-[12px] font-barlow-semibold text-foreground">
-                    Full route POIs
-                  </Text>
-                </TouchableOpacity>
-              )}
             </View>
           }
         />
@@ -462,7 +431,7 @@ export default function POITabContent({ activeData }: POITabContentProps) {
           <>
             <View className="flex-row items-center justify-between px-3 py-1.5">
               <Text className="text-[11px] font-barlow-semibold text-muted-foreground">
-                {starredUpcoming.length} starred · next {horizonLabel}
+                {starredUpcoming.length} starred · {horizonScopeLabel}
               </Text>
             </View>
             <FlatList
@@ -483,11 +452,13 @@ export default function POITabContent({ activeData }: POITabContentProps) {
           <View className="flex-1 items-center justify-center">
             <Star size={20} color={colors.textTertiary} />
             <Text className="text-[12px] text-muted-foreground font-barlow-medium mt-2">
-              No starred POIs in the next {horizonLabel}
+              No starred POIs in {horizonScopeLabel}
             </Text>
-            <Text className="text-[11px] text-muted-foreground mt-1 text-center px-5">
-              Starred places outside the riding horizon are available in full-route planning.
-            </Text>
+            {horizonWindow && (
+              <Text className="text-[11px] text-muted-foreground mt-1 text-center px-5">
+                Switch the riding horizon to FULL to include starred places outside this range.
+              </Text>
+            )}
           </View>
         )}
       </View>

--- a/components/map/ProfileTabContent.tsx
+++ b/components/map/ProfileTabContent.tsx
@@ -8,7 +8,6 @@ import { useRouteStore } from "@/store/routeStore";
 import { useSettingsStore } from "@/store/settingsStore";
 import { usePoiStore } from "@/store/poiStore";
 import { useClimbStore } from "@/store/climbStore";
-import { PANEL_MODES } from "@/constants";
 import {
   computeSliceAscentFromDistance,
   computeSliceElevationTotalsFromDistance,
@@ -21,24 +20,15 @@ import { formatDistance, formatElevation } from "@/utils/formatters";
 import { climbDifficultyColor } from "@/constants/climbHelpers";
 import { stitchPOIs } from "@/services/stitchingService";
 import { toDisplayPOIs } from "@/services/displayDistance";
+import { ridingHorizonMetersForMode } from "@/utils/ridingHorizon";
 import UpcomingElevation from "./UpcomingElevation";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
-import type { PanelMode, POI, ActiveRouteData, DisplayClimb } from "@/types";
+import type { POI, ActiveRouteData, DisplayClimb } from "@/types";
 
-const HEADER_HEIGHT = 44;
 const STATS_HEIGHT = 28;
 const CLIMB_ROW_HEIGHT = 36;
 const MAX_CLIMBS_AHEAD = 4;
 const HORIZONTAL_PADDING = 8;
-
-function lookAheadForMode(mode: PanelMode): number {
-  const match = mode.match(/^upcoming-(\d+)$/);
-  return match ? parseInt(match[1], 10) * 1_000 : 50_000;
-}
-
-function kmLabelForMode(mode: PanelMode): string {
-  return mode.replace("upcoming-", "");
-}
 
 interface ProfileTabContentProps {
   activeData: ActiveRouteData | null;
@@ -56,7 +46,6 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
   const activeTotalDistance = activeData?.totalDistanceMeters ?? 0;
 
   const panelMode = usePanelStore((s) => s.panelMode);
-  const setPanelMode = usePanelStore((s) => s.setPanelMode);
   const setPanelTab = usePanelStore((s) => s.setPanelTab);
   const isExpanded = usePanelStore((s) => s.isExpanded);
   const snappedPosition = useRouteStore((s) => s.snappedPosition);
@@ -157,7 +146,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
       return { windowStartDist: 0, windowEndDist: 0 };
     }
     const distDone = currentDistanceMeters;
-    const la = lookAheadForMode(panelMode);
+    const la = ridingHorizonMetersForMode(panelMode);
     const endDist = Math.min(distDone + la, activeTotalDistance);
     return { windowStartDist: distDone, windowEndDist: endDist };
   }, [currentDistanceMeters, activeRoutePoints, panelMode, activeTotalDistance]);
@@ -192,9 +181,8 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
     );
   }
 
-  const lookAhead = lookAheadForMode(panelMode);
+  const lookAhead = ridingHorizonMetersForMode(panelMode);
 
-  const showHeader = !showClimbZoom;
   const showClimbBar = isExpanded && showClimbZoom && !!climbProgressText;
   const showStats = isExpanded && !showClimbZoom && !!statsText;
   const showClimbsAhead = isExpanded && !showClimbZoom && climbsAhead.length > 0;
@@ -204,10 +192,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
     : 0;
 
   const headerBlockHeight =
-    (showHeader ? HEADER_HEIGHT : 0) +
-    (showStats ? STATS_HEIGHT : 0) +
-    (showClimbBar ? STATS_HEIGHT : 0) +
-    climbsAheadHeight;
+    (showStats ? STATS_HEIGHT : 0) + (showClimbBar ? STATS_HEIGHT : 0) + climbsAheadHeight;
 
   const chartHeight = height - headerBlockHeight - safeBottom;
   const chartWidth = width - HORIZONTAL_PADDING * 2;
@@ -228,18 +213,6 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
             {climbProgressText}
           </Text>
         </TouchableOpacity>
-      )}
-
-      {showHeader && (
-        <View
-          style={{
-            height: HEADER_HEIGHT,
-            paddingHorizontal: HORIZONTAL_PADDING,
-            justifyContent: "center",
-          }}
-        >
-          <RangePills current={panelMode} onChange={setPanelMode} />
-        </View>
       )}
 
       {showStats && (
@@ -303,59 +276,6 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
           />
         )}
       </View>
-    </View>
-  );
-}
-
-function RangePills({
-  current,
-  onChange,
-}: {
-  current: PanelMode;
-  onChange: (mode: PanelMode) => void;
-}) {
-  const colors = useThemeColors();
-  return (
-    <View
-      className="flex-row items-center rounded-full self-center"
-      style={{ backgroundColor: colors.surfaceRaised, padding: 2 }}
-    >
-      {PANEL_MODES.map((mode) => {
-        const isActive = mode === current;
-        return (
-          <TouchableOpacity
-            key={mode}
-            onPress={() => onChange(mode)}
-            accessibilityLabel={`Set range to ${kmLabelForMode(mode)} km`}
-            accessibilityRole="button"
-            accessibilityState={{ selected: isActive }}
-            className="rounded-full items-center justify-center"
-            style={{
-              minWidth: 44,
-              height: 32,
-              paddingHorizontal: 10,
-              backgroundColor: isActive ? colors.accent : "transparent",
-            }}
-          >
-            <Text
-              className="font-barlow-sc-semibold text-[13px]"
-              style={{
-                color: isActive ? colors.accentForeground : colors.textSecondary,
-              }}
-            >
-              {kmLabelForMode(mode)}
-              <Text
-                className="font-barlow-sc-medium text-[10px]"
-                style={{
-                  color: isActive ? colors.accentForeground : colors.textTertiary,
-                }}
-              >
-                {" km"}
-              </Text>
-            </Text>
-          </TouchableOpacity>
-        );
-      })}
     </View>
   );
 }

--- a/components/map/ProfileTabContent.tsx
+++ b/components/map/ProfileTabContent.tsx
@@ -147,7 +147,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
     }
     const distDone = currentDistanceMeters;
     const la = ridingHorizonMetersForMode(panelMode);
-    if (la == null) return { windowStartDist: 0, windowEndDist: activeTotalDistance };
+    if (la == null) return { windowStartDist: distDone, windowEndDist: activeTotalDistance };
     const endDist = Math.min(distDone + la, activeTotalDistance);
     return { windowStartDist: distDone, windowEndDist: endDist };
   }, [currentDistanceMeters, activeRoutePoints, panelMode, activeTotalDistance]);

--- a/components/map/ProfileTabContent.tsx
+++ b/components/map/ProfileTabContent.tsx
@@ -147,6 +147,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
     }
     const distDone = currentDistanceMeters;
     const la = ridingHorizonMetersForMode(panelMode);
+    if (la == null) return { windowStartDist: 0, windowEndDist: activeTotalDistance };
     const endDist = Math.min(distDone + la, activeTotalDistance);
     return { windowStartDist: distDone, windowEndDist: endDist };
   }, [currentDistanceMeters, activeRoutePoints, panelMode, activeTotalDistance]);
@@ -181,7 +182,7 @@ export default function ProfileTabContent({ activeData, width, height }: Profile
     );
   }
 
-  const lookAhead = ridingHorizonMetersForMode(panelMode);
+  const lookAhead = ridingHorizonMetersForMode(panelMode) ?? activeTotalDistance;
 
   const showClimbBar = isExpanded && showClimbZoom && !!climbProgressText;
   const showStats = isExpanded && !showClimbZoom && !!statsText;

--- a/components/map/RidingHorizonSelector.tsx
+++ b/components/map/RidingHorizonSelector.tsx
@@ -1,14 +1,39 @@
 import React, { useState } from "react";
-import { View, TouchableOpacity } from "react-native";
+import { LayoutAnimation, TouchableOpacity, View } from "react-native";
 import { Text } from "@/components/ui/text";
 import { usePanelStore } from "@/store/panelStore";
 import { useThemeColors } from "@/theme";
 import { PANEL_MODES } from "@/constants";
-import { ChevronDown } from "lucide-react-native";
-import { ridingHorizonKmLabelForMode } from "@/utils/ridingHorizon";
+import { ridingHorizonKmLabelForMode, ridingHorizonLabelForMode } from "@/utils/ridingHorizon";
 
 const SELECTOR_HEIGHT = 48;
 const SHEET_GAP = 8;
+const FLOATING_SURFACE_STYLE = {
+  shadowColor: "#000000",
+  shadowOffset: { width: 0, height: 6 },
+  shadowOpacity: 0.18,
+  shadowRadius: 12,
+  elevation: 6,
+};
+const ANIMATION = {
+  duration: 180,
+  update: {
+    type: LayoutAnimation.Types.easeInEaseOut,
+    property: LayoutAnimation.Properties.opacity,
+  },
+  create: {
+    type: LayoutAnimation.Types.easeInEaseOut,
+    property: LayoutAnimation.Properties.opacity,
+  },
+  delete: {
+    type: LayoutAnimation.Types.easeInEaseOut,
+    property: LayoutAnimation.Properties.opacity,
+  },
+};
+
+function animateNextLayout() {
+  LayoutAnimation.configureNext(ANIMATION);
+}
 
 export default function RidingHorizonSelector() {
   const colors = useThemeColors();
@@ -16,7 +41,17 @@ export default function RidingHorizonSelector() {
   const setPanelMode = usePanelStore((s) => s.setPanelMode);
   const [isOpen, setIsOpen] = useState(false);
 
-  const selectedKm = ridingHorizonKmLabelForMode(panelMode);
+  const selectedLabel = ridingHorizonLabelForMode(panelMode);
+
+  const open = () => {
+    animateNextLayout();
+    setIsOpen(true);
+  };
+
+  const close = () => {
+    animateNextLayout();
+    setIsOpen(false);
+  };
 
   return (
     <View
@@ -35,6 +70,7 @@ export default function RidingHorizonSelector() {
             padding: 2,
             gap: 4,
             height: SELECTOR_HEIGHT,
+            ...FLOATING_SURFACE_STYLE,
           }}
         >
           {PANEL_MODES.map((mode) => {
@@ -45,10 +81,10 @@ export default function RidingHorizonSelector() {
                 key={mode}
                 onPress={() => {
                   setPanelMode(mode);
-                  setIsOpen(false);
+                  close();
                 }}
                 hitSlop={{ left: 2, right: 2 }}
-                accessibilityLabel={`Set riding horizon to ${km} km`}
+                accessibilityLabel={`Set riding horizon to ${ridingHorizonLabelForMode(mode)}`}
                 accessibilityRole="button"
                 accessibilityState={{ selected: isActive }}
                 className="flex-1 rounded-full items-center justify-center"
@@ -75,18 +111,18 @@ export default function RidingHorizonSelector() {
           className="self-end flex-row items-center justify-center rounded-full border border-border px-4"
           style={{
             height: SELECTOR_HEIGHT,
-            minWidth: 92,
+            minWidth: 88,
             backgroundColor: colors.surfaceRaised,
+            ...FLOATING_SURFACE_STYLE,
           }}
-          onPress={() => setIsOpen(true)}
-          accessibilityLabel={`Riding horizon ${selectedKm} km`}
+          onPress={open}
+          accessibilityLabel={`Riding horizon ${selectedLabel}`}
           accessibilityRole="button"
           accessibilityState={{ expanded: false }}
         >
           <Text className="font-barlow-sc-semibold text-[15px]" style={{ color: colors.accent }}>
-            {selectedKm} km
+            {selectedLabel}
           </Text>
-          <ChevronDown size={16} color={colors.accent} style={{ marginLeft: 6 }} />
         </TouchableOpacity>
       )}
     </View>

--- a/components/map/RidingHorizonSelector.tsx
+++ b/components/map/RidingHorizonSelector.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { View, TouchableOpacity } from "react-native";
+import { Text } from "@/components/ui/text";
+import { usePanelStore } from "@/store/panelStore";
+import { useThemeColors } from "@/theme";
+import { PANEL_MODES } from "@/constants";
+import { ridingHorizonKmLabelForMode } from "@/utils/ridingHorizon";
+
+export const RIDING_HORIZON_SELECTOR_HEIGHT = 56;
+
+export default function RidingHorizonSelector() {
+  const colors = useThemeColors();
+  const panelMode = usePanelStore((s) => s.panelMode);
+  const setPanelMode = usePanelStore((s) => s.setPanelMode);
+
+  return (
+    <View
+      className="flex-row items-center px-3"
+      style={{
+        height: RIDING_HORIZON_SELECTOR_HEIGHT,
+        borderBottomWidth: 1,
+        borderBottomColor: colors.borderSubtle,
+      }}
+    >
+      <Text className="text-[12px] font-barlow-semibold text-muted-foreground mr-2">Horizon</Text>
+      <View
+        className="flex-1 flex-row items-center rounded-full"
+        style={{ backgroundColor: colors.surfaceRaised, padding: 2, gap: 4 }}
+      >
+        {PANEL_MODES.map((mode) => {
+          const isActive = mode === panelMode;
+          const km = ridingHorizonKmLabelForMode(mode);
+          return (
+            <TouchableOpacity
+              key={mode}
+              onPress={() => setPanelMode(mode)}
+              hitSlop={{ left: 2, right: 2 }}
+              accessibilityLabel={`Set riding horizon to ${km} km`}
+              accessibilityRole="button"
+              accessibilityState={{ selected: isActive }}
+              className="flex-1 rounded-full items-center justify-center"
+              style={{
+                minWidth: 44,
+                height: 48,
+                backgroundColor: isActive ? colors.accent : "transparent",
+              }}
+            >
+              <Text
+                className="font-barlow-sc-semibold text-[13px]"
+                style={{
+                  color: isActive ? colors.accentForeground : colors.textSecondary,
+                }}
+              >
+                {km}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}

--- a/components/map/RidingHorizonSelector.tsx
+++ b/components/map/RidingHorizonSelector.tsx
@@ -12,8 +12,11 @@ import { useThemeColors } from "@/theme";
 import { PANEL_MODES } from "@/constants";
 import { ridingHorizonKmLabelForMode, ridingHorizonLabelForMode } from "@/utils/ridingHorizon";
 
-const SELECTOR_HEIGHT = 48;
-const SHEET_GAP = 8;
+export const RIDING_HORIZON_SELECTOR_HEIGHT = 48;
+export const RIDING_HORIZON_SELECTOR_GAP = 8;
+export const RIDING_HORIZON_SELECTOR_OFFSET =
+  RIDING_HORIZON_SELECTOR_HEIGHT + RIDING_HORIZON_SELECTOR_GAP;
+
 const HORIZONTAL_MARGIN = 12;
 const COLLAPSED_WIDTH = 88;
 const SURFACE_ALPHA = 0.96;
@@ -80,7 +83,7 @@ export default function RidingHorizonSelector() {
       style={{
         position: "absolute",
         right: HORIZONTAL_MARGIN,
-        top: -SELECTOR_HEIGHT - SHEET_GAP,
+        top: 0,
         zIndex: 20,
       }}
     >
@@ -90,7 +93,7 @@ export default function RidingHorizonSelector() {
           {
             backgroundColor: withAlpha(colors.surface, SURFACE_ALPHA),
             borderColor: withAlpha(colors.borderSubtle, 0.95),
-            height: SELECTOR_HEIGHT,
+            height: RIDING_HORIZON_SELECTOR_HEIGHT,
             overflow: "hidden",
             ...FLOATING_SURFACE_STYLE,
           },

--- a/components/map/RidingHorizonSelector.tsx
+++ b/components/map/RidingHorizonSelector.tsx
@@ -1,5 +1,11 @@
 import React, { useState } from "react";
-import { LayoutAnimation, TouchableOpacity, View } from "react-native";
+import { TouchableOpacity, View, useWindowDimensions } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 import { Text } from "@/components/ui/text";
 import { usePanelStore } from "@/store/panelStore";
 import { useThemeColors } from "@/theme";
@@ -8,70 +14,128 @@ import { ridingHorizonKmLabelForMode, ridingHorizonLabelForMode } from "@/utils/
 
 const SELECTOR_HEIGHT = 48;
 const SHEET_GAP = 8;
+const HORIZONTAL_MARGIN = 12;
+const COLLAPSED_WIDTH = 88;
+const SURFACE_ALPHA = 0.96;
 const FLOATING_SURFACE_STYLE = {
   shadowColor: "#000000",
-  shadowOffset: { width: 0, height: 6 },
-  shadowOpacity: 0.18,
-  shadowRadius: 12,
-  elevation: 6,
-};
-const ANIMATION = {
-  duration: 180,
-  update: {
-    type: LayoutAnimation.Types.easeInEaseOut,
-    property: LayoutAnimation.Properties.opacity,
-  },
-  create: {
-    type: LayoutAnimation.Types.easeInEaseOut,
-    property: LayoutAnimation.Properties.opacity,
-  },
-  delete: {
-    type: LayoutAnimation.Types.easeInEaseOut,
-    property: LayoutAnimation.Properties.opacity,
-  },
+  shadowOffset: { width: 0, height: 4 },
+  shadowOpacity: 0.12,
+  shadowRadius: 10,
+  elevation: 4,
 };
 
-function animateNextLayout() {
-  LayoutAnimation.configureNext(ANIMATION);
+function withAlpha(hex: string, alpha: number): string {
+  const normalized = hex.replace("#", "");
+  const value = Number.parseInt(normalized, 16);
+  const r = (value >> 16) & 255;
+  const g = (value >> 8) & 255;
+  const b = value & 255;
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
 export default function RidingHorizonSelector() {
   const colors = useThemeColors();
+  const { width: screenWidth } = useWindowDimensions();
   const panelMode = usePanelStore((s) => s.panelMode);
   const setPanelMode = usePanelStore((s) => s.setPanelMode);
   const [isOpen, setIsOpen] = useState(false);
+  const openProgress = useSharedValue(0);
 
   const selectedLabel = ridingHorizonLabelForMode(panelMode);
+  const expandedWidth = Math.max(COLLAPSED_WIDTH, screenWidth - HORIZONTAL_MARGIN * 2);
+
+  const selectorStyle = useAnimatedStyle(() => ({
+    width: COLLAPSED_WIDTH + (expandedWidth - COLLAPSED_WIDTH) * openProgress.value,
+  }));
+
+  const collapsedLayerStyle = useAnimatedStyle(() => ({
+    opacity: 1 - openProgress.value,
+    transform: [{ scale: 1 - openProgress.value * 0.04 }],
+  }));
+
+  const expandedLayerStyle = useAnimatedStyle(() => ({
+    opacity: openProgress.value,
+    transform: [{ translateX: (1 - openProgress.value) * 10 }],
+  }));
 
   const open = () => {
-    animateNextLayout();
     setIsOpen(true);
+    openProgress.value = withTiming(1, {
+      duration: 220,
+      easing: Easing.out(Easing.cubic),
+    });
   };
 
   const close = () => {
-    animateNextLayout();
     setIsOpen(false);
+    openProgress.value = withTiming(0, {
+      duration: 170,
+      easing: Easing.inOut(Easing.quad),
+    });
   };
 
   return (
     <View
-      className="absolute right-3"
       style={{
+        position: "absolute",
+        right: HORIZONTAL_MARGIN,
         top: -SELECTOR_HEIGHT - SHEET_GAP,
-        left: isOpen ? 12 : undefined,
         zIndex: 20,
       }}
     >
-      {isOpen ? (
-        <View
-          className="flex-row items-center rounded-full border border-border"
-          style={{
-            backgroundColor: colors.surfaceRaised,
-            padding: 2,
-            gap: 4,
+      <Animated.View
+        className="rounded-full border border-border"
+        style={[
+          {
+            backgroundColor: withAlpha(colors.surface, SURFACE_ALPHA),
+            borderColor: withAlpha(colors.borderSubtle, 0.95),
             height: SELECTOR_HEIGHT,
+            overflow: "hidden",
             ...FLOATING_SURFACE_STYLE,
-          }}
+          },
+          selectorStyle,
+        ]}
+      >
+        <Animated.View
+          className="absolute inset-y-0 right-0"
+          pointerEvents={isOpen ? "none" : "auto"}
+          accessibilityElementsHidden={isOpen}
+          importantForAccessibility={isOpen ? "no-hide-descendants" : "auto"}
+          style={[
+            {
+              width: COLLAPSED_WIDTH,
+            },
+            collapsedLayerStyle,
+          ]}
+        >
+          <TouchableOpacity
+            className="h-full w-full flex-row items-center justify-center px-4"
+            onPress={open}
+            accessibilityLabel={`Riding horizon ${selectedLabel}`}
+            accessibilityRole="button"
+            accessibilityState={{ expanded: false }}
+            activeOpacity={0.75}
+          >
+            <Text className="font-barlow-sc-semibold text-[15px]" style={{ color: colors.accent }}>
+              {selectedLabel}
+            </Text>
+          </TouchableOpacity>
+        </Animated.View>
+
+        <Animated.View
+          className="absolute inset-y-0 right-0 flex-row items-center"
+          pointerEvents={isOpen ? "auto" : "none"}
+          accessibilityElementsHidden={!isOpen}
+          importantForAccessibility={isOpen ? "auto" : "no-hide-descendants"}
+          style={[
+            {
+              width: expandedWidth,
+              padding: 2,
+              gap: 4,
+            },
+            expandedLayerStyle,
+          ]}
         >
           {PANEL_MODES.map((mode) => {
             const isActive = mode === panelMode;
@@ -93,6 +157,7 @@ export default function RidingHorizonSelector() {
                   height: 44,
                   backgroundColor: isActive ? colors.accent : "transparent",
                 }}
+                activeOpacity={0.78}
               >
                 <Text
                   className="font-barlow-sc-semibold text-[13px]"
@@ -105,26 +170,8 @@ export default function RidingHorizonSelector() {
               </TouchableOpacity>
             );
           })}
-        </View>
-      ) : (
-        <TouchableOpacity
-          className="self-end flex-row items-center justify-center rounded-full border border-border px-4"
-          style={{
-            height: SELECTOR_HEIGHT,
-            minWidth: 88,
-            backgroundColor: colors.surfaceRaised,
-            ...FLOATING_SURFACE_STYLE,
-          }}
-          onPress={open}
-          accessibilityLabel={`Riding horizon ${selectedLabel}`}
-          accessibilityRole="button"
-          accessibilityState={{ expanded: false }}
-        >
-          <Text className="font-barlow-sc-semibold text-[15px]" style={{ color: colors.accent }}>
-            {selectedLabel}
-          </Text>
-        </TouchableOpacity>
-      )}
+        </Animated.View>
+      </Animated.View>
     </View>
   );
 }

--- a/components/map/RidingHorizonSelector.tsx
+++ b/components/map/RidingHorizonSelector.tsx
@@ -1,62 +1,94 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, TouchableOpacity } from "react-native";
 import { Text } from "@/components/ui/text";
 import { usePanelStore } from "@/store/panelStore";
 import { useThemeColors } from "@/theme";
 import { PANEL_MODES } from "@/constants";
+import { ChevronDown } from "lucide-react-native";
 import { ridingHorizonKmLabelForMode } from "@/utils/ridingHorizon";
 
-export const RIDING_HORIZON_SELECTOR_HEIGHT = 56;
+const SELECTOR_HEIGHT = 48;
+const SHEET_GAP = 8;
 
 export default function RidingHorizonSelector() {
   const colors = useThemeColors();
   const panelMode = usePanelStore((s) => s.panelMode);
   const setPanelMode = usePanelStore((s) => s.setPanelMode);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const selectedKm = ridingHorizonKmLabelForMode(panelMode);
 
   return (
     <View
-      className="flex-row items-center px-3"
+      className="absolute right-3"
       style={{
-        height: RIDING_HORIZON_SELECTOR_HEIGHT,
-        borderBottomWidth: 1,
-        borderBottomColor: colors.borderSubtle,
+        top: -SELECTOR_HEIGHT - SHEET_GAP,
+        left: isOpen ? 12 : undefined,
+        zIndex: 20,
       }}
     >
-      <Text className="text-[12px] font-barlow-semibold text-muted-foreground mr-2">Horizon</Text>
-      <View
-        className="flex-1 flex-row items-center rounded-full"
-        style={{ backgroundColor: colors.surfaceRaised, padding: 2, gap: 4 }}
-      >
-        {PANEL_MODES.map((mode) => {
-          const isActive = mode === panelMode;
-          const km = ridingHorizonKmLabelForMode(mode);
-          return (
-            <TouchableOpacity
-              key={mode}
-              onPress={() => setPanelMode(mode)}
-              hitSlop={{ left: 2, right: 2 }}
-              accessibilityLabel={`Set riding horizon to ${km} km`}
-              accessibilityRole="button"
-              accessibilityState={{ selected: isActive }}
-              className="flex-1 rounded-full items-center justify-center"
-              style={{
-                minWidth: 44,
-                height: 48,
-                backgroundColor: isActive ? colors.accent : "transparent",
-              }}
-            >
-              <Text
-                className="font-barlow-sc-semibold text-[13px]"
+      {isOpen ? (
+        <View
+          className="flex-row items-center rounded-full border border-border"
+          style={{
+            backgroundColor: colors.surfaceRaised,
+            padding: 2,
+            gap: 4,
+            height: SELECTOR_HEIGHT,
+          }}
+        >
+          {PANEL_MODES.map((mode) => {
+            const isActive = mode === panelMode;
+            const km = ridingHorizonKmLabelForMode(mode);
+            return (
+              <TouchableOpacity
+                key={mode}
+                onPress={() => {
+                  setPanelMode(mode);
+                  setIsOpen(false);
+                }}
+                hitSlop={{ left: 2, right: 2 }}
+                accessibilityLabel={`Set riding horizon to ${km} km`}
+                accessibilityRole="button"
+                accessibilityState={{ selected: isActive }}
+                className="flex-1 rounded-full items-center justify-center"
                 style={{
-                  color: isActive ? colors.accentForeground : colors.textSecondary,
+                  minWidth: 44,
+                  height: 44,
+                  backgroundColor: isActive ? colors.accent : "transparent",
                 }}
               >
-                {km}
-              </Text>
-            </TouchableOpacity>
-          );
-        })}
-      </View>
+                <Text
+                  className="font-barlow-sc-semibold text-[13px]"
+                  style={{
+                    color: isActive ? colors.accentForeground : colors.textSecondary,
+                  }}
+                >
+                  {km}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      ) : (
+        <TouchableOpacity
+          className="self-end flex-row items-center justify-center rounded-full border border-border px-4"
+          style={{
+            height: SELECTOR_HEIGHT,
+            minWidth: 92,
+            backgroundColor: colors.surfaceRaised,
+          }}
+          onPress={() => setIsOpen(true)}
+          accessibilityLabel={`Riding horizon ${selectedKm} km`}
+          accessibilityRole="button"
+          accessibilityState={{ expanded: false }}
+        >
+          <Text className="font-barlow-sc-semibold text-[15px]" style={{ color: colors.accent }}>
+            {selectedKm} km
+          </Text>
+          <ChevronDown size={16} color={colors.accent} style={{ marginLeft: 6 }} />
+        </TouchableOpacity>
+      )}
     </View>
   );
 }

--- a/components/map/TabbedBottomPanel.tsx
+++ b/components/map/TabbedBottomPanel.tsx
@@ -17,7 +17,7 @@ import ProfileTabContent from "./ProfileTabContent";
 import WeatherPanel from "./WeatherPanel";
 import ClimbTabContent from "./ClimbTabContent";
 import POITabContent from "./POITabContent";
-import RidingHorizonSelector from "./RidingHorizonSelector";
+import RidingHorizonSelector, { RIDING_HORIZON_SELECTOR_OFFSET } from "./RidingHorizonSelector";
 import type { ActiveRouteData, PanelTab } from "@/types";
 
 /** Combined handle + tabs height */
@@ -113,78 +113,84 @@ export default function TabbedBottomPanel({ activeData }: TabbedBottomPanelProps
 
   return (
     <Animated.View
-      className="absolute bottom-0 left-0 right-0 rounded-t-2xl shadow-lg border-t border-border"
-      style={[{ height: expandedHeight, backgroundColor: colors.surface }, animatedSheetStyle]}
+      pointerEvents="box-none"
+      className="absolute bottom-0 left-0 right-0"
+      style={[{ height: expandedHeight + RIDING_HORIZON_SELECTOR_OFFSET }, animatedSheetStyle]}
     >
-      {/* Handle + tabs — single compact gesture target */}
-      <GestureDetector gesture={panGesture}>
-        <Animated.View>
-          <View
-            className="px-2"
-            style={{
-              height: HEADER_HEIGHT,
-              borderBottomWidth: 1,
-              borderBottomColor: colors.borderSubtle,
-            }}
-          >
-            {/* Drag handle pill */}
-            <View className="items-center pt-1.5 pb-0.5">
-              <View
-                className="rounded-full"
-                style={{
-                  width: 32,
-                  height: 4,
-                  backgroundColor: colors.textTertiary,
-                  opacity: 0.5,
-                }}
-              />
-            </View>
-
-            {/* Tab buttons */}
-            <View className="flex-row flex-1 items-center">
-              {ALL_TABS.map((tab) => {
-                const isActive = panelTab === tab.key;
-                return (
-                  <TouchableOpacity
-                    key={tab.key}
-                    className="flex-1 items-center justify-center h-full"
-                    onPress={() => setPanelTab(tab.key)}
-                    accessibilityLabel={`${tab.label} tab`}
-                  >
-                    <Text
-                      className="text-[13px] font-barlow-semibold"
-                      style={{ color: isActive ? colors.accent : colors.textTertiary }}
-                    >
-                      {tab.label}
-                    </Text>
-                    {isActive && (
-                      <View
-                        className="absolute bottom-0 left-3 right-3 rounded-t-sm"
-                        style={{ height: 2, backgroundColor: colors.accent }}
-                      />
-                    )}
-                  </TouchableOpacity>
-                );
-              })}
-            </View>
-          </View>
-        </Animated.View>
-      </GestureDetector>
-
       <RidingHorizonSelector />
 
-      {/* Content — clips to available height */}
-      <View style={{ height: effectiveContentHeight, overflow: "hidden" }}>
-        {panelTab === "profile" && (
-          <ProfileTabContent
-            activeData={activeData}
-            width={screenWidth}
-            height={effectiveContentHeight}
-          />
-        )}
-        {panelTab === "weather" && <WeatherPanel />}
-        {panelTab === "climbs" && <ClimbTabContent activeData={activeData} />}
-        {panelTab === "pois" && <POITabContent activeData={activeData} />}
+      <View
+        className="absolute bottom-0 left-0 right-0 rounded-t-2xl shadow-lg border-t border-border"
+        style={{ height: expandedHeight, backgroundColor: colors.surface }}
+      >
+        {/* Handle + tabs — single compact gesture target */}
+        <GestureDetector gesture={panGesture}>
+          <Animated.View>
+            <View
+              className="px-2"
+              style={{
+                height: HEADER_HEIGHT,
+                borderBottomWidth: 1,
+                borderBottomColor: colors.borderSubtle,
+              }}
+            >
+              {/* Drag handle pill */}
+              <View className="items-center pt-1.5 pb-0.5">
+                <View
+                  className="rounded-full"
+                  style={{
+                    width: 32,
+                    height: 4,
+                    backgroundColor: colors.textTertiary,
+                    opacity: 0.5,
+                  }}
+                />
+              </View>
+
+              {/* Tab buttons */}
+              <View className="flex-row flex-1 items-center">
+                {ALL_TABS.map((tab) => {
+                  const isActive = panelTab === tab.key;
+                  return (
+                    <TouchableOpacity
+                      key={tab.key}
+                      className="flex-1 items-center justify-center h-full"
+                      onPress={() => setPanelTab(tab.key)}
+                      accessibilityLabel={`${tab.label} tab`}
+                    >
+                      <Text
+                        className="text-[13px] font-barlow-semibold"
+                        style={{ color: isActive ? colors.accent : colors.textTertiary }}
+                      >
+                        {tab.label}
+                      </Text>
+                      {isActive && (
+                        <View
+                          className="absolute bottom-0 left-3 right-3 rounded-t-sm"
+                          style={{ height: 2, backgroundColor: colors.accent }}
+                        />
+                      )}
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+            </View>
+          </Animated.View>
+        </GestureDetector>
+
+        {/* Content — clips to available height */}
+        <View style={{ height: effectiveContentHeight, overflow: "hidden" }}>
+          {panelTab === "profile" && (
+            <ProfileTabContent
+              activeData={activeData}
+              width={screenWidth}
+              height={effectiveContentHeight}
+            />
+          )}
+          {panelTab === "weather" && <WeatherPanel />}
+          {panelTab === "climbs" && <ClimbTabContent activeData={activeData} />}
+          {panelTab === "pois" && <POITabContent activeData={activeData} />}
+        </View>
       </View>
     </Animated.View>
   );

--- a/components/map/TabbedBottomPanel.tsx
+++ b/components/map/TabbedBottomPanel.tsx
@@ -17,7 +17,7 @@ import ProfileTabContent from "./ProfileTabContent";
 import WeatherPanel from "./WeatherPanel";
 import ClimbTabContent from "./ClimbTabContent";
 import POITabContent from "./POITabContent";
-import RidingHorizonSelector, { RIDING_HORIZON_SELECTOR_HEIGHT } from "./RidingHorizonSelector";
+import RidingHorizonSelector from "./RidingHorizonSelector";
 import type { ActiveRouteData, PanelTab } from "@/types";
 
 /** Combined handle + tabs height */
@@ -107,9 +107,8 @@ export default function TabbedBottomPanel({ activeData }: TabbedBottomPanelProps
   });
 
   const isExpanded = usePanelStore((s) => s.isExpanded);
-  const panelChromeHeight = HEADER_HEIGHT + RIDING_HORIZON_SELECTOR_HEIGHT;
-  const compactContentHeight = compactHeight - panelChromeHeight;
-  const expandedContentHeight = expandedHeight - panelChromeHeight;
+  const compactContentHeight = compactHeight - HEADER_HEIGHT;
+  const expandedContentHeight = expandedHeight - HEADER_HEIGHT;
   const effectiveContentHeight = isExpanded ? expandedContentHeight : compactContentHeight;
 
   return (

--- a/components/map/TabbedBottomPanel.tsx
+++ b/components/map/TabbedBottomPanel.tsx
@@ -17,6 +17,7 @@ import ProfileTabContent from "./ProfileTabContent";
 import WeatherPanel from "./WeatherPanel";
 import ClimbTabContent from "./ClimbTabContent";
 import POITabContent from "./POITabContent";
+import RidingHorizonSelector, { RIDING_HORIZON_SELECTOR_HEIGHT } from "./RidingHorizonSelector";
 import type { ActiveRouteData, PanelTab } from "@/types";
 
 /** Combined handle + tabs height */
@@ -106,8 +107,9 @@ export default function TabbedBottomPanel({ activeData }: TabbedBottomPanelProps
   });
 
   const isExpanded = usePanelStore((s) => s.isExpanded);
-  const compactContentHeight = compactHeight - HEADER_HEIGHT;
-  const expandedContentHeight = expandedHeight - HEADER_HEIGHT;
+  const panelChromeHeight = HEADER_HEIGHT + RIDING_HORIZON_SELECTOR_HEIGHT;
+  const compactContentHeight = compactHeight - panelChromeHeight;
+  const expandedContentHeight = expandedHeight - panelChromeHeight;
   const effectiveContentHeight = isExpanded ? expandedContentHeight : compactContentHeight;
 
   return (
@@ -169,6 +171,8 @@ export default function TabbedBottomPanel({ activeData }: TabbedBottomPanelProps
           </View>
         </Animated.View>
       </GestureDetector>
+
+      <RidingHorizonSelector />
 
       {/* Content — clips to available height */}
       <View style={{ height: effectiveContentHeight, overflow: "hidden" }}>

--- a/components/map/WeatherPanel.tsx
+++ b/components/map/WeatherPanel.tsx
@@ -21,6 +21,7 @@ import { useThemeColors } from "@/theme";
 import { useWeatherStore } from "@/store/weatherStore";
 import { usePanelStore } from "@/store/panelStore";
 import { formatTimeAgo } from "@/utils/formatters";
+import { ridingHorizonMetersForMode } from "@/utils/ridingHorizon";
 import { getWeatherInfo } from "@/utils/weatherCodes";
 import { classifyWind } from "@/services/weatherService";
 import type { WeatherPoint, WindRelative } from "@/types";
@@ -202,8 +203,14 @@ export default function WeatherPanel() {
   const fetchedAt = useWeatherStore((s) => s.fetchedAt);
   const fetchStatus = useWeatherStore((s) => s.fetchStatus);
   const isExpanded = usePanelStore((s) => s.isExpanded);
+  const panelMode = usePanelStore((s) => s.panelMode);
+  const ridingHorizonMeters = ridingHorizonMetersForMode(panelMode);
+  const horizonTimeline = useMemo(
+    () => timeline.filter((point) => point.distanceAlongRouteM <= ridingHorizonMeters),
+    [timeline, ridingHorizonMeters],
+  );
 
-  const current = timeline.length > 0 ? timeline[0] : null;
+  const current = horizonTimeline.length > 0 ? horizonTimeline[0] : null;
 
   if (fetchStatus === "fetching") {
     return (
@@ -224,6 +231,17 @@ export default function WeatherPanel() {
         </Text>
         <Text className="text-[11px] text-muted-foreground mt-1">
           Weather requires internet connectivity
+        </Text>
+      </View>
+    );
+  }
+
+  if (horizonTimeline.length === 0) {
+    return (
+      <View className="items-center justify-center py-6">
+        <Wind size={24} color={colors.textTertiary} />
+        <Text className="text-[13px] text-muted-foreground font-barlow-medium mt-2">
+          No weather inside this horizon
         </Text>
       </View>
     );
@@ -270,7 +288,7 @@ export default function WeatherPanel() {
       )}
 
       {/* Hourly timeline — vertical rows */}
-      <TimelineList timeline={timeline.slice(1)} colors={colors} isExpanded={isExpanded} />
+      <TimelineList timeline={horizonTimeline.slice(1)} colors={colors} isExpanded={isExpanded} />
     </View>
   );
 }

--- a/components/map/WeatherPanel.tsx
+++ b/components/map/WeatherPanel.tsx
@@ -206,7 +206,10 @@ export default function WeatherPanel() {
   const panelMode = usePanelStore((s) => s.panelMode);
   const ridingHorizonMeters = ridingHorizonMetersForMode(panelMode);
   const horizonTimeline = useMemo(
-    () => timeline.filter((point) => point.distanceAlongRouteM <= ridingHorizonMeters),
+    () =>
+      ridingHorizonMeters == null
+        ? timeline
+        : timeline.filter((point) => point.distanceAlongRouteM <= ridingHorizonMeters),
     [timeline, ridingHorizonMeters],
   );
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -30,6 +30,7 @@ export const PANEL_MODES = [
   "upcoming-50",
   "upcoming-100",
   "upcoming-200",
+  "full-route",
 ] as const;
 
 // --- Phase 3: POI constants ---

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -48,8 +48,6 @@ export const POI_CATEGORIES: POICategoryMeta[] = [
 
 /** How far behind the rider a POI remains visible in the list */
 export const POI_BEHIND_THRESHOLD_M = 1000;
-/** Ordinary riding map view keeps POIs route-windowed to avoid rendering full collections. */
-export const POI_MAP_LOOKAHEAD_M = 100_000;
 
 export const DEFAULT_CORRIDOR_WIDTH_M = 1000;
 export const MAX_CORRIDOR_WIDTH_M = 10000;

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -250,7 +250,7 @@ border-t border-border
 px-3 pt-3
 ```
 
-The riding horizon selector floats above the bottom sheet and scopes all riding bottom-sheet content. Default state shows only the selected value (`50 km`); tapping it expands the full `10 / 25 / 50 / 100 / 200 km` range row.
+The riding horizon selector floats above the bottom sheet and scopes all riding bottom-sheet content. Default state shows only the selected value (`50 km` or `FULL`); tapping it animates open to the full `10 / 25 / 50 / 100 / 200 / FULL` range row.
 
 ```
 collapsed height: 48dp
@@ -365,7 +365,7 @@ The map takes 100% of the screen. Everything else floats.
 ### Phase 3: POI Search Along Route
 
 - **POI markers on map**: Small, category-colored icons limited to the active riding horizon. Tap to expand detail.
-- **POI list**: Bottom-sheet tab. Defaults to the active riding horizon and can explicitly switch to full-route planning. List items show: category icon + name + distance along route + ETA.
+- **POI list**: Bottom-sheet tab. Follows the active riding horizon; `FULL` is the planning mode for route-wide browsing. List items show: category icon + name + distance along route + ETA.
 - **Category filter**: Horizontal scrollable chip row at top of POI panel. Chips use `label` style, accent when selected.
 - **Quick summary on map**: Nearest POI of each critical category (water, food) shown as small floating tags near the route line.
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -250,13 +250,14 @@ border-t border-border
 px-3 pt-3
 ```
 
-The panel mode indicator (5km / 10km / 20km / remaining / full) is a tappable pill in the panel header:
+The riding horizon selector (`10 / 25 / 50 / 100 / 200 km`) sits below the tab header and scopes all riding bottom-sheet content:
 
 ```
-bg-accent/10 (accentSubtle)
-text-accent
+height: 56dp
+min touch target: 48dp
+active: bg-accent, text-accentForeground
+inactive: text-secondary
 rounded-full (pill)
-px-3 py-1
 font: label
 ```
 
@@ -325,10 +326,10 @@ bg-accent/10 text-accent rounded-full px-2 py-0.5 font-labelSmall
 
 The map takes 100% of the screen. Everything else floats.
 
-- **Floating controls**: top-right corner, vertically stacked (center-on-user, panel mode toggle)
-- **Bottom panel**: always visible, showing either elevation profile or weather. Tap buttons to switch; tap elevation button again to cycle distance
+- **Floating controls**: top-right corner, vertically stacked (center-on-user)
+- **Bottom panel**: always visible, with tabs for Profile, Weather, Climbs, and POIs plus the shared riding horizon selector
 - **No persistent HUD on map** — keep map clean. Data lives in the panel
-- **Panel closed state**: just the map + floating buttons + tab bar
+- **Panel closed state**: map + floating buttons + bottom sheet tabs/horizon
 - **Panel open state**: map compresses upward, panel takes bottom ~25% with route stats + elevation profile
 
 ### Route List Screen
@@ -361,8 +362,8 @@ The map takes 100% of the screen. Everything else floats.
 
 ### Phase 3: POI Search Along Route
 
-- **POI markers on map**: Small, category-colored icons. Tap to expand detail.
-- **POI list**: Slide-up bottom sheet (same treatment as elevation panel). List items show: category icon + name + distance along route + ETA.
+- **POI markers on map**: Small, category-colored icons limited to the active riding horizon. Tap to expand detail.
+- **POI list**: Bottom-sheet tab. Defaults to the active riding horizon and can explicitly switch to full-route planning. List items show: category icon + name + distance along route + ETA.
 - **Category filter**: Horizontal scrollable chip row at top of POI panel. Chips use `label` style, accent when selected.
 - **Quick summary on map**: Nearest POI of each critical category (water, food) shown as small floating tags near the route line.
 
@@ -374,7 +375,7 @@ The map takes 100% of the screen. Everything else floats.
 
 ### Phase 5: Weather
 
-- **Weather strip**: Horizontal timeline at top of bottom panel (above elevation profile when both are shown). Shows hourly icons + temp for next 6–12 hours at estimated route positions.
+- **Weather timeline**: Bottom-sheet tab scoped to the active riding horizon. Shows hourly rows with icon, temp, precipitation, and wind at estimated route positions.
 - **Wind indicator**: Directional arrow icon near current position on map, colored by intensity (green = light, yellow = moderate, red = strong). Arrow shows direction relative to route heading (headwind/tailwind/crosswind).
 - **Severe weather alert**: Full-width banner at top of screen in `warning` or `destructive` color. Persistent until dismissed. RNR `Alert` component.
 - **"Last updated" badge**: Small timestamp near weather data since it requires connectivity. Uses `text-tertiary` / `labelSmall`.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -250,10 +250,12 @@ border-t border-border
 px-3 pt-3
 ```
 
-The riding horizon selector (`10 / 25 / 50 / 100 / 200 km`) sits below the tab header and scopes all riding bottom-sheet content:
+The riding horizon selector floats above the bottom sheet and scopes all riding bottom-sheet content. Default state shows only the selected value (`50 km`); tapping it expands the full `10 / 25 / 50 / 100 / 200 km` range row.
 
 ```
-height: 56dp
+collapsed height: 48dp
+expanded row height: 48dp
+position: just above sheet top edge; right aligned when collapsed, full width when expanded
 min touch target: 48dp
 active: bg-accent, text-accentForeground
 inactive: text-secondary
@@ -327,9 +329,9 @@ bg-accent/10 text-accent rounded-full px-2 py-0.5 font-labelSmall
 The map takes 100% of the screen. Everything else floats.
 
 - **Floating controls**: top-right corner, vertically stacked (center-on-user)
-- **Bottom panel**: always visible, with tabs for Profile, Weather, Climbs, and POIs plus the shared riding horizon selector
+- **Bottom panel**: always visible, with tabs for Profile, Weather, Climbs, and POIs; the shared riding horizon selector floats just above it
 - **No persistent HUD on map** — keep map clean. Data lives in the panel
-- **Panel closed state**: map + floating buttons + bottom sheet tabs/horizon
+- **Panel closed state**: map + floating buttons + bottom sheet tabs + collapsed horizon chip
 - **Panel open state**: map compresses upward, panel takes bottom ~25% with route stats + elevation profile
 
 ### Route List Screen

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,7 +8,8 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - On-demand GPS — position refreshes on app focus (if stale >10 min) or manual tap, no background polling
 - Position age indicator when stale
 - Heading-up / north-up toggle
-- Floating map controls (center-on-user, panel mode)
+- Floating map controls (center-on-user)
+- Global riding horizon selector: 10km / 25km / 50km / 100km / 200km
 
 ## Routes
 
@@ -30,7 +31,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Interactive chart with gradient color coding (green through red by steepness)
 - Current position marker
 - Pinch-to-zoom, tap to highlight on map
-- Bottom panel modes: 10km / 25km / 50km / 100km / 200km upcoming
+- Elevation profile follows the global riding horizon
 - Segment boundary markers for stitched collections
 
 ## Climb Detection
@@ -39,6 +40,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Smoothing, dip absorption, qualification (50m+ gain, 2.5%+ avg gradient)
 - Difficulty scoring (Climbbybike method — gradient squared times length)
 - Upcoming climbs list with distance, ETA, stats
+- Climb tab defaults to climbs inside the selected riding horizon
 - Current climb mode — auto-zooms elevation chart, shows progress to top
 - Climb shading on elevation profile (colored by difficulty)
 
@@ -48,7 +50,9 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Categories: water, groceries, gas stations, bakery, toilets/showers, shelter
 - Two data sources: Overpass/OSM for most categories, Google Places for gas stations and groceries (better opening hours)
 - POI markers on map and elevation profile
-- POI list sortable by distance along route
+- Riding view POI markers and lists are scoped to the selected riding horizon by default
+- Expanded POI list can explicitly switch to full-route planning
+- POI list sorted by distance along route
 - POI text search (filter by name)
 - Starred POIs
 - Saved custom POIs from iOS share sheet or manual coordinates, route-scoped and starred by default
@@ -67,7 +71,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 
 - Current weather at position
 - Forecast at waypoints along route (~50km spacing)
-- Weather timeline — conditions at estimated future positions (uses ETA calculator)
+- Weather timeline — conditions at estimated future positions within the selected riding horizon (uses ETA calculator)
 - Wind indicator: headwind/tailwind/crosswind relative to route direction
 - Cached when online, shows "last updated" timestamp
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Position age indicator when stale
 - Heading-up / north-up toggle
 - Floating map controls (center-on-user)
-- Global riding horizon selector: 10km / 25km / 50km / 100km / 200km
+- Global riding horizon selector: 10km / 25km / 50km / 100km / 200km / FULL
 
 ## Routes
 
@@ -51,7 +51,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Two data sources: Overpass/OSM for most categories, Google Places for gas stations and groceries (better opening hours)
 - POI markers on map and elevation profile
 - Riding view POI markers and lists are scoped to the selected riding horizon by default
-- Expanded POI list can explicitly switch to full-route planning
+- FULL horizon switches riding POI views to full-route planning
 - POI list sorted by distance along route
 - POI text search (filter by name)
 - Starred POIs

--- a/services/stitchingService.ts
+++ b/services/stitchingService.ts
@@ -1,26 +1,11 @@
 import { getRouteWithPoints, getCollectionSegments } from "@/db/database";
 import { toDisplayPOI } from "@/services/displayDistance";
+import { isDistanceInWindow, type DistanceWindow } from "@/utils/ridingHorizon";
 import type { StitchedCollection, StitchedSegmentInfo, RoutePoint, POI, DisplayPOI } from "@/types";
 
 interface StitchCollectionOptions {
   /** Keep raw per-segment point arrays in the returned view model. */
   includePointsByRouteId?: boolean;
-}
-
-interface DistanceWindow {
-  startDistanceMeters?: number;
-  endDistanceMeters?: number;
-}
-
-function isInDistanceWindow(distanceMeters: number, window?: DistanceWindow): boolean {
-  if (!window) return true;
-  if (window.startDistanceMeters != null && distanceMeters < window.startDistanceMeters) {
-    return false;
-  }
-  if (window.endDistanceMeters != null && distanceMeters > window.endDistanceMeters) {
-    return false;
-  }
-  return true;
 }
 
 export async function stitchCollection(
@@ -103,7 +88,7 @@ export function stitchPOIs(
 
     for (const poi of pois) {
       const effectiveDistanceMeters = poi.distanceAlongRouteMeters + seg.distanceOffsetMeters;
-      if (!isInDistanceWindow(effectiveDistanceMeters, window)) continue;
+      if (!isDistanceInWindow(effectiveDistanceMeters, window)) continue;
       combined.push(toDisplayPOI(poi, seg.distanceOffsetMeters));
     }
   }

--- a/tests/utils/ridingHorizon.test.ts
+++ b/tests/utils/ridingHorizon.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRidingHorizonWindow,
+  filterClimbsToRidingHorizon,
+  isDistanceInWindow,
+  ridingHorizonKmLabelForMode,
+  ridingHorizonMetersForMode,
+} from "@/utils/ridingHorizon";
+import { toDisplayClimb } from "@/services/displayDistance";
+import type { Climb, PanelMode } from "@/types";
+
+const climb = (id: string, startDistanceMeters: number, endDistanceMeters: number): Climb => ({
+  id,
+  routeId: "route-1",
+  name: id,
+  startDistanceMeters,
+  endDistanceMeters,
+  lengthMeters: endDistanceMeters - startDistanceMeters,
+  totalAscentMeters: 100,
+  startElevationMeters: 200,
+  endElevationMeters: 300,
+  averageGradientPercent: 5,
+  maxGradientPercent: 9,
+  difficultyScore: 120,
+});
+
+describe("ridingHorizon", () => {
+  it("maps panel modes to finite riding horizons", () => {
+    const modes: PanelMode[] = [
+      "upcoming-10",
+      "upcoming-25",
+      "upcoming-50",
+      "upcoming-100",
+      "upcoming-200",
+    ];
+
+    expect(modes.map(ridingHorizonMetersForMode)).toEqual([
+      10_000, 25_000, 50_000, 100_000, 200_000,
+    ]);
+    expect(modes.map(ridingHorizonKmLabelForMode)).toEqual(["10", "25", "50", "100", "200"]);
+  });
+
+  it("anchors the horizon at snapped progress and preserves the behind buffer", () => {
+    const window = createRidingHorizonWindow(12_000, 50_000, {
+      behindMeters: 1_000,
+      totalDistanceMeters: 55_000,
+    });
+
+    expect(window).toEqual({ startDistanceMeters: 11_000, endDistanceMeters: 55_000 });
+    expect(isDistanceInWindow(10_999, window)).toBe(false);
+    expect(isDistanceInWindow(11_000, window)).toBe(true);
+    expect(isDistanceInWindow(55_000, window)).toBe(true);
+    expect(isDistanceInWindow(55_001, window)).toBe(false);
+  });
+
+  it("falls back to a route-start horizon when the rider is not snapped", () => {
+    expect(createRidingHorizonWindow(null, 25_000, { totalDistanceMeters: 80_000 })).toEqual({
+      startDistanceMeters: 0,
+      endDistanceMeters: 25_000,
+    });
+  });
+
+  it("keeps climbs that overlap the horizon and drops distant climbs", () => {
+    const window = createRidingHorizonWindow(10_000, 20_000);
+    const climbs = [
+      toDisplayClimb(climb("past", 8_000, 9_000)),
+      toDisplayClimb(climb("current", 9_500, 10_500)),
+      toDisplayClimb(climb("ahead", 29_000, 31_000)),
+      toDisplayClimb(climb("far", 31_001, 33_000)),
+    ];
+
+    expect(filterClimbsToRidingHorizon(climbs, window).map((item) => item.id)).toEqual([
+      "current",
+      "ahead",
+    ]);
+  });
+});

--- a/tests/utils/ridingHorizon.test.ts
+++ b/tests/utils/ridingHorizon.test.ts
@@ -4,7 +4,9 @@ import {
   filterClimbsToRidingHorizon,
   isDistanceInWindow,
   ridingHorizonKmLabelForMode,
+  ridingHorizonLabelForMode,
   ridingHorizonMetersForMode,
+  ridingHorizonScopeLabelForMode,
 } from "@/utils/ridingHorizon";
 import { toDisplayClimb } from "@/services/displayDistance";
 import type { Climb, PanelMode } from "@/types";
@@ -25,19 +27,34 @@ const climb = (id: string, startDistanceMeters: number, endDistanceMeters: numbe
 });
 
 describe("ridingHorizon", () => {
-  it("maps panel modes to finite riding horizons", () => {
+  it("maps panel modes to riding horizons", () => {
     const modes: PanelMode[] = [
       "upcoming-10",
       "upcoming-25",
       "upcoming-50",
       "upcoming-100",
       "upcoming-200",
+      "full-route",
     ];
 
     expect(modes.map(ridingHorizonMetersForMode)).toEqual([
-      10_000, 25_000, 50_000, 100_000, 200_000,
+      10_000,
+      25_000,
+      50_000,
+      100_000,
+      200_000,
+      null,
     ]);
-    expect(modes.map(ridingHorizonKmLabelForMode)).toEqual(["10", "25", "50", "100", "200"]);
+    expect(modes.map(ridingHorizonKmLabelForMode)).toEqual([
+      "10",
+      "25",
+      "50",
+      "100",
+      "200",
+      "FULL",
+    ]);
+    expect(ridingHorizonLabelForMode("full-route")).toBe("FULL");
+    expect(ridingHorizonScopeLabelForMode("full-route")).toBe("the full route");
   });
 
   it("anchors the horizon at snapped progress and preserves the behind buffer", () => {
@@ -58,6 +75,11 @@ describe("ridingHorizon", () => {
       startDistanceMeters: 0,
       endDistanceMeters: 25_000,
     });
+  });
+
+  it("returns no distance window for full-route mode", () => {
+    expect(createRidingHorizonWindow(12_000, null, { behindMeters: 1_000 })).toBeUndefined();
+    expect(isDistanceInWindow(500_000, undefined)).toBe(true);
   });
 
   it("keeps climbs that overlap the horizon and drops distant climbs", () => {

--- a/types/index.ts
+++ b/types/index.ts
@@ -110,7 +110,8 @@ export type PanelMode =
   | "upcoming-25"
   | "upcoming-50"
   | "upcoming-100"
-  | "upcoming-200";
+  | "upcoming-200"
+  | "full-route";
 
 export type PanelTab = "profile" | "weather" | "climbs" | "pois";
 

--- a/utils/ridingHorizon.ts
+++ b/utils/ridingHorizon.ts
@@ -5,7 +5,7 @@ export interface DistanceWindow {
   endDistanceMeters?: number;
 }
 
-export function ridingHorizonMetersForMode(mode: PanelMode): number {
+export function ridingHorizonMetersForMode(mode: PanelMode): number | null {
   switch (mode) {
     case "upcoming-10":
       return 10_000;
@@ -17,21 +17,36 @@ export function ridingHorizonMetersForMode(mode: PanelMode): number {
       return 100_000;
     case "upcoming-200":
       return 200_000;
+    case "full-route":
+      return null;
   }
 }
 
 export function ridingHorizonKmLabelForMode(mode: PanelMode): string {
-  return String(ridingHorizonMetersForMode(mode) / 1_000);
+  const meters = ridingHorizonMetersForMode(mode);
+  return meters == null ? "FULL" : String(meters / 1_000);
+}
+
+export function ridingHorizonLabelForMode(mode: PanelMode): string {
+  const meters = ridingHorizonMetersForMode(mode);
+  return meters == null ? "FULL" : `${meters / 1_000} km`;
+}
+
+export function ridingHorizonScopeLabelForMode(mode: PanelMode): string {
+  const meters = ridingHorizonMetersForMode(mode);
+  return meters == null ? "the full route" : `the next ${meters / 1_000} km`;
 }
 
 export function createRidingHorizonWindow(
   currentDistanceMeters: number | null,
-  horizonMeters: number,
+  horizonMeters: number | null,
   options: {
     behindMeters?: number;
     totalDistanceMeters?: number;
   } = {},
-): DistanceWindow {
+): DistanceWindow | undefined {
+  if (horizonMeters == null) return undefined;
+
   const anchor = Math.max(0, currentDistanceMeters ?? 0);
   const startDistanceMeters = Math.max(0, anchor - (options.behindMeters ?? 0));
   const rawEndDistanceMeters = anchor + horizonMeters;

--- a/utils/ridingHorizon.ts
+++ b/utils/ridingHorizon.ts
@@ -1,0 +1,83 @@
+import type { DisplayClimb, PanelMode } from "@/types";
+
+export interface DistanceWindow {
+  startDistanceMeters?: number;
+  endDistanceMeters?: number;
+}
+
+export function ridingHorizonMetersForMode(mode: PanelMode): number {
+  switch (mode) {
+    case "upcoming-10":
+      return 10_000;
+    case "upcoming-25":
+      return 25_000;
+    case "upcoming-50":
+      return 50_000;
+    case "upcoming-100":
+      return 100_000;
+    case "upcoming-200":
+      return 200_000;
+  }
+}
+
+export function ridingHorizonKmLabelForMode(mode: PanelMode): string {
+  return String(ridingHorizonMetersForMode(mode) / 1_000);
+}
+
+export function createRidingHorizonWindow(
+  currentDistanceMeters: number | null,
+  horizonMeters: number,
+  options: {
+    behindMeters?: number;
+    totalDistanceMeters?: number;
+  } = {},
+): DistanceWindow {
+  const anchor = Math.max(0, currentDistanceMeters ?? 0);
+  const startDistanceMeters = Math.max(0, anchor - (options.behindMeters ?? 0));
+  const rawEndDistanceMeters = anchor + horizonMeters;
+  const endDistanceMeters =
+    options.totalDistanceMeters != null
+      ? Math.min(options.totalDistanceMeters, rawEndDistanceMeters)
+      : rawEndDistanceMeters;
+
+  return { startDistanceMeters, endDistanceMeters };
+}
+
+export function isDistanceInWindow(distanceMeters: number, window?: DistanceWindow): boolean {
+  if (!window) return true;
+  if (window.startDistanceMeters != null && distanceMeters < window.startDistanceMeters) {
+    return false;
+  }
+  if (window.endDistanceMeters != null && distanceMeters > window.endDistanceMeters) {
+    return false;
+  }
+  return true;
+}
+
+export function isDistanceRangeInWindow(
+  startDistanceMeters: number,
+  endDistanceMeters: number,
+  window?: DistanceWindow,
+): boolean {
+  if (!window) return true;
+  if (window.startDistanceMeters != null && endDistanceMeters < window.startDistanceMeters) {
+    return false;
+  }
+  if (window.endDistanceMeters != null && startDistanceMeters > window.endDistanceMeters) {
+    return false;
+  }
+  return true;
+}
+
+export function filterClimbsToRidingHorizon(
+  climbs: DisplayClimb[],
+  window?: DistanceWindow,
+): DisplayClimb[] {
+  return climbs.filter((climb) =>
+    isDistanceRangeInWindow(
+      climb.effectiveStartDistanceMeters,
+      climb.effectiveEndDistanceMeters,
+      window,
+    ),
+  );
+}


### PR DESCRIPTION
## Summary

- Move the riding range selector out of Profile into shared bottom-sheet chrome.
- Make the selector a collapsed value chip that animates open to the full horizon row, without a chevron.
- Add a global `FULL` horizon option and apply the selected horizon to Profile, Climbs, Weather, POI list defaults, and POI map markers.
- Remove the POI-specific full-route toggle so full-route browsing uses the global horizon selector.
- Centralize riding-horizon distance-window helpers and cover them with unit tests.

Fixes #12

## Verification

- `npm run format:check`
- `npx --cache /private/tmp/codex-npm-cache tsc --noEmit`
- `npm test`
- `npm run lint`
- Commit hook also ran `oxfmt`, `oxlint --fix`, and `tsc --noEmit`.

## Notes

- I attempted `./scripts/smoke-test.sh`; it only captured the simulator home screen because the app was not launched/available in the booted simulator, so no in-app AXe screenshot verification was completed.