### PR TITLE
[codex] Backport configurable POI discovery

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,13 +1,14 @@
 import React, { useState, useMemo, useCallback } from "react";
 import { View, TouchableOpacity, ScrollView, TextInput } from "react-native";
 import { Text } from "@/components/ui/text";
-import { ChevronDown, ChevronUp } from "lucide-react-native";
+import { Check, ChevronDown, ChevronUp } from "lucide-react-native";
 import { cn } from "@/lib/cn";
 import { useThemeColors } from "@/theme";
 import { useSettingsStore } from "@/store/settingsStore";
 import { useEtaStore } from "@/store/etaStore";
 import { usePoiStore } from "@/store/poiStore";
 import { solveVelocity } from "@/services/powerModel";
+import { POI_DISCOVERY_GROUPS } from "@/constants";
 import type { UnitSystem } from "@/types";
 import StorageSection from "@/components/offline/StorageSection";
 
@@ -102,6 +103,43 @@ function NumericInput({
   );
 }
 
+function DiscoveryGroupRow({
+  label,
+  detail,
+  enabled,
+  onPress,
+}: {
+  label: string;
+  detail: string;
+  enabled: boolean;
+  onPress: () => void;
+}) {
+  const colors = useThemeColors();
+
+  return (
+    <TouchableOpacity
+      className="min-h-[64px] flex-row items-center py-3"
+      onPress={onPress}
+      accessibilityRole="switch"
+      accessibilityState={{ checked: enabled }}
+      accessibilityLabel={`${enabled ? "Disable" : "Enable"} ${label} POI discovery`}
+    >
+      <View
+        className={cn(
+          "w-[28px] h-[28px] rounded-full items-center justify-center border",
+          enabled ? "bg-primary border-primary" : "bg-transparent border-border",
+        )}
+      >
+        {enabled && <Check size={16} color={colors.accentForeground} />}
+      </View>
+      <View className="flex-1 ml-3">
+        <Text className="text-[15px] font-barlow-semibold text-foreground">{label}</Text>
+        <Text className="text-[12px] font-barlow text-muted-foreground mt-0.5">{detail}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
 export default function SettingsScreen() {
   const { units, setUnits } = useSettingsStore();
   const colors = useThemeColors();
@@ -109,7 +147,19 @@ export default function SettingsScreen() {
   const updatePowerConfig = useEtaStore((s) => s.updatePowerConfig);
   const corridorWidthM = usePoiStore((s) => s.corridorWidthM);
   const setCorridorWidth = usePoiStore((s) => s.setCorridorWidth);
+  const discoveryCategories = usePoiStore((s) => s.discoveryCategories);
+  const setDiscoveryGroupEnabled = usePoiStore((s) => s.setDiscoveryGroupEnabled);
+  const resetDiscoveryCategories = usePoiStore((s) => s.resetDiscoveryCategories);
   const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const discoverySet = useMemo(() => new Set(discoveryCategories), [discoveryCategories]);
+  const enabledDiscoveryGroupCount = useMemo(
+    () =>
+      POI_DISCOVERY_GROUPS.filter((group) =>
+        group.categories.every((category) => discoverySet.has(category)),
+      ).length,
+    [discoverySet],
+  );
 
   const flatSpeedKmh = useMemo(() => {
     const v = solveVelocity(0, powerConfig);
@@ -129,6 +179,38 @@ export default function SettingsScreen() {
         value={String(corridorWidthM)}
         onChange={(v) => setCorridorWidth(Number(v))}
       />
+
+      <View className="flex-row items-end justify-between mt-6 mb-3">
+        <View>
+          <Text className="text-[22px] font-barlow-semibold text-foreground">POI Discovery</Text>
+          <Text className="text-[12px] text-muted-foreground font-barlow mt-0.5">
+            {enabledDiscoveryGroupCount}/{POI_DISCOVERY_GROUPS.length} groups enabled
+          </Text>
+        </View>
+        <TouchableOpacity
+          className="min-h-[48px] px-3 items-center justify-center"
+          onPress={resetDiscoveryCategories}
+          accessibilityLabel="Reset POI discovery defaults"
+        >
+          <Text className="text-[14px] font-barlow-semibold text-primary">Reset</Text>
+        </TouchableOpacity>
+      </View>
+      <View className="bg-card rounded-xl px-4">
+        {POI_DISCOVERY_GROUPS.map((group, index) => {
+          const enabled = group.categories.every((category) => discoverySet.has(category));
+          return (
+            <React.Fragment key={group.key}>
+              {index > 0 && <View className="border-b border-border" />}
+              <DiscoveryGroupRow
+                label={group.label}
+                detail={group.detail}
+                enabled={enabled}
+                onPress={() => setDiscoveryGroupEnabled(group.categories, !enabled)}
+              />
+            </React.Fragment>
+          );
+        })}
+      </View>
 
       <Text className="text-[22px] font-barlow-semibold text-foreground mt-8 mb-1">
         ETA Calculator

--- a/components/map/POIFilterBar.tsx
+++ b/components/map/POIFilterBar.tsx
@@ -13,6 +13,48 @@ interface POIFilterBarProps {
   routeIds: string[];
 }
 
+const CATEGORY_GROUPS: Array<{
+  label: string;
+  categories: POICategory[];
+  iconCategory: POICategory;
+}> = [
+  { label: "Water", categories: ["water", "cemetery"], iconCategory: "water" },
+  {
+    label: "Food",
+    categories: ["groceries", "gas_station", "bakery"],
+    iconCategory: "groceries",
+  },
+  {
+    label: "Eat",
+    categories: ["coffee", "restaurant", "bar_pub"],
+    iconCategory: "coffee",
+  },
+  {
+    label: "Rest",
+    categories: ["shelter", "bus_stop", "camp_site", "sports", "school"],
+    iconCategory: "shelter",
+  },
+  { label: "WC", categories: ["toilet_shower"], iconCategory: "toilet_shower" },
+  {
+    label: "Help",
+    categories: [
+      "pharmacy",
+      "hospital_er",
+      "defibrillator",
+      "emergency_phone",
+      "ambulance_station",
+    ],
+    iconCategory: "pharmacy",
+  },
+  {
+    label: "Repair",
+    categories: ["bike_shop", "repair_station", "pump_air"],
+    iconCategory: "bike_shop",
+  },
+  { label: "Escape", categories: ["train_station"], iconCategory: "train_station" },
+  { label: "Other", categories: ["other"], iconCategory: "other" },
+];
+
 /** Inline horizontal filter chip row — meant to be embedded in panels/lists, not floating on the map */
 export default function POIFilterBar({ routeIds }: POIFilterBarProps) {
   const colors = useThemeColors();
@@ -26,11 +68,13 @@ export default function POIFilterBar({ routeIds }: POIFilterBarProps) {
     return combined.length > 0 ? combined : undefined;
   }, [routeIds, allPois]);
   const enabledCategories = usePoiStore((s) => s.enabledCategories);
-  const toggleCategory = usePoiStore((s) => s.toggleCategory);
+  const setEnabledCategories = usePoiStore((s) => s.setEnabledCategories);
+  const setAllCategories = usePoiStore((s) => s.setAllCategories);
   const showOpenOnly = usePoiStore((s) => s.showOpenOnly);
   const toggleShowOpenOnly = usePoiStore((s) => s.toggleShowOpenOnly);
 
   const enabledSet = useMemo(() => new Set(enabledCategories), [enabledCategories]);
+  const isCategoryFilterActive = enabledCategories.length < POI_CATEGORIES.length;
 
   const categoryCounts = useMemo(() => {
     if (!pois) return {};
@@ -42,6 +86,30 @@ export default function POIFilterBar({ routeIds }: POIFilterBarProps) {
   }, [pois]);
 
   if (!pois || pois.length === 0) return null;
+
+  const handleToggleGroup = (categories: POICategory[]) => {
+    if (!isCategoryFilterActive) {
+      setEnabledCategories(categories);
+      return;
+    }
+
+    const isGroupActive = categories.some((category) => enabledSet.has(category));
+    if (isGroupActive) {
+      const target = new Set(categories);
+      const next = enabledCategories.filter((category) => !target.has(category));
+      if (next.length === 0) setAllCategories(true);
+      else setEnabledCategories(next);
+      return;
+    }
+
+    setEnabledCategories([...new Set([...enabledCategories, ...categories])]);
+  };
+
+  const getGroupAccessibilityLabel = (label: string, isActive: boolean) => {
+    if (!isCategoryFilterActive) return `Show ${label} POIs`;
+    if (isActive) return `Clear ${label} filter`;
+    return `Add ${label} filter`;
+  };
 
   return (
     <ScrollView
@@ -69,29 +137,36 @@ export default function POIFilterBar({ routeIds }: POIFilterBarProps) {
         </Text>
       </TouchableOpacity>
 
-      {POI_CATEGORIES.map((cat) => {
-        const isEnabled = enabledSet.has(cat.key);
-        const count = categoryCounts[cat.key] ?? 0;
-        const IconComp = POI_ICON_MAP[cat.iconName];
+      {CATEGORY_GROUPS.map((group) => {
+        const isEnabled =
+          isCategoryFilterActive && group.categories.some((category) => enabledSet.has(category));
+        const count = group.categories.reduce(
+          (sum, category) => sum + (categoryCounts[category] ?? 0),
+          0,
+        );
+        const meta = POI_CATEGORIES.find((cat) => cat.key === group.iconCategory);
+        const IconComp = meta ? POI_ICON_MAP[meta.iconName] : null;
 
         return (
           <TouchableOpacity
-            key={cat.key}
+            key={group.label}
             className={cn(
               "flex-row items-center px-3 min-h-[48px] rounded-full",
               isEnabled ? "bg-muted border border-border" : "border border-transparent",
             )}
-            onPress={() => toggleCategory(cat.key)}
-            accessibilityLabel={`${isEnabled ? "Hide" : "Show"} ${cat.label}`}
+            onPress={() => handleToggleGroup(group.categories)}
+            accessibilityLabel={getGroupAccessibilityLabel(group.label, isEnabled)}
           >
-            {IconComp && <IconComp size={13} color={isEnabled ? cat.color : colors.textTertiary} />}
+            {IconComp && (
+              <IconComp size={13} color={isEnabled && meta ? meta.color : colors.textTertiary} />
+            )}
             <Text
               className={cn(
                 "ml-1 text-[12px] font-barlow-medium",
                 isEnabled ? "text-foreground" : "text-muted-foreground",
               )}
             >
-              {cat.label}
+              {group.label}
             </Text>
             {count > 0 && (
               <Text

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -47,12 +47,15 @@ import POIFilterBar from "@/components/map/POIFilterBar";
 import POIListItem from "@/components/poi/POIListItem";
 import AddSavedPOISheet from "@/components/poi/AddSavedPOISheet";
 import type { ActiveRouteData, DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
+import { getPOINotes, isGoogleDerivedPOI, type SavedPOITarget } from "@/services/savedPOIService";
 import {
-  getGoogleMapsUrlForPOI,
-  getPOINotes,
-  isGoogleDerivedPOI,
-  type SavedPOITarget,
-} from "@/services/savedPOIService";
+  buildPhoneUrl,
+  getPoiAddress,
+  getPoiExtraDetailFields,
+  getPoiMapUrl,
+  getPoiPhone,
+  getPoiWebsiteUrl,
+} from "@/utils/poiActions";
 
 interface POITabContentProps {
   activeData: ActiveRouteData | null;
@@ -604,21 +607,13 @@ function InlinePOIDetail({
     return isOpenAt(openingHoursRaw, etaResult.eta);
   }, [etaResult, openingHoursRaw]);
 
-  const address = useMemo(() => {
-    const t = poi.tags;
-    if (t.formatted_address) return t.formatted_address;
-    const parts: string[] = [];
-    if (t["addr:street"]) {
-      const num = t["addr:housenumber"] ? ` ${t["addr:housenumber"]}` : "";
-      parts.push(`${t["addr:street"]}${num}`);
-    }
-    if (t["addr:city"]) parts.push(t["addr:city"]);
-    return parts.length > 0 ? parts.join(", ") : null;
-  }, [poi]);
-
-  const phone = poi.tags?.phone ?? poi.tags?.["contact:phone"] ?? null;
+  const address = useMemo(() => getPoiAddress(poi), [poi]);
+  const phone = useMemo(() => getPoiPhone(poi), [poi]);
+  const phoneUrl = useMemo(() => (phone ? buildPhoneUrl(phone) : null), [phone]);
+  const websiteUrl = useMemo(() => getPoiWebsiteUrl(poi), [poi]);
+  const extraDetailFields = useMemo(() => getPoiExtraDetailFields(poi), [poi]);
   const notes = getPOINotes(poi);
-  const googleMapsUrl = useMemo(() => getGoogleMapsUrlForPOI(poi), [poi]);
+  const mapUrl = useMemo(() => getPoiMapUrl(poi), [poi]);
 
   const handleEditNotes = useCallback(() => {
     Alert.prompt(
@@ -651,12 +646,25 @@ function InlinePOIDetail({
     ]);
   }, [deleteCustomPOI, poi.id, poi.routeId]);
 
-  const handleOpenGoogleMaps = useCallback(() => {
-    if (!googleMapsUrl) return;
-    Linking.openURL(googleMapsUrl).catch(() => {
-      Alert.alert("Open Failed", "Could not open Google Maps.");
+  const handleOpenMaps = useCallback(() => {
+    Linking.openURL(mapUrl).catch(() => {
+      Alert.alert("Open Failed", "Could not open this POI in Maps.");
     });
-  }, [googleMapsUrl]);
+  }, [mapUrl]);
+
+  const handleCallPhone = useCallback(() => {
+    if (!phoneUrl) return;
+    Linking.openURL(phoneUrl).catch(() => {
+      Alert.alert("Call Failed", "Could not start a call for this POI.");
+    });
+  }, [phoneUrl]);
+
+  const handleOpenWebsite = useCallback(() => {
+    if (!websiteUrl) return;
+    Linking.openURL(websiteUrl).catch(() => {
+      Alert.alert("Open Failed", "Could not open this POI website.");
+    });
+  }, [websiteUrl]);
 
   return (
     <ScrollView className="flex-1 px-3 pt-1">
@@ -768,12 +776,45 @@ function InlinePOIDetail({
         </View>
       )}
 
-      {phone && (
+      {phone && !phoneUrl && (
         <View className="flex-row items-center mt-2">
           <Phone size={13} color={colors.textSecondary} />
           <Text className="ml-1.5 text-[13px] text-muted-foreground font-barlow">{phone}</Text>
         </View>
       )}
+
+      {phone && phoneUrl && (
+        <TouchableOpacity
+          className="flex-row items-center min-h-[48px] mt-1"
+          onPress={handleCallPhone}
+          accessibilityLabel={`Call ${phone}`}
+        >
+          <Phone size={13} color={colors.textSecondary} />
+          <Text className="ml-1.5 text-[13px] text-primary font-barlow-semibold">{phone}</Text>
+        </TouchableOpacity>
+      )}
+
+      {websiteUrl && (
+        <TouchableOpacity
+          className="flex-row items-center min-h-[48px] mt-1"
+          onPress={handleOpenWebsite}
+          accessibilityLabel="Open POI website"
+        >
+          <ExternalLink size={14} color={colors.accent} />
+          <Text className="ml-2 text-[14px] font-barlow-medium text-primary">Website</Text>
+        </TouchableOpacity>
+      )}
+
+      {extraDetailFields.map((field) => (
+        <View key={`${field.label}:${field.value}`} className="mt-2 flex-row">
+          <Text className="w-[84px] text-[12px] font-barlow-semibold text-muted-foreground">
+            {field.label}
+          </Text>
+          <Text className="flex-1 text-[12px] font-barlow-medium text-foreground">
+            {field.value}
+          </Text>
+        </View>
+      ))}
 
       {notes ? (
         <View className="mt-3">
@@ -782,18 +823,14 @@ function InlinePOIDetail({
         </View>
       ) : null}
 
-      {googleMapsUrl && (
-        <TouchableOpacity
-          className="flex-row items-center min-h-[48px] mt-2"
-          onPress={handleOpenGoogleMaps}
-          accessibilityLabel="Open in Google Maps"
-        >
-          <ExternalLink size={14} color={colors.accent} />
-          <Text className="ml-2 text-[14px] font-barlow-medium text-primary">
-            Open in Google Maps
-          </Text>
-        </TouchableOpacity>
-      )}
+      <TouchableOpacity
+        className="flex-row items-center min-h-[48px] mt-2"
+        onPress={handleOpenMaps}
+        accessibilityLabel="Open in Maps"
+      >
+        <ExternalLink size={14} color={colors.accent} />
+        <Text className="ml-2 text-[14px] font-barlow-medium text-primary">Open in Maps</Text>
+      </TouchableOpacity>
 
       {poi.source === "custom" && (
         <View className="mt-1">

--- a/components/route/DataSection.tsx
+++ b/components/route/DataSection.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { View, Alert } from "react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import type { POIFetchedSource, RoutePoint } from "@/types";
+import { poiDiscoveryCategoriesForSource } from "@/constants";
 import { usePoiStore, DEFAULT_SOURCE_INFO, type SourceInfo } from "@/store/poiStore";
 import { useOfflineStore } from "@/store/offlineStore";
 import { formatFileSize } from "@/utils/formatters";
@@ -42,12 +43,21 @@ export default function DataSection({ routeId, points }: DataSectionProps) {
   // POI state — subscribe to raw state so Zustand re-renders on changes
   const osmInfo = usePoiStore((s) => s.sourceInfo[routeId]?.osm) ?? DEFAULT_SOURCE_INFO;
   const googleInfo = usePoiStore((s) => s.sourceInfo[routeId]?.google) ?? DEFAULT_SOURCE_INFO;
+  const discoveryCategories = usePoiStore((s) => s.discoveryCategories);
   const fetchSource = usePoiStore((s) => s.fetchSource);
   const clearSource = usePoiStore((s) => s.clearSource);
+  const googleDiscoveryEnabled = useMemo(
+    () => poiDiscoveryCategoriesForSource(discoveryCategories, "google").length > 0,
+    [discoveryCategories],
+  );
+  const osmDiscoveryEnabled = useMemo(
+    () => poiDiscoveryCategoriesForSource(discoveryCategories, "osm").length > 0,
+    [discoveryCategories],
+  );
   const osmFetching = osmInfo.status === "fetching";
   const googleFetching = googleInfo.status === "fetching";
-  const osmReady = isSourceReady(osmInfo);
-  const googleReady = isSourceReady(googleInfo);
+  const osmReady = !osmDiscoveryEnabled || isSourceReady(osmInfo);
+  const googleReady = !googleDiscoveryEnabled || isSourceReady(googleInfo);
   const routeOfflineReady = tilesReady && osmReady && googleReady;
   const hasBusySource = osmFetching || googleFetching;
   const prepBusy = isPreparingOffline || tilesDownloading || hasBusySource;
@@ -93,8 +103,8 @@ export default function DataSection({ routeId, points }: DataSectionProps) {
           </Text>
           <Text className="text-[13px] text-muted-foreground font-barlow mt-1">
             {routeOfflineReady
-              ? "Map tiles, Google Places, and OpenStreetMap ready"
-              : "Map tiles + missing Google Places and OpenStreetMap"}
+              ? "Map tiles and enabled POI sources ready"
+              : "Map tiles + missing enabled POI sources"}
           </Text>
         </View>
         <Button
@@ -162,6 +172,7 @@ export default function DataSection({ routeId, points }: DataSectionProps) {
         onFetch={() => fetchSource(routeId, "google", points)}
         onDelete={() => handleDeleteSource("google", "Google Places data")}
         isConnected={isConnected}
+        discoveryEnabled={googleDiscoveryEnabled}
       />
 
       {/* OSM / Overpass */}
@@ -171,6 +182,7 @@ export default function DataSection({ routeId, points }: DataSectionProps) {
         onFetch={() => fetchSource(routeId, "osm", points)}
         onDelete={() => handleDeleteSource("osm", "OSM data")}
         isConnected={isConnected}
+        discoveryEnabled={osmDiscoveryEnabled}
       />
     </View>
   );
@@ -221,12 +233,14 @@ function SourceRow({
   onFetch,
   onDelete,
   isConnected,
+  discoveryEnabled,
 }: {
   title: string;
   info: SourceInfo;
   onFetch: () => void;
   onDelete: () => void;
   isConnected: boolean;
+  discoveryEnabled: boolean;
 }) {
   const isFetching = info.status === "fetching";
   const hasData = isSourceReady(info);
@@ -243,7 +257,9 @@ function SourceRow({
               : "Fetching..."
             : hasData
               ? `${info.count} POIs`
-              : "Not fetched"
+              : discoveryEnabled
+                ? "Not fetched"
+                : "Disabled in settings"
         }
         timestamp={info.fetchedAt ? formatDate(info.fetchedAt) : null}
         error={info.status === "error" ? info.error : null}
@@ -253,7 +269,7 @@ function SourceRow({
           <Button
             size="sm"
             variant={hasData ? "secondary" : "default"}
-            disabled={isFetching || !isConnected}
+            disabled={isFetching || !isConnected || !discoveryEnabled}
             onPress={onFetch}
             label={isFetching ? "Fetching..." : hasData ? "Refresh" : "Fetch"}
           />

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -35,17 +35,221 @@ export const PANEL_MODES = [
 
 // --- Phase 3: POI constants ---
 
-import type { POICategoryMeta } from "@/types";
+import type {
+  POICategory,
+  POICategoryMeta,
+  POIDiscoveryGroupMeta,
+  POIDiscoverySource,
+} from "@/types";
 
 export const POI_CATEGORIES: POICategoryMeta[] = [
-  { key: "water", label: "Water", color: "#3B82F6", iconName: "Droplets" },
-  { key: "groceries", label: "Groceries", color: "#22C55E", iconName: "ShoppingCart" },
-  { key: "gas_station", label: "Gas Station", color: "#F97316", iconName: "Fuel" },
-  { key: "bakery", label: "Bakery", color: "#EAB308", iconName: "Croissant" },
-  { key: "toilet_shower", label: "WC", color: "#6366F1", iconName: "ShowerHead" },
-  { key: "shelter", label: "Shelter", color: "#8B5CF6", iconName: "Tent" },
-  { key: "other", label: "Other", color: "#64748B", iconName: "MapPin" },
+  { key: "water", label: "Water", group: "water", color: "#3B82F6", iconName: "Droplets" },
+  {
+    key: "groceries",
+    label: "Groceries",
+    group: "food",
+    color: "#22C55E",
+    iconName: "ShoppingCart",
+  },
+  { key: "gas_station", label: "Gas Station", group: "food", color: "#F97316", iconName: "Fuel" },
+  { key: "bakery", label: "Bakery", group: "food", color: "#EAB308", iconName: "Croissant" },
+  { key: "coffee", label: "Coffee", group: "eat_drink", color: "#A16207", iconName: "Coffee" },
+  {
+    key: "restaurant",
+    label: "Restaurant",
+    group: "eat_drink",
+    color: "#F59E0B",
+    iconName: "Utensils",
+  },
+  { key: "bar_pub", label: "Bar / Pub", group: "eat_drink", color: "#D97706", iconName: "Beer" },
+  { key: "toilet_shower", label: "WC", group: "wc", color: "#6366F1", iconName: "Toilet" },
+  { key: "shelter", label: "Shelter", group: "rest", color: "#8B5CF6", iconName: "Tent" },
+  { key: "bus_stop", label: "Bus Shelter", group: "rest", color: "#0EA5E9", iconName: "Bus" },
+  { key: "camp_site", label: "Camp Site", group: "rest", color: "#7C3AED", iconName: "Tent" },
+  { key: "pharmacy", label: "Pharmacy", group: "help", color: "#10B981", iconName: "Pill" },
+  {
+    key: "hospital_er",
+    label: "Hospital / ER",
+    group: "help",
+    color: "#DC2626",
+    iconName: "Hospital",
+  },
+  {
+    key: "defibrillator",
+    label: "Defibrillator",
+    group: "help",
+    color: "#EF4444",
+    iconName: "HeartPulse",
+  },
+  {
+    key: "emergency_phone",
+    label: "Emergency Phone",
+    group: "help",
+    color: "#7C2D12",
+    iconName: "Phone",
+  },
+  {
+    key: "ambulance_station",
+    label: "Ambulance",
+    group: "help",
+    color: "#B91C1C",
+    iconName: "Ambulance",
+  },
+  { key: "bike_shop", label: "Bike Shop", group: "repair", color: "#2563EB", iconName: "Bike" },
+  {
+    key: "repair_station",
+    label: "Repair Station",
+    group: "repair",
+    color: "#0F766E",
+    iconName: "Wrench",
+  },
+  {
+    key: "pump_air",
+    label: "Pump / Air",
+    group: "repair",
+    color: "#0891B2",
+    iconName: "CircleDot",
+  },
+  {
+    key: "train_station",
+    label: "Train Station",
+    group: "escape",
+    color: "#475569",
+    iconName: "TrainFront",
+  },
+  { key: "sports", label: "Sports", group: "other", color: "#84CC16", iconName: "Dumbbell" },
+  { key: "cemetery", label: "Cemetery", group: "other", color: "#64748B", iconName: "Landmark" },
+  { key: "school", label: "School", group: "other", color: "#14B8A6", iconName: "School" },
+  { key: "other", label: "Other", group: "other", color: "#64748B", iconName: "MapPin" },
 ];
+
+export const POI_DISCOVERY_GROUPS: POIDiscoveryGroupMeta[] = [
+  {
+    key: "water_wc",
+    label: "Water + WC",
+    detail: "Drinking water, springs, taps, toilets, and showers from OSM.",
+    categories: ["water", "toilet_shower"],
+    defaultEnabled: true,
+  },
+  {
+    key: "food_supplies",
+    label: "Food Supplies",
+    detail: "Groceries, gas stations, and bakeries from Google Places.",
+    categories: ["groceries", "gas_station", "bakery"],
+    defaultEnabled: true,
+  },
+  {
+    key: "bike_shops",
+    label: "Bike Shops",
+    detail: "Commercial bike shops from Google Places.",
+    categories: ["bike_shop"],
+    defaultEnabled: true,
+  },
+  {
+    key: "repair_infrastructure",
+    label: "Repair Infrastructure",
+    detail: "Public repair stands and air pumps from OSM.",
+    categories: ["repair_station", "pump_air"],
+    defaultEnabled: true,
+  },
+  {
+    key: "basic_rest",
+    label: "Shelter",
+    detail: "Shelters and huts from OSM.",
+    categories: ["shelter"],
+    defaultEnabled: true,
+  },
+  {
+    key: "eat_drink",
+    label: "Eat + Drink",
+    detail: "Cafes, restaurants, bars, and pubs from Google Places.",
+    categories: ["coffee", "restaurant", "bar_pub"],
+    defaultEnabled: false,
+  },
+  {
+    key: "pharmacy",
+    label: "Pharmacy",
+    detail: "Pharmacies from Google Places.",
+    categories: ["pharmacy"],
+    defaultEnabled: false,
+  },
+  {
+    key: "rough_sleep",
+    label: "Rough Sleep",
+    detail: "Bus shelters and camp sites from OSM.",
+    categories: ["bus_stop", "camp_site"],
+    defaultEnabled: false,
+  },
+  {
+    key: "emergency",
+    label: "Emergency",
+    detail: "Hospitals, defibrillators, emergency phones, and ambulance stations from OSM.",
+    categories: ["hospital_er", "defibrillator", "emergency_phone", "ambulance_station"],
+    defaultEnabled: false,
+  },
+  {
+    key: "escape",
+    label: "Escape / Transport",
+    detail: "Train stations from OSM.",
+    categories: ["train_station"],
+    defaultEnabled: false,
+  },
+  {
+    key: "opportunistic_rest",
+    label: "Opportunistic Rest",
+    detail: "Sports grounds, cemeteries, and schools from OSM.",
+    categories: ["sports", "cemetery", "school"],
+    defaultEnabled: false,
+  },
+];
+
+export const DEFAULT_POI_DISCOVERY_CATEGORIES: POICategory[] = POI_DISCOVERY_GROUPS.flatMap(
+  (group) => (group.defaultEnabled ? group.categories : []),
+);
+
+export const GOOGLE_POI_DISCOVERY_CATEGORIES: POICategory[] = [
+  "groceries",
+  "gas_station",
+  "bakery",
+  "coffee",
+  "restaurant",
+  "bar_pub",
+  "pharmacy",
+  "bike_shop",
+];
+
+export const OSM_POI_DISCOVERY_CATEGORIES: POICategory[] = [
+  "water",
+  "toilet_shower",
+  "shelter",
+  "bus_stop",
+  "camp_site",
+  "hospital_er",
+  "defibrillator",
+  "emergency_phone",
+  "ambulance_station",
+  "repair_station",
+  "pump_air",
+  "train_station",
+  "sports",
+  "cemetery",
+  "school",
+];
+
+export function normalizePoiCategories(categories: POICategory[]): POICategory[] {
+  const valid = new Set<string>(POI_CATEGORIES.map((category) => category.key));
+  return Array.from(new Set(categories)).filter((category) => valid.has(category)) as POICategory[];
+}
+
+export function poiDiscoveryCategoriesForSource(
+  categories: POICategory[],
+  source: POIDiscoverySource,
+): POICategory[] {
+  const sourceCategories =
+    source === "google" ? GOOGLE_POI_DISCOVERY_CATEGORIES : OSM_POI_DISCOVERY_CATEGORIES;
+  const requested = new Set(categories);
+  return sourceCategories.filter((category) => requested.has(category));
+}
 
 /** How far behind the rider a POI remains visible in the list */
 export const POI_BEHIND_THRESHOLD_M = 1000;
@@ -53,6 +257,45 @@ export const POI_BEHIND_THRESHOLD_M = 1000;
 export const DEFAULT_CORRIDOR_WIDTH_M = 1000;
 export const MAX_CORRIDOR_WIDTH_M = 10000;
 export const MIN_CORRIDOR_WIDTH_M = 500;
+
+export const DEFAULT_POI_CATEGORY_CORRIDOR_WIDTH_M: Record<POICategory, number> = {
+  water: 1000,
+  groceries: 1000,
+  gas_station: 1500,
+  bakery: 1000,
+  coffee: 1000,
+  restaurant: 1500,
+  bar_pub: 1500,
+  toilet_shower: 1000,
+  shelter: 300,
+  bus_stop: 30,
+  camp_site: 5000,
+  pharmacy: 3000,
+  hospital_er: 10000,
+  defibrillator: 1000,
+  emergency_phone: 1000,
+  ambulance_station: 5000,
+  bike_shop: 5000,
+  repair_station: 500,
+  pump_air: 500,
+  train_station: 10000,
+  sports: 1000,
+  cemetery: 1000,
+  school: 1000,
+  other: DEFAULT_CORRIDOR_WIDTH_M,
+};
+
+export function getPoiCategoryCorridorWidthM(
+  category: POICategory,
+  fallbackWidthM = DEFAULT_CORRIDOR_WIDTH_M,
+): number {
+  return DEFAULT_POI_CATEGORY_CORRIDOR_WIDTH_M[category] ?? fallbackWidthM;
+}
+
+export function getMaxPoiCorridorWidthM(fallbackWidthM = DEFAULT_CORRIDOR_WIDTH_M): number {
+  return Math.max(fallbackWidthM, ...Object.values(DEFAULT_POI_CATEGORY_CORRIDOR_WIDTH_M));
+}
+
 export const OVERPASS_API_URLS = [
   "https://overpass-api.de/api/interpreter",
   "https://overpass.kumi.systems/api/interpreter",

--- a/constants/poiIcons.ts
+++ b/constants/poiIcons.ts
@@ -1,20 +1,59 @@
 import {
+  Ambulance,
+  Beer,
+  Bike,
+  Bus,
+  CircleDot,
+  Coffee,
   Droplets,
-  ShoppingCart,
-  Fuel,
   Croissant,
-  ShowerHead,
-  Tent,
+  Dumbbell,
+  Fuel,
+  HeartPulse,
+  Hospital,
+  Landmark,
   MapPin,
+  Phone,
+  Pill,
+  School,
+  ShoppingCart,
+  Tent,
+  Toilet,
+  TrainFront,
+  Utensils,
+  Wrench,
 } from "lucide-react-native";
+import type { ComponentType } from "react";
+
+type POIIconComponent = ComponentType<{
+  color?: string;
+  size?: number;
+  strokeWidth?: number;
+}>;
 
 /** Shared icon map for POI categories, keyed by POICategoryMeta.iconName */
-export const POI_ICON_MAP: Record<string, React.ComponentType<any>> = {
+export const POI_ICON_MAP: Record<string, POIIconComponent> = {
+  Ambulance,
+  Beer,
+  Bike,
+  Bus,
+  CircleDot,
+  Coffee,
   Droplets,
-  ShoppingCart,
-  Fuel,
   Croissant,
-  ShowerHead,
-  Tent,
+  Dumbbell,
+  Fuel,
+  HeartPulse,
+  Hospital,
+  Landmark,
   MapPin,
+  Phone,
+  Pill,
+  School,
+  ShoppingCart,
+  Tent,
+  Toilet,
+  TrainFront,
+  Utensils,
+  Wrench,
 };

--- a/services/googlePlacesClient.ts
+++ b/services/googlePlacesClient.ts
@@ -1,6 +1,10 @@
+import Constants from "expo-constants";
 import type { RoutePoint, POICategory } from "@/types";
+import { GOOGLE_POI_DISCOVERY_CATEGORIES } from "@/constants";
 import { downsampleRoutePointsByDistance, splitRoutePointsByDistance } from "@/utils/geo";
 import type { ClassifiedPOI } from "./poiClassifier";
+
+const BUNDLE_ID = Constants.expoConfig?.ios?.bundleIdentifier ?? "";
 
 // --- Google Places API response types ---
 
@@ -101,9 +105,28 @@ export function inferPOICategoryFromGoogleTypes(types: string[]): POICategory {
     return "groceries";
   }
   if (t.has("bakery")) return "bakery";
+  if (t.has("cafe") || t.has("coffee_shop")) return "coffee";
+  if (
+    t.has("restaurant") ||
+    t.has("meal_takeaway") ||
+    t.has("fast_food_restaurant") ||
+    t.has("pizza_restaurant")
+  ) {
+    return "restaurant";
+  }
+  if (t.has("bar") || t.has("pub") || t.has("wine_bar")) return "bar_pub";
   if (t.has("drinking_water")) return "water";
   if (t.has("public_bathroom") || t.has("restroom")) return "toilet_shower";
-  if (t.has("lodging") || t.has("campground") || t.has("rv_park")) return "shelter";
+  if (t.has("campground") || t.has("rv_park")) return "camp_site";
+  if (t.has("lodging")) return "shelter";
+  if (t.has("pharmacy") || t.has("drugstore")) return "pharmacy";
+  if (t.has("hospital") || t.has("emergency_room")) return "hospital_er";
+  if (t.has("bicycle_store")) return "bike_shop";
+  if (t.has("train_station") || t.has("transit_station") || t.has("subway_station")) {
+    return "train_station";
+  }
+  if (t.has("school")) return "school";
+  if (t.has("athletic_field") || t.has("fitness_center") || t.has("gym")) return "sports";
   return "other";
 }
 
@@ -140,7 +163,21 @@ const SEARCHES: { textQuery: string; includedType?: string; category: POICategor
   { textQuery: "gas station", includedType: "gas_station", category: "gas_station" },
   { textQuery: "grocery store", category: "groceries" },
   { textQuery: "bakery", category: "bakery" },
+  { textQuery: "cafe", includedType: "cafe", category: "coffee" },
+  { textQuery: "restaurant", includedType: "restaurant", category: "restaurant" },
+  { textQuery: "bar or pub", includedType: "bar", category: "bar_pub" },
+  { textQuery: "pharmacy", includedType: "pharmacy", category: "pharmacy" },
+  { textQuery: "bicycle shop", category: "bike_shop" },
 ];
+
+function googlePlacesHeaders(apiKey: string, fieldMask: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "X-Goog-Api-Key": apiKey,
+    "X-Goog-FieldMask": fieldMask,
+    ...(BUNDLE_ID ? { "X-Ios-Bundle-Identifier": BUNDLE_ID } : {}),
+  };
+}
 
 /** Fetch all pages of a Text Search Along Route query (max 60 results) */
 async function searchAlongRoute(
@@ -165,11 +202,7 @@ async function searchAlongRoute(
 
     const response = await fetch("https://places.googleapis.com/v1/places:searchText", {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Goog-Api-Key": apiKey,
-        "X-Goog-FieldMask": FIELD_MASK,
-      },
+      headers: googlePlacesHeaders(apiKey, FIELD_MASK),
       body: JSON.stringify(body),
     });
 
@@ -199,11 +232,7 @@ export async function fetchGooglePlaceDetails(
 ): Promise<GooglePlace> {
   const response = await fetch(`https://places.googleapis.com/v1/places/${placeId}`, {
     method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Goog-Api-Key": apiKey,
-      "X-Goog-FieldMask": DETAILS_FIELD_MASK,
-    },
+    headers: googlePlacesHeaders(apiKey, DETAILS_FIELD_MASK),
   });
 
   if (!response.ok) {
@@ -220,11 +249,7 @@ export async function fetchGooglePlaceTextSearch(
 ): Promise<GooglePlace | null> {
   const response = await fetch("https://places.googleapis.com/v1/places:searchText", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Goog-Api-Key": apiKey,
-      "X-Goog-FieldMask": FIELD_MASK,
-    },
+    headers: googlePlacesHeaders(apiKey, FIELD_MASK),
     body: JSON.stringify({ textQuery, pageSize: 1 }),
   });
 
@@ -254,14 +279,22 @@ function samePolylinePoint(
 export async function fetchGooglePlacesPOIs(
   routePoints: RoutePoint[],
   apiKey: string,
+  discoveryCategories: POICategory[] = GOOGLE_POI_DISCOVERY_CATEGORIES,
   onProgress?: (done: number, total: number) => void,
 ): Promise<ClassifiedPOI[]> {
+  const enabled = new Set(discoveryCategories);
+  const searches = SEARCHES.filter((search) => enabled.has(search.category));
+  if (searches.length === 0 || routePoints.length === 0) {
+    onProgress?.(0, 0);
+    return [];
+  }
+
   const segments = splitRoutePointsByDistance(routePoints, {
     maxSegmentLengthMeters: MAX_SEGMENT_M,
     balanceSegments: true,
     includeShortRoute: true,
   });
-  const totalSteps = segments.length * SEARCHES.length;
+  const totalSteps = segments.length * searches.length;
   let step = 0;
 
   const seen = new Set<string>();
@@ -279,7 +312,7 @@ export async function fetchGooglePlacesPOIs(
 
     // Run all search types in parallel within each segment
     const searchResults = await Promise.all(
-      SEARCHES.map((search) =>
+      searches.map((search) =>
         searchAlongRoute(search.textQuery, search.includedType, encodedPolyline, apiKey).then(
           (places) => ({ places, category: search.category }),
         ),
@@ -302,7 +335,7 @@ export async function fetchGooglePlacesPOIs(
       }
     }
 
-    step += SEARCHES.length;
+    step += searches.length;
   }
 
   onProgress?.(totalSteps, totalSteps);

--- a/services/overpassClient.ts
+++ b/services/overpassClient.ts
@@ -1,5 +1,11 @@
-import type { RoutePoint } from "@/types";
-import { OVERPASS_API_URLS, OVERPASS_SEGMENT_LENGTH_M, OVERPASS_RETRY_DELAYS } from "@/constants";
+import type { POICategory, RoutePoint } from "@/types";
+import {
+  OSM_POI_DISCOVERY_CATEGORIES,
+  getPoiCategoryCorridorWidthM,
+  OVERPASS_API_URLS,
+  OVERPASS_SEGMENT_LENGTH_M,
+  OVERPASS_RETRY_DELAYS,
+} from "@/constants";
 import { downsampleRoutePointsByDistance, splitRoutePointsByDistance } from "@/utils/geo";
 
 let _nextServerIndex = 0;
@@ -19,6 +25,7 @@ export interface OverpassElement {
   lat?: number;
   lon?: number;
   center?: { lat: number; lon: number };
+  geometry?: { lat: number; lon: number }[];
   tags?: Record<string, string>;
 }
 
@@ -43,23 +50,75 @@ function coordString(pts: { lat: number; lon: number }[]): string {
 export function buildOverpassQuery(
   points: { lat: number; lon: number }[],
   corridorWidthM: number,
-): string {
+  discoveryCategories: POICategory[] = OSM_POI_DISCOVERY_CATEGORIES,
+): string | null {
   const coords = coordString(points);
-  const r = corridorWidthM;
+  const enabled = new Set(discoveryCategories);
+  const q = (category: POICategory, selector: string) => {
+    if (!enabled.has(category)) return null;
+    const radius = getPoiCategoryCorridorWidthM(category, corridorWidthM);
+    return `  ${selector}(around:${radius},${coords});`;
+  };
 
-  // Each line queries one OSM tag pattern using the around filter
+  const clauses = [
+    q("water", 'node["amenity"="drinking_water"]'),
+    q("water", 'node["natural"="spring"]'),
+    q("water", 'node["man_made"="water_tap"]'),
+    q("toilet_shower", 'node["amenity"~"^(toilets|shower)$"]'),
+    q("shelter", 'node["amenity"="shelter"]["shelter_type"!="public_transport"]'),
+    q("shelter", 'way["amenity"="shelter"]["shelter_type"!="public_transport"]'),
+    q("bus_stop", 'node["amenity"="shelter"]["shelter_type"="public_transport"]'),
+    q("bus_stop", 'way["amenity"="shelter"]["shelter_type"="public_transport"]'),
+    q("shelter", 'node["tourism"="wilderness_hut"]'),
+    q("shelter", 'way["tourism"="wilderness_hut"]'),
+    q("shelter", 'node["tourism"="alpine_hut"]'),
+    q("shelter", 'way["tourism"="alpine_hut"]'),
+    q("bus_stop", 'node["highway"="bus_stop"]["shelter"="yes"]'),
+    q(
+      "bus_stop",
+      'node["public_transport"~"^(platform|stop_position)$"]["bus"="yes"]["shelter"="yes"]',
+    ),
+    q("camp_site", 'node["tourism"="camp_site"]'),
+    q("camp_site", 'way["tourism"="camp_site"]'),
+    q("pharmacy", 'node["amenity"="pharmacy"]'),
+    q("pharmacy", 'way["amenity"="pharmacy"]'),
+    q("pharmacy", 'node["healthcare"="pharmacy"]'),
+    q("pharmacy", 'way["healthcare"="pharmacy"]'),
+    q("hospital_er", 'node["amenity"="hospital"]'),
+    q("hospital_er", 'way["amenity"="hospital"]'),
+    q("hospital_er", 'node["healthcare"="hospital"]'),
+    q("hospital_er", 'way["healthcare"="hospital"]'),
+    q("defibrillator", 'node["emergency"="defibrillator"]'),
+    q("emergency_phone", 'node["emergency"="phone"]'),
+    q("ambulance_station", 'node["emergency"="ambulance_station"]'),
+    q("ambulance_station", 'way["emergency"="ambulance_station"]'),
+    q("bike_shop", 'node["shop"="bicycle"]'),
+    q("bike_shop", 'way["shop"="bicycle"]'),
+    q("repair_station", 'node["amenity"="bicycle_repair_station"]'),
+    q("pump_air", 'node["amenity"="compressed_air"]'),
+    q("pump_air", 'node["service:bicycle:pump"="yes"]'),
+    q("pump_air", 'way["service:bicycle:pump"="yes"]'),
+    q("train_station", 'node["railway"~"^(station|halt)$"]'),
+    q("train_station", 'way["railway"~"^(station|halt)$"]'),
+    q("train_station", 'node["public_transport"="station"]["train"="yes"]'),
+    q("train_station", 'way["public_transport"="station"]["train"="yes"]'),
+    q("sports", 'node["leisure"="pitch"]["sport"="soccer"]'),
+    q("sports", 'way["leisure"="pitch"]["sport"="soccer"]'),
+    q("sports", 'node["leisure"="sports_centre"]'),
+    q("sports", 'way["leisure"="sports_centre"]'),
+    q("cemetery", 'node["amenity"="grave_yard"]'),
+    q("cemetery", 'way["amenity"="grave_yard"]'),
+    q("cemetery", 'node["landuse"="cemetery"]'),
+    q("cemetery", 'way["landuse"="cemetery"]'),
+    q("school", 'node["amenity"="school"]'),
+    q("school", 'way["amenity"="school"]'),
+  ].filter((clause): clause is string => clause != null);
+
+  if (clauses.length === 0) return null;
+
   return `[out:json][timeout:30];
 (
-  node["amenity"="drinking_water"](around:${r},${coords});
-  node["natural"="spring"](around:${r},${coords});
-  node["man_made"="water_tap"](around:${r},${coords});
-  node["amenity"~"^(toilets|shower)$"](around:${r},${coords});
-  node["amenity"="shelter"]["shelter_type"!="public_transport"](around:${r},${coords});
-  way["amenity"="shelter"]["shelter_type"!="public_transport"](around:${r},${coords});
-  node["tourism"="wilderness_hut"](around:${r},${coords});
-  way["tourism"="wilderness_hut"](around:${r},${coords});
-  node["tourism"="alpine_hut"](around:${r},${coords});
-  way["tourism"="alpine_hut"](around:${r},${coords});
+${clauses.join("\n")}
 );
 out center body;`;
 }
@@ -136,13 +195,21 @@ function delay(ms: number): Promise<void> {
 export async function fetchAllPOIs(
   routePoints: RoutePoint[],
   corridorWidthM: number,
+  discoveryCategories: POICategory[] = OSM_POI_DISCOVERY_CATEGORIES,
   onProgress?: (done: number, total: number) => void,
 ): Promise<OverpassElement[]> {
+  if (routePoints.length === 0) return [];
+  if (discoveryCategories.length === 0) {
+    onProgress?.(0, 0);
+    return [];
+  }
+
   const segments = splitRoutePointsByDistance(routePoints, {
     maxSegmentLengthMeters: OVERPASS_SEGMENT_LENGTH_M,
+    includeShortRoute: true,
   });
   const allElements: OverpassElement[] = [];
-  const seen = new Set<number>(); // deduplicate by OSM id
+  const seen = new Set<string>(); // deduplicate by OSM type/id
 
   for (let i = 0; i < segments.length; i++) {
     onProgress?.(i, segments.length);
@@ -153,12 +220,14 @@ export async function fetchAllPOIs(
       mapPoint: (point) => ({ lat: point.latitude, lon: point.longitude }),
       isSameOutput: sameQueryPoint,
     });
-    const query = buildOverpassQuery(downsampled, corridorWidthM);
+    const query = buildOverpassQuery(downsampled, corridorWidthM, discoveryCategories);
+    if (!query) continue;
     const elements = await fetchOverpassSegment(query);
 
     for (const el of elements) {
-      if (!seen.has(el.id)) {
-        seen.add(el.id);
+      const key = `${el.type}/${el.id}`;
+      if (!seen.has(key)) {
+        seen.add(key);
         allElements.push(el);
       }
     }

--- a/services/poiClassifier.ts
+++ b/services/poiClassifier.ts
@@ -18,11 +18,99 @@ const TAG_RULES: {
     check: (t) => t.amenity === "toilets" || t.amenity === "shower",
   },
   {
+    category: "coffee",
+    check: (t) => t.amenity === "cafe",
+  },
+  {
+    category: "restaurant",
+    check: (t) => t.amenity === "restaurant",
+  },
+  {
+    category: "bar_pub",
+    check: (t) => t.amenity === "bar" || t.amenity === "pub",
+  },
+  {
+    category: "groceries",
+    check: (t) => ["supermarket", "convenience", "grocery"].includes(t.shop),
+  },
+  {
+    category: "bakery",
+    check: (t) => t.shop === "bakery",
+  },
+  {
+    category: "gas_station",
+    check: (t) => t.amenity === "fuel",
+  },
+  {
     category: "shelter",
     check: (t) =>
       (t.amenity === "shelter" && t.shelter_type !== "public_transport") ||
       t.tourism === "wilderness_hut" ||
       t.tourism === "alpine_hut",
+  },
+  {
+    category: "bus_stop",
+    check: (t) =>
+      (t.highway === "bus_stop" && t.shelter === "yes") ||
+      (t.amenity === "shelter" && t.shelter_type === "public_transport") ||
+      ((t.public_transport === "platform" || t.public_transport === "stop_position") &&
+        t.bus === "yes" &&
+        t.shelter === "yes"),
+  },
+  {
+    category: "camp_site",
+    check: (t) => t.tourism === "camp_site",
+  },
+  {
+    category: "pharmacy",
+    check: (t) => t.amenity === "pharmacy" || t.healthcare === "pharmacy",
+  },
+  {
+    category: "hospital_er",
+    check: (t) => t.amenity === "hospital" || t.healthcare === "hospital" || t.emergency === "yes",
+  },
+  {
+    category: "defibrillator",
+    check: (t) => t.emergency === "defibrillator",
+  },
+  {
+    category: "emergency_phone",
+    check: (t) => t.emergency === "phone",
+  },
+  {
+    category: "ambulance_station",
+    check: (t) => t.emergency === "ambulance_station",
+  },
+  {
+    category: "bike_shop",
+    check: (t) => t.shop === "bicycle",
+  },
+  {
+    category: "repair_station",
+    check: (t) => t.amenity === "bicycle_repair_station",
+  },
+  {
+    category: "pump_air",
+    check: (t) => t.amenity === "compressed_air" || t["service:bicycle:pump"] === "yes",
+  },
+  {
+    category: "train_station",
+    check: (t) =>
+      t.railway === "station" ||
+      t.railway === "halt" ||
+      (t.public_transport === "station" && t.train === "yes"),
+  },
+  {
+    category: "sports",
+    check: (t) => (t.leisure === "pitch" && t.sport === "soccer") || t.leisure === "sports_centre",
+  },
+  {
+    category: "cemetery",
+    check: (t) => t.amenity === "grave_yard" || t.landuse === "cemetery",
+  },
+  {
+    category: "school",
+    check: (t) => t.amenity === "school",
   },
 ];
 

--- a/services/poiFetcher.ts
+++ b/services/poiFetcher.ts
@@ -1,13 +1,18 @@
 import Constants from "expo-constants";
-import type { POI, POISource, RoutePoint } from "@/types";
+import type { POI, POICategory, POISource, RoutePoint } from "@/types";
 import { fetchAllPOIs } from "./overpassClient";
 import { mapOverpassToPOIs, type ClassifiedPOI } from "./poiClassifier";
 import { fetchGooglePlacesPOIs } from "./googlePlacesClient";
 import { buildRouteSegmentSpatialIndex, computePOIRouteAssociation } from "@/utils/geo";
 import { insertPOIs, deletePOIsBySource } from "@/db/database";
+import {
+  getMaxPoiCorridorWidthM,
+  getPoiCategoryCorridorWidthM,
+  poiDiscoveryCategoriesForSource,
+} from "@/constants";
 
 /** Associate classified POIs with route and filter by corridor */
-function associateAndFilter(
+export function associateAndFilter(
   classified: ClassifiedPOI[],
   routeId: string,
   routePoints: RoutePoint[],
@@ -15,10 +20,15 @@ function associateAndFilter(
   source: POISource,
 ): POI[] {
   const pois: POI[] = [];
-  const routeIndex = buildRouteSegmentSpatialIndex(routePoints, corridorWidthM);
+  const routeIndex = buildRouteSegmentSpatialIndex(
+    routePoints,
+    getMaxPoiCorridorWidthM(corridorWidthM),
+  );
   for (const c of classified) {
     const assoc = computePOIRouteAssociation(c.latitude, c.longitude, routePoints, routeIndex);
-    if (assoc.distanceFromRouteMeters > corridorWidthM) continue;
+    if (assoc.distanceFromRouteMeters > getPoiCategoryCorridorWidthM(c.category, corridorWidthM)) {
+      continue;
+    }
     pois.push({
       id: `${routeId}_${c.sourceId}`,
       sourceId: c.sourceId,
@@ -36,17 +46,24 @@ function associateAndFilter(
   return pois;
 }
 
-/** Fetch OSM POIs only (water, bike_shop, atm, pharmacy, toilet_shower, shelter) */
+/** Fetch OSM POIs only */
 export async function fetchOsmPOIs(
   routeId: string,
   routePoints: RoutePoint[],
   corridorWidthM: number,
   onProgress?: (phase: string, done: number, total: number) => void,
+  discoveryCategories?: POICategory[],
 ): Promise<number> {
-  const elements = await fetchAllPOIs(routePoints, corridorWidthM, (done, total) => {
+  const categories = discoveryCategories
+    ? poiDiscoveryCategoriesForSource(discoveryCategories, "osm")
+    : undefined;
+  const elements = await fetchAllPOIs(routePoints, corridorWidthM, categories, (done, total) => {
     onProgress?.("Fetching", done, total);
   });
-  const classified = mapOverpassToPOIs(elements);
+  const enabled = categories ? new Set(categories) : null;
+  const classified = mapOverpassToPOIs(elements).filter(
+    (poi) => !enabled || enabled.has(poi.category),
+  );
   onProgress?.("Processing", 0, 1);
   const pois = associateAndFilter(classified, routeId, routePoints, corridorWidthM, "osm");
   await deletePOIsBySource(routeId, "osm");
@@ -55,17 +72,21 @@ export async function fetchOsmPOIs(
   return pois.length;
 }
 
-/** Fetch Google Places POIs only (gas_station, groceries) */
+/** Fetch Google Places POIs only */
 export async function fetchGooglePOIs(
   routeId: string,
   routePoints: RoutePoint[],
   corridorWidthM: number,
   onProgress?: (phase: string, done: number, total: number) => void,
+  discoveryCategories?: POICategory[],
 ): Promise<number> {
   const apiKey = Constants.expoConfig?.extra?.googlePlacesApiKey as string | undefined;
   if (!apiKey) throw new Error("Google Places API key not configured");
 
-  const classified = await fetchGooglePlacesPOIs(routePoints, apiKey, (done, total) => {
+  const categories = discoveryCategories
+    ? poiDiscoveryCategoriesForSource(discoveryCategories, "google")
+    : undefined;
+  const classified = await fetchGooglePlacesPOIs(routePoints, apiKey, categories, (done, total) => {
     onProgress?.("Fetching", done, total);
   });
   onProgress?.("Processing", 0, 1);

--- a/store/offlineStore.ts
+++ b/store/offlineStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { createMMKV, type MMKV } from "react-native-mmkv";
 import { addNetworkStateListener, getNetworkStateAsync } from "expo-network";
 import type { OfflineRouteInfo, RoutePoint } from "@/types";
+import { poiDiscoveryCategoriesForSource } from "@/constants";
 import { getPOICountsBySource } from "@/db/database";
 import {
   downloadRouteTiles,
@@ -174,6 +175,9 @@ export const useOfflineStore = create<OfflineState>((set, get) => ({
     }
 
     const fetchIfMissing = async (source: "google" | "osm", count: number) => {
+      if (poiDiscoveryCategoriesForSource(poiStore.discoveryCategories, source).length === 0) {
+        return;
+      }
       if (count > 0) return;
       try {
         await poiStore.fetchSource(routeId, source, points);

--- a/store/poiStore.ts
+++ b/store/poiStore.ts
@@ -4,11 +4,18 @@ import type {
   DisplayPOI,
   POI,
   POICategory,
+  POIDiscoverySource,
   POIFetchStatus,
   POIFetchedSource,
   RoutePoint,
 } from "@/types";
-import { DEFAULT_CORRIDOR_WIDTH_M, POI_CATEGORIES } from "@/constants";
+import {
+  DEFAULT_CORRIDOR_WIDTH_M,
+  DEFAULT_POI_DISCOVERY_CATEGORIES,
+  POI_CATEGORIES,
+  normalizePoiCategories as normalizeKnownPoiCategories,
+  poiDiscoveryCategoriesForSource,
+} from "@/constants";
 import {
   getPOIsForRoute,
   deletePOIsBySource,
@@ -47,14 +54,43 @@ function parseStarredIds(raw: string | undefined): Set<string> {
 }
 
 const allPoiCategories = (): POICategory[] => POI_CATEGORIES.map((c) => c.key);
+const LEGACY_DEFAULT_CATEGORIES: POICategory[] = [
+  "water",
+  "groceries",
+  "gas_station",
+  "bakery",
+  "toilet_shower",
+  "shelter",
+  "other",
+];
 
 function parseCategories(raw: string | undefined): POICategory[] {
   if (raw === undefined) return allPoiCategories();
   try {
     const valid = new Set<string>(POI_CATEGORIES.map((c) => c.key));
-    return (JSON.parse(raw) as string[]).filter((c) => valid.has(c)) as POICategory[];
+    const parsed = (JSON.parse(raw) as string[]).filter((c) => valid.has(c)) as POICategory[];
+    const parsedSet = new Set(parsed);
+    if (LEGACY_DEFAULT_CATEGORIES.every((category) => parsedSet.has(category))) {
+      return allPoiCategories();
+    }
+    return parsed;
   } catch {
     return allPoiCategories();
+  }
+}
+
+function normalizeCategories(categories: POICategory[]): POICategory[] {
+  const valid = new Set<string>(POI_CATEGORIES.map((c) => c.key));
+  return Array.from(new Set(categories)).filter((c) => valid.has(c)) as POICategory[];
+}
+
+function parseDiscoveryCategories(raw: string | undefined): POICategory[] {
+  if (raw === undefined) return DEFAULT_POI_DISCOVERY_CATEGORIES;
+  try {
+    const parsed = JSON.parse(raw) as POICategory[];
+    return normalizeKnownPoiCategories(parsed);
+  } catch {
+    return DEFAULT_POI_DISCOVERY_CATEGORIES;
   }
 }
 
@@ -214,6 +250,7 @@ interface POIState {
 
   // Filter state (persisted)
   enabledCategories: POICategory[];
+  discoveryCategories: POICategory[];
   corridorWidthM: number;
   showOpenOnly: boolean;
   starredPOIIds: Set<string>;
@@ -236,6 +273,11 @@ interface POIState {
   updatePOINotes: (routeId: string, poiId: string, notes: string) => Promise<void>;
   deleteCustomPOI: (routeId: string, poiId: string) => Promise<void>;
   toggleCategory: (category: POICategory) => void;
+  setEnabledCategories: (categories: POICategory[]) => void;
+  setDiscoveryCategories: (categories: POICategory[]) => void;
+  setDiscoveryGroupEnabled: (categories: POICategory[], enabled: boolean) => void;
+  resetDiscoveryCategories: () => void;
+  hasDiscoveryCategoriesForSource: (source: POIDiscoverySource) => boolean;
   setCorridorWidth: (widthM: number) => void;
   setAllCategories: (enabled: boolean) => void;
   toggleShowOpenOnly: () => void;
@@ -257,6 +299,7 @@ interface POIState {
 export const usePoiStore = create<POIState>((set, get) => ({
   pois: {},
   enabledCategories: parseCategories(readString("enabledCategories")),
+  discoveryCategories: parseDiscoveryCategories(readString("discoveryCategories")),
   corridorWidthM: Number(readString("corridorWidthM")) || DEFAULT_CORRIDOR_WIDTH_M,
   showOpenOnly: readString("showOpenOnly") === "true",
   starredPOIIds: parseStarredIds(readString("starredPOIIds")),
@@ -320,11 +363,18 @@ export const usePoiStore = create<POIState>((set, get) => ({
 
     try {
       const corridorWidthM = get().corridorWidthM;
+      const discoveryCategories = get().discoveryCategories;
       const fetchFn = source === "osm" ? fetchOsmPOIs : fetchGooglePOIs;
-      const count = await fetchFn(routeId, routePoints, corridorWidthM, (phase, done, total) => {
-        // progress is ephemeral — skip MMKV write, it'd churn on every tick
-        updateSourceInfo({ progress: { phase, done, total } }, { persist: false });
-      });
+      const count = await fetchFn(
+        routeId,
+        routePoints,
+        corridorWidthM,
+        (phase, done, total) => {
+          // progress is ephemeral — skip MMKV write, it'd churn on every tick
+          updateSourceInfo({ progress: { phase, done, total } }, { persist: false });
+        },
+        discoveryCategories,
+      );
       updateSourceInfo({
         status: "done",
         count,
@@ -432,6 +482,38 @@ export const usePoiStore = create<POIState>((set, get) => ({
     } catch {}
     set({ enabledCategories: next });
   },
+
+  setEnabledCategories: (categories) => {
+    const next = normalizeCategories(categories);
+    try {
+      getStorage().set("enabledCategories", JSON.stringify(next));
+    } catch {}
+    set({ enabledCategories: next });
+  },
+
+  setDiscoveryCategories: (categories) => {
+    const next = normalizeKnownPoiCategories(categories);
+    try {
+      getStorage().set("discoveryCategories", JSON.stringify(next));
+    } catch {}
+    set({ discoveryCategories: next });
+  },
+
+  setDiscoveryGroupEnabled: (categories, enabled) => {
+    const current = new Set(get().discoveryCategories);
+    for (const category of categories) {
+      if (enabled) current.add(category);
+      else current.delete(category);
+    }
+    get().setDiscoveryCategories([...current]);
+  },
+
+  resetDiscoveryCategories: () => {
+    get().setDiscoveryCategories(DEFAULT_POI_DISCOVERY_CATEGORIES);
+  },
+
+  hasDiscoveryCategoriesForSource: (source) =>
+    poiDiscoveryCategoriesForSource(get().discoveryCategories, source).length > 0,
 
   setCorridorWidth: (widthM) => {
     try {

--- a/store/poiStore.ts
+++ b/store/poiStore.ts
@@ -54,26 +54,11 @@ function parseStarredIds(raw: string | undefined): Set<string> {
 }
 
 const allPoiCategories = (): POICategory[] => POI_CATEGORIES.map((c) => c.key);
-const LEGACY_DEFAULT_CATEGORIES: POICategory[] = [
-  "water",
-  "groceries",
-  "gas_station",
-  "bakery",
-  "toilet_shower",
-  "shelter",
-  "other",
-];
 
-function parseCategories(raw: string | undefined): POICategory[] {
+export function parsePersistedEnabledCategories(raw: string | undefined): POICategory[] {
   if (raw === undefined) return allPoiCategories();
   try {
-    const valid = new Set<string>(POI_CATEGORIES.map((c) => c.key));
-    const parsed = (JSON.parse(raw) as string[]).filter((c) => valid.has(c)) as POICategory[];
-    const parsedSet = new Set(parsed);
-    if (LEGACY_DEFAULT_CATEGORIES.every((category) => parsedSet.has(category))) {
-      return allPoiCategories();
-    }
-    return parsed;
+    return normalizeKnownPoiCategories(JSON.parse(raw) as POICategory[]);
   } catch {
     return allPoiCategories();
   }
@@ -298,7 +283,7 @@ interface POIState {
 
 export const usePoiStore = create<POIState>((set, get) => ({
   pois: {},
-  enabledCategories: parseCategories(readString("enabledCategories")),
+  enabledCategories: parsePersistedEnabledCategories(readString("enabledCategories")),
   discoveryCategories: parseDiscoveryCategories(readString("discoveryCategories")),
   corridorWidthM: Number(readString("corridorWidthM")) || DEFAULT_CORRIDOR_WIDTH_M,
   showOpenOnly: readString("showOpenOnly") === "true",

--- a/tests/services/googlePlacesClient.test.ts
+++ b/tests/services/googlePlacesClient.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchGooglePlacesPOIs,
+  inferPOICategoryFromGoogleTypes,
+} from "@/services/googlePlacesClient";
+import type { RoutePoint } from "@/types";
+
+const routePoints: RoutePoint[] = [
+  { latitude: 48.1, longitude: 17.1, elevationMeters: null, distanceFromStartMeters: 0, idx: 0 },
+  {
+    latitude: 48.2,
+    longitude: 17.2,
+    elevationMeters: null,
+    distanceFromStartMeters: 15_000,
+    idx: 1,
+  },
+];
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("googlePlacesClient", () => {
+  it("infers expanded POI categories from Google place types", () => {
+    expect(inferPOICategoryFromGoogleTypes(["cafe"])).toBe("coffee");
+    expect(inferPOICategoryFromGoogleTypes(["restaurant"])).toBe("restaurant");
+    expect(inferPOICategoryFromGoogleTypes(["bar"])).toBe("bar_pub");
+    expect(inferPOICategoryFromGoogleTypes(["pharmacy"])).toBe("pharmacy");
+    expect(inferPOICategoryFromGoogleTypes(["hospital"])).toBe("hospital_er");
+    expect(inferPOICategoryFromGoogleTypes(["bicycle_store"])).toBe("bike_shop");
+  });
+
+  it("only runs Google searches for enabled discovery categories", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ places: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchGooglePlacesPOIs(routePoints, "api-key", ["gas_station"]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      textQuery: "gas station",
+    });
+  });
+
+  it("skips Google when no Google discovery categories are enabled", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const pois = await fetchGooglePlacesPOIs(routePoints, "api-key", ["water"]);
+
+    expect(pois).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/overpassClient.test.ts
+++ b/tests/services/overpassClient.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildOverpassQuery } from "@/services/overpassClient";
+
+describe("overpassClient", () => {
+  it("builds category-specific corridor radii for infrastructure POI searches", () => {
+    const query = buildOverpassQuery([{ lat: 48.1, lon: 17.1 }], 1000);
+
+    expect(query).toBeTruthy();
+    expect(query!).toContain('node["amenity"="drinking_water"](around:1000,48.1,17.1)');
+    expect(query!).toContain('node["highway"="bus_stop"]["shelter"="yes"](around:30,48.1,17.1)');
+    expect(query!).toContain('node["amenity"="hospital"](around:10000,48.1,17.1)');
+    expect(query!).toContain('node["amenity"="bicycle_repair_station"](around:500,48.1,17.1)');
+  });
+
+  it("keeps commercial stops on Google Places or disabled discovery groups", () => {
+    const query = buildOverpassQuery([{ lat: 48.1, lon: 17.1 }], 1000);
+
+    expect(query).toBeTruthy();
+    expect(query!).not.toContain('"amenity"="fuel"');
+    expect(query!).not.toContain('"shop"~"^(supermarket|convenience|grocery)$"');
+    expect(query!).not.toContain('"shop"="bakery"');
+    expect(query!).not.toContain('"amenity"="cafe"');
+    expect(query!).not.toContain('"amenity"="restaurant"');
+    expect(query!).not.toContain('"amenity"~"^(bar|pub)$"');
+    expect(query!).not.toContain('"shop"="bicycle"');
+  });
+
+  it("omits disabled OSM discovery categories", () => {
+    const query = buildOverpassQuery([{ lat: 48.1, lon: 17.1 }], 1000, ["water"]);
+
+    expect(query).toContain('node["amenity"="drinking_water"]');
+    expect(query).not.toContain('"amenity"~"^(toilets|shower)$"');
+    expect(query).not.toContain('"amenity"="bicycle_repair_station"');
+  });
+
+  it("returns null when no OSM categories are enabled", () => {
+    expect(buildOverpassQuery([{ lat: 48.1, lon: 17.1 }], 1000, [])).toBeNull();
+  });
+});

--- a/tests/services/poiClassifier.test.ts
+++ b/tests/services/poiClassifier.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { classifyElement } from "@/services/poiClassifier";
+import type { OverpassElement } from "@/services/overpassClient";
+
+function element(tags: Record<string, string>): OverpassElement {
+  return { type: "node", id: 1, lat: 0, lon: 0, tags };
+}
+
+describe("poiClassifier", () => {
+  it("classifies expanded food and service POI categories", () => {
+    expect(classifyElement(element({ amenity: "cafe" }))).toBe("coffee");
+    expect(classifyElement(element({ amenity: "restaurant" }))).toBe("restaurant");
+    expect(classifyElement(element({ amenity: "pub" }))).toBe("bar_pub");
+    expect(classifyElement(element({ shop: "bicycle" }))).toBe("bike_shop");
+    expect(classifyElement(element({ amenity: "bicycle_repair_station" }))).toBe("repair_station");
+    expect(classifyElement(element({ amenity: "compressed_air" }))).toBe("pump_air");
+  });
+
+  it("keeps public transport shelters separate from general shelter", () => {
+    expect(classifyElement(element({ amenity: "shelter", shelter_type: "public_transport" }))).toBe(
+      "bus_stop",
+    );
+    expect(classifyElement(element({ amenity: "shelter", shelter_type: "basic_hut" }))).toBe(
+      "shelter",
+    );
+  });
+
+  it("classifies help, escape, and other logistics POIs", () => {
+    expect(classifyElement(element({ amenity: "pharmacy" }))).toBe("pharmacy");
+    expect(classifyElement(element({ emergency: "defibrillator" }))).toBe("defibrillator");
+    expect(classifyElement(element({ railway: "station" }))).toBe("train_station");
+    expect(classifyElement(element({ amenity: "grave_yard" }))).toBe("cemetery");
+    expect(classifyElement(element({ amenity: "school" }))).toBe("school");
+  });
+});

--- a/tests/services/poiFetcher.test.ts
+++ b/tests/services/poiFetcher.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/db/database", () => ({
+  deletePOIsBySource: vi.fn(),
+  insertPOIs: vi.fn(),
+}));
+
+import { associateAndFilter } from "@/services/poiFetcher";
+import type { RoutePoint } from "@/types";
+
+const routePoints: RoutePoint[] = [
+  { latitude: 0, longitude: 0, elevationMeters: null, distanceFromStartMeters: 0, idx: 0 },
+  {
+    latitude: 0,
+    longitude: 0.1,
+    elevationMeters: null,
+    distanceFromStartMeters: 11_132,
+    idx: 1,
+  },
+];
+
+describe("poiFetcher", () => {
+  it("filters associated POIs with category-specific corridor widths", () => {
+    const pois = associateAndFilter(
+      [
+        {
+          sourceId: "hospital",
+          name: "Hospital",
+          category: "hospital_er",
+          latitude: 0.018,
+          longitude: 0.05,
+          tags: {},
+        },
+        {
+          sourceId: "bus",
+          name: "Bus Shelter",
+          category: "bus_stop",
+          latitude: 0.001,
+          longitude: 0.05,
+          tags: {},
+        },
+      ],
+      "route-1",
+      routePoints,
+      1000,
+      "osm",
+    );
+
+    expect(pois.map((poi) => poi.sourceId)).toEqual(["hospital"]);
+    expect(pois[0].distanceFromRouteMeters).toBeGreaterThan(1000);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,6 +10,15 @@ vi.mock("expo-network", async () => {
   return expoNetworkMocks;
 });
 
+vi.mock("expo-constants", () => ({
+  default: {
+    expoConfig: {
+      extra: {},
+      ios: { bundleIdentifier: "com.ultra.test" },
+    },
+  },
+}));
+
 vi.mock("@/db/database", async () => {
   const { databaseMocks } = await import("@/tests/mocks/database");
   return databaseMocks;

--- a/tests/store/offlineStore.test.ts
+++ b/tests/store/offlineStore.test.ts
@@ -5,12 +5,14 @@ import { offlineTilesMocks } from "@/tests/mocks/offlineTiles";
 
 const mocks = vi.hoisted(() => ({
   fetchSource: vi.fn(),
+  discoveryCategories: ["gas_station", "water"],
 }));
 
 vi.mock("@/store/poiStore", () => ({
   usePoiStore: {
     getState: () => ({
       fetchSource: mocks.fetchSource,
+      discoveryCategories: mocks.discoveryCategories,
     }),
   },
 }));
@@ -23,6 +25,7 @@ describe("offlineStore offline preparation", () => {
   beforeEach(() => {
     useOfflineStore.setState({ routeInfo: {}, isConnected: true });
     mocks.fetchSource.mockResolvedValue(undefined);
+    mocks.discoveryCategories = ["gas_station", "water"];
     offlineTilesMocks.estimateDownloadSize.mockReturnValue(1234);
   });
 
@@ -90,6 +93,21 @@ describe("offlineStore offline preparation", () => {
 
     resolveDownload?.();
     await tileDownload;
+  });
+
+  it("skips disabled POI sources while preparing offline data", async () => {
+    mocks.discoveryCategories = ["water"];
+    databaseMocks.getPOICountsBySource.mockResolvedValue({ google: 0, osm: 0 });
+    offlineTilesMocks.downloadRouteTiles.mockImplementation(
+      async (_routeId, _points, _onProgress, onComplete) => {
+        onComplete();
+      },
+    );
+
+    await useOfflineStore.getState().prepareRouteOffline("r1", points);
+
+    expect(mocks.fetchSource.mock.calls.map(([, source]) => source)).toEqual(["osm"]);
+    expect(offlineTilesMocks.downloadRouteTiles).toHaveBeenCalledOnce();
   });
 
   it("cancel resets visible tile state and ignores late native errors", async () => {

--- a/tests/store/poiStoreParsing.test.ts
+++ b/tests/store/poiStoreParsing.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { POI_CATEGORIES } from "@/constants";
+import { parsePersistedEnabledCategories } from "@/store/poiStore";
+import type { POICategory } from "@/types";
+
+const allCategoryKeys = POI_CATEGORIES.map((category) => category.key);
+
+describe("parsePersistedEnabledCategories", () => {
+  it("enables all categories when no preference is saved", () => {
+    expect(parsePersistedEnabledCategories(undefined)).toEqual(allCategoryKeys);
+  });
+
+  it("preserves stored subsets without legacy expansion", () => {
+    const stored: POICategory[] = [
+      "water",
+      "groceries",
+      "gas_station",
+      "bakery",
+      "toilet_shower",
+      "shelter",
+      "other",
+      "coffee",
+    ];
+
+    expect(parsePersistedEnabledCategories(JSON.stringify(stored))).toEqual(stored);
+  });
+
+  it("drops unknown and duplicate stored categories", () => {
+    expect(parsePersistedEnabledCategories(JSON.stringify(["water", "unknown", "water"]))).toEqual([
+      "water",
+    ]);
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -122,8 +122,36 @@ export type POICategory =
   | "groceries"
   | "gas_station"
   | "bakery"
+  | "coffee"
+  | "restaurant"
+  | "bar_pub"
   | "toilet_shower"
   | "shelter"
+  | "bus_stop"
+  | "camp_site"
+  | "pharmacy"
+  | "hospital_er"
+  | "defibrillator"
+  | "emergency_phone"
+  | "ambulance_station"
+  | "bike_shop"
+  | "repair_station"
+  | "pump_air"
+  | "train_station"
+  | "sports"
+  | "cemetery"
+  | "school"
+  | "other";
+
+export type POICategoryGroup =
+  | "water"
+  | "food"
+  | "eat_drink"
+  | "wc"
+  | "rest"
+  | "help"
+  | "repair"
+  | "escape"
   | "other";
 
 export type POIFetchedSource = "osm" | "google";
@@ -150,8 +178,19 @@ export interface DisplayPOI extends POI {
 export interface POICategoryMeta {
   key: POICategory;
   label: string;
+  group: POICategoryGroup;
   color: string;
   iconName: string;
+}
+
+export type POIDiscoverySource = POIFetchedSource;
+
+export interface POIDiscoveryGroupMeta {
+  key: string;
+  label: string;
+  detail: string;
+  categories: POICategory[];
+  defaultEnabled: boolean;
 }
 
 export type POIFetchStatus = "idle" | "fetching" | "done" | "error";

--- a/utils/poiActions.ts
+++ b/utils/poiActions.ts
@@ -1,0 +1,110 @@
+import type { POI } from "@/types";
+
+const ADDRESS_TAG_KEYS = [
+  "formatted_address",
+  "addr:street",
+  "addr:housenumber",
+  "addr:city",
+  "addr:postcode",
+  "addr:country",
+];
+const PHONE_TAG_KEYS = ["phone", "contact:phone"];
+const WEBSITE_TAG_KEYS = ["website", "contact:website", "url"];
+const EXTRA_DETAIL_TAGS: Array<{ key: string; label: string }> = [
+  { key: "operator", label: "Operator" },
+  { key: "brand", label: "Brand" },
+  { key: "description", label: "Details" },
+  { key: "description:en", label: "Details" },
+  { key: "note", label: "Note" },
+  { key: "fee", label: "Fee" },
+  { key: "wheelchair", label: "Wheelchair" },
+  { key: "drinking_water", label: "Drinking water" },
+];
+
+export interface PoiDetailField {
+  label: string;
+  value: string;
+}
+
+function cleanTagValue(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function getPoiMapUrl(poi: POI): string {
+  if (poi.tags?.google_maps_url) return poi.tags.google_maps_url;
+  const query = encodeURIComponent(`${poi.latitude},${poi.longitude}`);
+  if (poi.tags?.google_place_id) {
+    const placeId = encodeURIComponent(poi.tags.google_place_id);
+    return `https://www.google.com/maps/search/?api=1&query=${query}&query_place_id=${placeId}`;
+  }
+  return `https://www.google.com/maps/search/?api=1&query=${query}`;
+}
+
+export function buildPhoneUrl(phone: string): string | null {
+  const trimmed = phone.trim();
+  if (!trimmed) return null;
+
+  const normalized = trimmed.replace(/(?!^\+)\D/g, "");
+  return normalized ? `tel:${normalized}` : null;
+}
+
+export function getPoiAddress(poi: POI): string | null {
+  const t = poi.tags;
+  const formatted = cleanTagValue(t.formatted_address);
+  if (formatted) return formatted;
+
+  const street = cleanTagValue(t["addr:street"]);
+  const houseNumber = cleanTagValue(t["addr:housenumber"]);
+  const city = cleanTagValue(t["addr:city"]);
+  const postcode = cleanTagValue(t["addr:postcode"]);
+  const country = cleanTagValue(t["addr:country"]);
+
+  const parts: string[] = [];
+  if (street) parts.push(`${street}${houseNumber ? ` ${houseNumber}` : ""}`);
+  if (postcode || city) parts.push([postcode, city].filter(Boolean).join(" "));
+  if (country) parts.push(country);
+
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
+export function getPoiPhone(poi: POI): string | null {
+  for (const key of PHONE_TAG_KEYS) {
+    const value = cleanTagValue(poi.tags[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+export function getPoiWebsiteUrl(poi: POI): string | null {
+  for (const key of WEBSITE_TAG_KEYS) {
+    const value = cleanTagValue(poi.tags[key]);
+    if (!value) continue;
+    return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+  }
+  return null;
+}
+
+export function getPoiExtraDetailFields(poi: POI): PoiDetailField[] {
+  const seenLabels = new Set<string>();
+  const fields: PoiDetailField[] = [];
+
+  for (const { key, label } of EXTRA_DETAIL_TAGS) {
+    const value = cleanTagValue(poi.tags[key]);
+    if (!value || seenLabels.has(label)) continue;
+    fields.push({ label, value });
+    seenLabels.add(label);
+  }
+
+  return fields;
+}
+
+export function hasExpandablePoiDetails(poi: POI): boolean {
+  if (cleanTagValue(poi.tags.opening_hours)) return true;
+  if (getPoiAddress(poi)) return true;
+  if (getPoiPhone(poi)) return true;
+  if (getPoiWebsiteUrl(poi)) return true;
+  if (getPoiExtraDetailFields(poi).length > 0) return true;
+
+  return ADDRESS_TAG_KEYS.some((key) => Boolean(cleanTagValue(poi.tags[key])));
+}


### PR DESCRIPTION
## Summary

Backports the first POI-focused batch from the fork while adapting it to our current app architecture.

- Expands POI categories, icons, and category-specific corridor widths.
- Keeps commercial food/fuel discovery Google-backed and infrastructure/rest/repair discovery OSM-backed.
- Adds configurable POI Discovery groups in Settings so fetch/prep scope is separate from map/list visibility filters.
- Adds richer POI detail actions for Maps, phone, website, address, and extra tags.
- Updates offline preparation to skip disabled POI sources.

## Impact

This reduces noisy cached POIs without opening hours, keeps high-value logistics categories available by default, and lets optional categories like emergency, rough sleep, escape/transport, pharmacy, and eat/drink be enabled when needed.

Existing cached POIs are not automatically removed; a route source needs to be cleared/refetched for new discovery settings to take effect.

## Verification

- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test`

AXe smoke test was attempted, but the simulator was on the iOS home screen and the script failed before reaching the app (`Toggle weather` label not found).