### PR TITLE
[codex] Add POI clustering with category markers

### DIFF
--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -307,6 +307,19 @@ export default function MapScreen() {
     }
   }, [selectedPOI, setFollowUser]);
 
+  const handlePOIClusterPress = useCallback(
+    (centerCoordinate: [number, number], zoomLevel: number) => {
+      setFollowUser(false);
+      cameraRef.current?.setCamera({
+        centerCoordinate,
+        zoomLevel,
+        animationMode: "easeTo",
+        animationDuration: 450,
+      });
+    },
+    [setFollowUser],
+  );
+
   const handleLocate = useCallback(async () => {
     setFollowUser(true);
     // Snap to cached position instantly, then ease to fresh fix (no zoom change)
@@ -518,6 +531,7 @@ export default function MapScreen() {
             routeIds={activeRouteIds}
             segments={activeData?.segments ?? null}
             currentDistanceMeters={currentPOIDistanceMeters}
+            onClusterPress={handlePOIClusterPress}
           />
         )}
         {highlightedClimb && activeRoutePoints && (

--- a/components/map/POILayer.tsx
+++ b/components/map/POILayer.tsx
@@ -9,12 +9,18 @@ import {
   POI_CLUSTER_MAX_ZOOM,
   POI_CLUSTER_MIN_ZOOM,
   POI_CLUSTER_RADIUS,
+  POI_CLUSTER_SUMMARY_CATEGORIES,
+  POI_CLUSTER_SUMMARY_ICON_SYMBOL_SIZE,
+  POI_CLUSTER_SUMMARY_PRIORITY_PROPERTY,
   POI_MAP_ICON_SYMBOL_SIZE,
+  poiClusterSummaryProperty,
+  poiMapIconImageId,
+  poiMapIconImageIdForCategory,
 } from "@/constants";
 import { haversineDistance } from "@/utils/geo";
 import { toDisplayPOIs } from "@/services/displayDistance";
 import { stitchPOIs } from "@/services/stitchingService";
-import { buildPOIMapFeatureCollections } from "@/utils/poiMapFeatures";
+import { buildPOIClusterProperties, buildPOIMapFeatureCollections } from "@/utils/poiMapFeatures";
 import POIMapImages from "./POIMapImages";
 import {
   createRidingHorizonWindow,
@@ -26,6 +32,10 @@ import type { DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
 const CLUSTER_FILTER = ["has", "point_count"] as const;
 const UNCLUSTERED_FILTER = ["!", ["has", "point_count"]] as const;
 const POI_ICON_COLOR = "#FFFFFF";
+const CLUSTER_OVERFLOW_TEXT_OFFSET = [0.45, 0];
+const POI_CLUSTER_PROPERTIES = buildPOIClusterProperties();
+
+type MapboxExpression = unknown[];
 
 interface ShapeSourcePressEvent {
   features?: GeoJSON.Feature[];
@@ -86,6 +96,74 @@ function findPressedPOI(
 
   const id = features[0]?.properties?.poiId;
   return typeof id === "string" ? pois.find((p) => p.id === id) : undefined;
+}
+
+function clusterCategoryCountExpression(category: (typeof POI_CLUSTER_SUMMARY_CATEGORIES)[number]) {
+  return ["coalesce", ["get", poiClusterSummaryProperty(category)], 0];
+}
+
+function clusterHasCategoryExpression(category: (typeof POI_CLUSTER_SUMMARY_CATEGORIES)[number]) {
+  return [">", clusterCategoryCountExpression(category), 0];
+}
+
+function countExpressions(expressions: MapboxExpression[]): number | MapboxExpression {
+  if (expressions.length === 0) return 0;
+  if (expressions.length === 1) return expressions[0];
+  return ["+", ...expressions];
+}
+
+function clusterPresentCategoryCountExpression(): number | MapboxExpression {
+  return countExpressions(
+    POI_CLUSTER_SUMMARY_CATEGORIES.map((category) => [
+      "case",
+      clusterHasCategoryExpression(category),
+      1,
+      0,
+    ]),
+  );
+}
+
+const CLUSTER_SUMMARY_TOTAL_EXPRESSION = clusterPresentCategoryCountExpression();
+const CLUSTER_SUMMARY_PRIORITY_EXPRESSION = [
+  "coalesce",
+  ["get", POI_CLUSTER_SUMMARY_PRIORITY_PROPERTY],
+  POI_CLUSTER_SUMMARY_CATEGORIES.length,
+];
+const CLUSTER_SUMMARY_ICON_OFFSET = [
+  "case",
+  [">", CLUSTER_SUMMARY_TOTAL_EXPRESSION, 1],
+  ["literal", [-4, 0]],
+  ["literal", [0, 0]],
+];
+
+function clusterSummaryIconExpression(): MapboxExpression {
+  const expression: MapboxExpression = ["match", CLUSTER_SUMMARY_PRIORITY_EXPRESSION];
+
+  POI_CLUSTER_SUMMARY_CATEGORIES.forEach((category, index) => {
+    expression.push(index);
+    expression.push(poiMapIconImageIdForCategory(category));
+  });
+
+  expression.push(poiMapIconImageId("MapPin"));
+  return expression;
+}
+
+function renderClusterSummaryIconLayer(): React.ReactElement {
+  return (
+    <SymbolLayer
+      id="poi-cluster-summary-icon"
+      filter={CLUSTER_FILTER}
+      style={{
+        iconImage: clusterSummaryIconExpression() as never,
+        iconSize: POI_CLUSTER_SUMMARY_ICON_SYMBOL_SIZE,
+        iconOffset: CLUSTER_SUMMARY_ICON_OFFSET as never,
+        iconColor: POI_ICON_COLOR,
+        iconAllowOverlap: true,
+        iconIgnorePlacement: true,
+      }}
+      minZoomLevel={POI_CLUSTER_MIN_ZOOM}
+    />
+  );
 }
 
 export default function POILayer({
@@ -196,27 +274,37 @@ export default function POILayer({
           cluster
           clusterRadius={POI_CLUSTER_RADIUS}
           clusterMaxZoomLevel={POI_CLUSTER_MAX_ZOOM}
+          clusterProperties={POI_CLUSTER_PROPERTIES}
           onPress={handleClusteredPress}
           hitbox={{ width: POI_CLUSTER_HITBOX, height: POI_CLUSTER_HITBOX }}
         >
           <CircleLayer
-            id="poi-clusters"
+            id="poi-clusters-outline"
             filter={CLUSTER_FILTER}
             style={{
-              circleRadius: ["step", ["get", "point_count"], 13, 10, 16, 50, 19],
-              circleColor: colors.accent,
-              circleStrokeWidth: 2,
-              circleStrokeColor: colors.surface,
+              circleRadius: ["step", ["get", "point_count"], 17, 10, 20, 50, 23],
+              circleColor: colors.surface,
             }}
             minZoomLevel={POI_CLUSTER_MIN_ZOOM}
           />
-          <SymbolLayer
-            id="poi-cluster-count"
+          <CircleLayer
+            id="poi-clusters-fill"
             filter={CLUSTER_FILTER}
             style={{
-              textField: ["get", "point_count_abbreviated"],
-              textSize: 12,
+              circleRadius: ["step", ["get", "point_count"], 14, 10, 17, 50, 20],
+              circleColor: colors.accent,
+            }}
+            minZoomLevel={POI_CLUSTER_MIN_ZOOM}
+          />
+          {renderClusterSummaryIconLayer()}
+          <SymbolLayer
+            id="poi-cluster-summary-overflow"
+            filter={["all", CLUSTER_FILTER, [">", CLUSTER_SUMMARY_TOTAL_EXPRESSION, 1]] as never}
+            style={{
+              textField: "+",
+              textSize: 13,
               textColor: colors.accentForeground,
+              textOffset: CLUSTER_OVERFLOW_TEXT_OFFSET,
               textAllowOverlap: true,
               textIgnorePlacement: true,
             }}

--- a/components/map/POILayer.tsx
+++ b/components/map/POILayer.tsx
@@ -1,12 +1,21 @@
-import React, { useMemo, useCallback } from "react";
-import { ShapeSource, CircleLayer } from "@rnmapbox/maps";
+import React, { useMemo, useCallback, useRef } from "react";
+import { ShapeSource, CircleLayer, SymbolLayer } from "@rnmapbox/maps";
 import { usePoiStore } from "@/store/poiStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useThemeColors } from "@/theme";
-import { POI_BEHIND_THRESHOLD_M, POI_CATEGORIES } from "@/constants";
+import {
+  POI_BEHIND_THRESHOLD_M,
+  POI_CLUSTER_HITBOX,
+  POI_CLUSTER_MAX_ZOOM,
+  POI_CLUSTER_MIN_ZOOM,
+  POI_CLUSTER_RADIUS,
+  POI_MAP_ICON_SYMBOL_SIZE,
+} from "@/constants";
 import { haversineDistance } from "@/utils/geo";
 import { toDisplayPOIs } from "@/services/displayDistance";
 import { stitchPOIs } from "@/services/stitchingService";
+import { buildPOIMapFeatureCollections } from "@/utils/poiMapFeatures";
+import POIMapImages from "./POIMapImages";
 import {
   createRidingHorizonWindow,
   isDistanceInWindow,
@@ -14,15 +23,78 @@ import {
 } from "@/utils/ridingHorizon";
 import type { DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
 
-const categoryColorMap = Object.fromEntries(POI_CATEGORIES.map((c) => [c.key, c.color]));
+const CLUSTER_FILTER = ["has", "point_count"] as const;
+const UNCLUSTERED_FILTER = ["!", ["has", "point_count"]] as const;
+const POI_ICON_COLOR = "#FFFFFF";
+
+interface ShapeSourcePressEvent {
+  features?: GeoJSON.Feature[];
+  coordinates?: {
+    latitude: number;
+    longitude: number;
+  };
+}
 
 interface POILayerProps {
   routeIds: string[];
   segments: StitchedSegmentInfo[] | null;
   currentDistanceMeters: number | null;
+  onClusterPress: (center: [number, number], zoomLevel: number) => void;
 }
 
-export default function POILayer({ routeIds, segments, currentDistanceMeters }: POILayerProps) {
+function isClusterFeature(feature: GeoJSON.Feature): boolean {
+  const props = feature.properties;
+  if (!props) return false;
+  return props.cluster === true || props.cluster === 1 || props.point_count != null;
+}
+
+function pointCoordinates(feature: GeoJSON.Feature): [number, number] | null {
+  if (feature.geometry?.type !== "Point") return null;
+  const [longitude, latitude] = feature.geometry.coordinates;
+  if (!Number.isFinite(longitude) || !Number.isFinite(latitude)) return null;
+  return [longitude, latitude];
+}
+
+function findPressedPOI(
+  features: GeoJSON.Feature[],
+  tapCoord: ShapeSourcePressEvent["coordinates"],
+  pois: DisplayPOI[],
+): DisplayPOI | undefined {
+  if (tapCoord && features.length > 1) {
+    let bestPoi: DisplayPOI | undefined;
+    let bestDist = Infinity;
+
+    for (const feature of features) {
+      const id = feature.properties?.poiId;
+      if (!id || typeof id !== "string") continue;
+      const poi = pois.find((p) => p.id === id);
+      if (!poi) continue;
+      const dist = haversineDistance(
+        tapCoord.latitude,
+        tapCoord.longitude,
+        poi.latitude,
+        poi.longitude,
+      );
+      if (dist < bestDist) {
+        bestDist = dist;
+        bestPoi = poi;
+      }
+    }
+
+    return bestPoi;
+  }
+
+  const id = features[0]?.properties?.poiId;
+  return typeof id === "string" ? pois.find((p) => p.id === id) : undefined;
+}
+
+export default function POILayer({
+  routeIds,
+  segments,
+  currentDistanceMeters,
+  onClusterPress,
+}: POILayerProps) {
+  const clusteredSourceRef = useRef<ShapeSource>(null);
   const getVisiblePOIs = usePoiStore((s) => s.getVisiblePOIs);
   const enabledCategories = usePoiStore((s) => s.enabledCategories);
   const starredPOIIds = usePoiStore((s) => s.starredPOIIds);
@@ -65,59 +137,46 @@ export default function POILayer({ routeIds, segments, currentDistanceMeters }: 
     starredPOIIds,
   ]);
 
-  const geoJSON = useMemo(
-    (): GeoJSON.FeatureCollection => ({
-      type: "FeatureCollection",
-      features: visiblePOIs.map((poi) => ({
-        type: "Feature",
-        properties: {
-          poiId: poi.id,
-          category: poi.category,
-          color: categoryColorMap[poi.category] ?? "#888888",
-          name: poi.name ?? "",
-          starred: starredPOIIds.has(poi.id) ? 1 : 0,
-        },
-        geometry: {
-          type: "Point",
-          coordinates: [poi.longitude, poi.latitude],
-        },
-      })),
-    }),
+  const { clustered, starred } = useMemo(
+    () => buildPOIMapFeatureCollections(visiblePOIs, starredPOIIds),
     [visiblePOIs, starredPOIIds],
   );
 
-  const handlePress = useCallback(
-    (event: any) => {
+  const handleClusteredPress = useCallback(
+    async (event: ShapeSourcePressEvent) => {
       const features = event?.features;
       if (!features?.length) return;
 
-      // When multiple features overlap, pick the one closest to the tap point
-      const tapCoord = event?.coordinates;
-      let bestPoi: DisplayPOI | undefined;
+      const clusterFeature = features.find(isClusterFeature);
+      if (clusterFeature) {
+        const center = pointCoordinates(clusterFeature);
+        if (!center) return;
 
-      if (tapCoord && features.length > 1) {
-        let bestDist = Infinity;
-        for (const feature of features) {
-          const id = feature?.properties?.poiId;
-          if (!id) continue;
-          const poi = visiblePOIs.find((p) => p.id === id);
-          if (!poi) continue;
-          const dist = haversineDistance(
-            tapCoord.latitude,
-            tapCoord.longitude,
-            poi.latitude,
-            poi.longitude,
-          );
-          if (dist < bestDist) {
-            bestDist = dist;
-            bestPoi = poi;
+        let zoomLevel = POI_CLUSTER_MAX_ZOOM + 1;
+        try {
+          const expansionZoom =
+            await clusteredSourceRef.current?.getClusterExpansionZoom(clusterFeature);
+          if (typeof expansionZoom === "number" && Number.isFinite(expansionZoom)) {
+            zoomLevel = expansionZoom;
           }
-        }
-      } else {
-        const id = features[0]?.properties?.poiId;
-        if (id) bestPoi = visiblePOIs.find((p) => p.id === id);
+        } catch {}
+
+        onClusterPress(center, zoomLevel);
+        return;
       }
 
+      const bestPoi = findPressedPOI(features, event?.coordinates, visiblePOIs);
+      if (bestPoi) setSelectedPOI(bestPoi);
+    },
+    [visiblePOIs, setSelectedPOI, onClusterPress],
+  );
+
+  const handleStarredPress = useCallback(
+    (event: ShapeSourcePressEvent) => {
+      const features = event?.features;
+      if (!features?.length) return;
+
+      const bestPoi = findPressedPOI(features, event?.coordinates, visiblePOIs);
       if (bestPoi) setSelectedPOI(bestPoi);
     },
     [visiblePOIs, setSelectedPOI],
@@ -126,51 +185,119 @@ export default function POILayer({ routeIds, segments, currentDistanceMeters }: 
   if (visiblePOIs.length === 0) return null;
 
   return (
-    <ShapeSource
-      id="poi-source"
-      shape={geoJSON}
-      onPress={handlePress}
-      hitbox={{ width: 16, height: 16 }}
-    >
-      {/* Regular POIs: surface-colored ring, visible from zoom 10 */}
-      <CircleLayer
-        id="poi-circles-outline"
-        filter={["==", ["get", "starred"], 0]}
-        style={{
-          circleRadius: 7,
-          circleColor: colors.surface,
-        }}
-        minZoomLevel={10}
-      />
-      <CircleLayer
-        id="poi-circles"
-        filter={["==", ["get", "starred"], 0]}
-        style={{
-          circleRadius: 5,
-          circleColor: ["get", "color"],
-        }}
-        minZoomLevel={10}
-      />
+    <>
+      <POIMapImages />
 
-      {/* Starred POIs: gold ring, larger, visible from zoom 8 — rendered last to be on top */}
-      <CircleLayer
-        id="poi-starred-outline"
-        filter={["==", ["get", "starred"], 1]}
-        style={{
-          circleRadius: 10,
-          circleColor: colors.warning,
-        }}
-        minZoomLevel={8}
-      />
-      <CircleLayer
-        id="poi-starred-fill"
-        filter={["==", ["get", "starred"], 1]}
-        style={{
-          circleRadius: 7,
-          circleColor: ["get", "color"],
-        }}
-        minZoomLevel={8}
-      />
-    </ShapeSource>
+      {clustered.features.length > 0 && (
+        <ShapeSource
+          id="poi-clustered-source"
+          ref={clusteredSourceRef}
+          shape={clustered}
+          cluster
+          clusterRadius={POI_CLUSTER_RADIUS}
+          clusterMaxZoomLevel={POI_CLUSTER_MAX_ZOOM}
+          onPress={handleClusteredPress}
+          hitbox={{ width: POI_CLUSTER_HITBOX, height: POI_CLUSTER_HITBOX }}
+        >
+          <CircleLayer
+            id="poi-clusters"
+            filter={CLUSTER_FILTER}
+            style={{
+              circleRadius: ["step", ["get", "point_count"], 13, 10, 16, 50, 19],
+              circleColor: colors.accent,
+              circleStrokeWidth: 2,
+              circleStrokeColor: colors.surface,
+            }}
+            minZoomLevel={POI_CLUSTER_MIN_ZOOM}
+          />
+          <SymbolLayer
+            id="poi-cluster-count"
+            filter={CLUSTER_FILTER}
+            style={{
+              textField: ["get", "point_count_abbreviated"],
+              textSize: 12,
+              textColor: colors.accentForeground,
+              textAllowOverlap: true,
+              textIgnorePlacement: true,
+            }}
+            minZoomLevel={POI_CLUSTER_MIN_ZOOM}
+          />
+
+          {/* Regular POIs: surface-colored ring, visible from zoom 10 */}
+          <CircleLayer
+            id="poi-circles-outline"
+            filter={UNCLUSTERED_FILTER}
+            style={{
+              circleRadius: 13,
+              circleColor: colors.surface,
+            }}
+            minZoomLevel={10}
+          />
+          <CircleLayer
+            id="poi-circles"
+            filter={UNCLUSTERED_FILTER}
+            style={{
+              circleRadius: 10,
+              circleColor: ["get", "color"],
+            }}
+            minZoomLevel={10}
+          />
+          <SymbolLayer
+            id="poi-icons"
+            filter={UNCLUSTERED_FILTER}
+            style={{
+              iconImage: ["get", "iconImage"],
+              iconSize: POI_MAP_ICON_SYMBOL_SIZE,
+              iconColor: POI_ICON_COLOR,
+              iconHaloColor: colors.surface,
+              iconHaloWidth: 1,
+              iconAllowOverlap: true,
+              iconIgnorePlacement: true,
+            }}
+            minZoomLevel={10}
+          />
+        </ShapeSource>
+      )}
+
+      {starred.features.length > 0 && (
+        <ShapeSource
+          id="poi-starred-source"
+          shape={starred}
+          onPress={handleStarredPress}
+          hitbox={{ width: POI_CLUSTER_HITBOX, height: POI_CLUSTER_HITBOX }}
+        >
+          {/* Starred POIs: gold ring, larger, visible from zoom 8 — rendered last to be on top */}
+          <CircleLayer
+            id="poi-starred-outline"
+            style={{
+              circleRadius: 14,
+              circleColor: colors.warning,
+            }}
+            minZoomLevel={8}
+          />
+          <CircleLayer
+            id="poi-starred-fill"
+            style={{
+              circleRadius: 10,
+              circleColor: ["get", "color"],
+            }}
+            minZoomLevel={8}
+          />
+          <SymbolLayer
+            id="poi-starred-icons"
+            style={{
+              iconImage: ["get", "iconImage"],
+              iconSize: POI_MAP_ICON_SYMBOL_SIZE,
+              iconColor: POI_ICON_COLOR,
+              iconHaloColor: colors.surface,
+              iconHaloWidth: 1,
+              iconAllowOverlap: true,
+              iconIgnorePlacement: true,
+            }}
+            minZoomLevel={8}
+          />
+        </ShapeSource>
+      )}
+    </>
   );
 }

--- a/components/map/POIMapImages.tsx
+++ b/components/map/POIMapImages.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { Image as MapboxImage, Images } from "@rnmapbox/maps";
+import {
+  POI_CATEGORIES,
+  POI_MAP_ICON_INSET,
+  POI_MAP_ICON_IMAGE_SIZE,
+  POI_MAP_ICON_STROKE_WIDTH,
+  poiMapIconImageId,
+} from "@/constants";
+import { POI_ICON_MAP } from "@/constants/poiIcons";
+
+const FALLBACK_ICON_NAME = "MapPin";
+const iconNames = Array.from(
+  new Set([...POI_CATEGORIES.map((category) => category.iconName), FALLBACK_ICON_NAME]),
+);
+
+const iconEntries = iconNames.map((iconName) => ({
+  imageId: poiMapIconImageId(iconName),
+  Icon: POI_ICON_MAP[iconName] ?? POI_ICON_MAP[FALLBACK_ICON_NAME],
+}));
+
+function POIMapImages() {
+  return (
+    <Images>
+      {iconEntries.map(({ imageId, Icon }) => (
+        <MapboxImage key={imageId} name={imageId} sdf>
+          <View style={styles.iconFrame}>
+            <Icon
+              color="#FFFFFF"
+              size={POI_MAP_ICON_IMAGE_SIZE - POI_MAP_ICON_INSET}
+              strokeWidth={POI_MAP_ICON_STROKE_WIDTH}
+            />
+          </View>
+        </MapboxImage>
+      ))}
+    </Images>
+  );
+}
+
+const styles = StyleSheet.create({
+  iconFrame: {
+    alignItems: "center",
+    backgroundColor: "transparent",
+    height: POI_MAP_ICON_IMAGE_SIZE,
+    justifyContent: "center",
+    width: POI_MAP_ICON_IMAGE_SIZE,
+  },
+});
+
+export default React.memo(POIMapImages);

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -123,6 +123,16 @@ export const POI_CATEGORIES: POICategoryMeta[] = [
   { key: "other", label: "Other", group: "other", color: "#64748B", iconName: "MapPin" },
 ];
 
+export const POI_MAP_ICON_IMAGE_SIZE = 24;
+export const POI_MAP_ICON_SYMBOL_SIZE = 0.9;
+export const POI_MAP_ICON_INSET = 8;
+export const POI_MAP_ICON_STROKE_WIDTH = 2.4;
+export const POI_MAP_ICON_PREFIX = "poi-lucide-";
+
+export function poiMapIconImageId(iconName: string): string {
+  return `${POI_MAP_ICON_PREFIX}${iconName}`;
+}
+
 export const POI_DISCOVERY_GROUPS: POIDiscoveryGroupMeta[] = [
   {
     key: "water_wc",
@@ -253,6 +263,11 @@ export function poiDiscoveryCategoriesForSource(
 
 /** How far behind the rider a POI remains visible in the list */
 export const POI_BEHIND_THRESHOLD_M = 1000;
+
+export const POI_CLUSTER_MIN_ZOOM = 8;
+export const POI_CLUSTER_MAX_ZOOM = 12;
+export const POI_CLUSTER_RADIUS = 48;
+export const POI_CLUSTER_HITBOX = 44;
 
 export const DEFAULT_CORRIDOR_WIDTH_M = 1000;
 export const MAX_CORRIDOR_WIDTH_M = 10000;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -133,6 +133,46 @@ export function poiMapIconImageId(iconName: string): string {
   return `${POI_MAP_ICON_PREFIX}${iconName}`;
 }
 
+export function poiMapIconImageIdForCategory(category: POICategory): string {
+  const meta = POI_CATEGORIES.find((c) => c.key === category);
+  return poiMapIconImageId(meta?.iconName ?? "MapPin");
+}
+
+export const POI_CLUSTER_SUMMARY_CATEGORIES = [
+  "groceries",
+  "gas_station",
+  "bakery",
+  "toilet_shower",
+  "water",
+  "shelter",
+  "bus_stop",
+  "camp_site",
+  "bike_shop",
+  "repair_station",
+  "pump_air",
+  "pharmacy",
+  "hospital_er",
+  "defibrillator",
+  "emergency_phone",
+  "ambulance_station",
+  "train_station",
+  "coffee",
+  "restaurant",
+  "bar_pub",
+  "sports",
+  "cemetery",
+  "school",
+  "other",
+] as const satisfies readonly POICategory[];
+
+export const POI_CLUSTER_SUMMARY_ICON_SYMBOL_SIZE = 0.82;
+export const POI_CLUSTER_SUMMARY_PROPERTY_PREFIX = "poi_cluster_summary_";
+export const POI_CLUSTER_SUMMARY_PRIORITY_PROPERTY = "poi_cluster_summary_priority";
+
+export function poiClusterSummaryProperty(category: POICategory): string {
+  return `${POI_CLUSTER_SUMMARY_PROPERTY_PREFIX}${category}`;
+}
+
 export const POI_DISCOVERY_GROUPS: POIDiscoveryGroupMeta[] = [
   {
     key: "water_wc",

--- a/tests/utils/poiMapFeatures.test.ts
+++ b/tests/utils/poiMapFeatures.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { poiMapIconImageId } from "@/constants";
+import {
+  POI_CLUSTER_SUMMARY_CATEGORIES,
+  POI_CLUSTER_SUMMARY_PRIORITY_PROPERTY,
+  poiClusterSummaryProperty,
+  poiMapIconImageId,
+} from "@/constants";
 import { buildPoi } from "@/tests/fixtures/poi";
-import { buildPOIMapFeatureCollections } from "@/utils/poiMapFeatures";
+import { buildPOIClusterProperties, buildPOIMapFeatureCollections } from "@/utils/poiMapFeatures";
 import type { DisplayPOI } from "@/types";
 
 function buildDisplayPoi(id: string, overrides: Parameters<typeof buildPoi>[3] = {}): DisplayPOI {
@@ -36,6 +41,7 @@ describe("buildPOIMapFeatureCollections", () => {
         category: "water",
         color: "#3B82F6",
         iconImage: poiMapIconImageId("Droplets"),
+        clusterSummaryPriority: 4,
         name: "",
         starred: 0,
       },
@@ -50,6 +56,7 @@ describe("buildPOIMapFeatureCollections", () => {
         category: "gas_station",
         color: "#F97316",
         iconImage: poiMapIconImageId("Fuel"),
+        clusterSummaryPriority: 1,
         name: "Fuel Stop",
         starred: 1,
       },
@@ -58,5 +65,29 @@ describe("buildPOIMapFeatureCollections", () => {
         coordinates: [17.2, 48.2],
       },
     });
+  });
+});
+
+describe("buildPOIClusterProperties", () => {
+  it("aggregates prioritized category counts for cluster summaries", () => {
+    const result = buildPOIClusterProperties();
+
+    expect(Object.keys(result)).toEqual([
+      POI_CLUSTER_SUMMARY_PRIORITY_PROPERTY,
+      ...POI_CLUSTER_SUMMARY_CATEGORIES.map((category) => poiClusterSummaryProperty(category)),
+    ]);
+    expect(result[POI_CLUSTER_SUMMARY_PRIORITY_PROPERTY]).toEqual([
+      "min",
+      ["get", "clusterSummaryPriority"],
+    ]);
+    expect(result[poiClusterSummaryProperty("gas_station")]).toEqual([
+      "+",
+      ["case", ["==", ["get", "category"], "gas_station"], 1, 0],
+    ]);
+    expect(POI_CLUSTER_SUMMARY_CATEGORIES.slice(0, 3)).toEqual([
+      "groceries",
+      "gas_station",
+      "bakery",
+    ]);
   });
 });

--- a/tests/utils/poiMapFeatures.test.ts
+++ b/tests/utils/poiMapFeatures.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { poiMapIconImageId } from "@/constants";
+import { buildPoi } from "@/tests/fixtures/poi";
+import { buildPOIMapFeatureCollections } from "@/utils/poiMapFeatures";
+import type { DisplayPOI } from "@/types";
+
+function buildDisplayPoi(id: string, overrides: Parameters<typeof buildPoi>[3] = {}): DisplayPOI {
+  return {
+    ...buildPoi(id, "route-1", 100, overrides),
+    effectiveDistanceMeters: 100,
+  } as DisplayPOI;
+}
+
+describe("buildPOIMapFeatureCollections", () => {
+  it("splits non-starred and starred POIs into separate feature collections", () => {
+    const regular = buildDisplayPoi("regular", {
+      category: "water",
+      name: null,
+      latitude: 48.1,
+      longitude: 17.1,
+    });
+    const starred = buildDisplayPoi("starred", {
+      category: "gas_station",
+      name: "Fuel Stop",
+      latitude: 48.2,
+      longitude: 17.2,
+    });
+
+    const result = buildPOIMapFeatureCollections([regular, starred], new Set(["starred"]));
+
+    expect(result.clustered.features).toHaveLength(1);
+    expect(result.starred.features).toHaveLength(1);
+    expect(result.clustered.features[0]).toMatchObject({
+      properties: {
+        poiId: "regular",
+        category: "water",
+        color: "#3B82F6",
+        iconImage: poiMapIconImageId("Droplets"),
+        name: "",
+        starred: 0,
+      },
+      geometry: {
+        type: "Point",
+        coordinates: [17.1, 48.1],
+      },
+    });
+    expect(result.starred.features[0]).toMatchObject({
+      properties: {
+        poiId: "starred",
+        category: "gas_station",
+        color: "#F97316",
+        iconImage: poiMapIconImageId("Fuel"),
+        name: "Fuel Stop",
+        starred: 1,
+      },
+      geometry: {
+        type: "Point",
+        coordinates: [17.2, 48.2],
+      },
+    });
+  });
+});

--- a/utils/poiMapFeatures.ts
+++ b/utils/poiMapFeatures.ts
@@ -1,14 +1,24 @@
-import { POI_CATEGORIES, poiMapIconImageId } from "@/constants";
+import {
+  POI_CATEGORIES,
+  POI_CLUSTER_SUMMARY_CATEGORIES,
+  POI_CLUSTER_SUMMARY_PRIORITY_PROPERTY,
+  poiClusterSummaryProperty,
+  poiMapIconImageIdForCategory,
+} from "@/constants";
 import type { DisplayPOI, POICategory } from "@/types";
 
 const categoryColorMap = Object.fromEntries(POI_CATEGORIES.map((c) => [c.key, c.color]));
-const categoryIconMap = Object.fromEntries(POI_CATEGORIES.map((c) => [c.key, c.iconName]));
+const categorySummaryPriorityMap = Object.fromEntries(
+  POI_CLUSTER_SUMMARY_CATEGORIES.map((category, index) => [category, index]),
+);
+const fallbackSummaryPriority = POI_CLUSTER_SUMMARY_CATEGORIES.length;
 
 export interface POIMapFeatureProperties {
   poiId: string;
   category: POICategory;
   color: string;
   iconImage: string;
+  clusterSummaryPriority: number;
   name: string;
   starred: 0 | 1;
 }
@@ -40,7 +50,8 @@ export function buildPOIMapFeature(poi: DisplayPOI, starred: boolean): POIMapFea
       poiId: poi.id,
       category: poi.category,
       color,
-      iconImage: poiMapIconImageId(categoryIconMap[poi.category] ?? "MapPin"),
+      iconImage: poiMapIconImageIdForCategory(poi.category),
+      clusterSummaryPriority: clusterSummaryPriorityForCategory(poi.category),
       name: poi.name ?? "",
       starred: starred ? 1 : 0,
     },
@@ -49,6 +60,22 @@ export function buildPOIMapFeature(poi: DisplayPOI, starred: boolean): POIMapFea
       coordinates: [poi.longitude, poi.latitude],
     },
   };
+}
+
+export function buildPOIClusterProperties(): Record<string, unknown[]> {
+  return {
+    [POI_CLUSTER_SUMMARY_PRIORITY_PROPERTY]: ["min", ["get", "clusterSummaryPriority"]],
+    ...Object.fromEntries(
+      POI_CLUSTER_SUMMARY_CATEGORIES.map((category) => [
+        poiClusterSummaryProperty(category),
+        ["+", ["case", ["==", ["get", "category"], category], 1, 0]],
+      ]),
+    ),
+  };
+}
+
+function clusterSummaryPriorityForCategory(category: POICategory): number {
+  return categorySummaryPriorityMap[category] ?? fallbackSummaryPriority;
 }
 
 export function buildPOIMapFeatureCollections(

--- a/utils/poiMapFeatures.ts
+++ b/utils/poiMapFeatures.ts
@@ -1,0 +1,72 @@
+import { POI_CATEGORIES, poiMapIconImageId } from "@/constants";
+import type { DisplayPOI, POICategory } from "@/types";
+
+const categoryColorMap = Object.fromEntries(POI_CATEGORIES.map((c) => [c.key, c.color]));
+const categoryIconMap = Object.fromEntries(POI_CATEGORIES.map((c) => [c.key, c.iconName]));
+
+export interface POIMapFeatureProperties {
+  poiId: string;
+  category: POICategory;
+  color: string;
+  iconImage: string;
+  name: string;
+  starred: 0 | 1;
+}
+
+export type POIMapFeature = GeoJSON.Feature<GeoJSON.Point, POIMapFeatureProperties>;
+export type POIMapFeatureCollection = GeoJSON.FeatureCollection<
+  GeoJSON.Point,
+  POIMapFeatureProperties
+>;
+
+export interface POIMapFeatureCollections {
+  clustered: POIMapFeatureCollection;
+  starred: POIMapFeatureCollection;
+}
+
+function emptyFeatureCollection(): POIMapFeatureCollection {
+  return {
+    type: "FeatureCollection",
+    features: [],
+  };
+}
+
+export function buildPOIMapFeature(poi: DisplayPOI, starred: boolean): POIMapFeature {
+  const color = categoryColorMap[poi.category] ?? "#888888";
+
+  return {
+    type: "Feature",
+    properties: {
+      poiId: poi.id,
+      category: poi.category,
+      color,
+      iconImage: poiMapIconImageId(categoryIconMap[poi.category] ?? "MapPin"),
+      name: poi.name ?? "",
+      starred: starred ? 1 : 0,
+    },
+    geometry: {
+      type: "Point",
+      coordinates: [poi.longitude, poi.latitude],
+    },
+  };
+}
+
+export function buildPOIMapFeatureCollections(
+  pois: DisplayPOI[],
+  starredPOIIds: ReadonlySet<string>,
+): POIMapFeatureCollections {
+  const clustered = emptyFeatureCollection();
+  const starred = emptyFeatureCollection();
+
+  for (const poi of pois) {
+    const isStarred = starredPOIIds.has(poi.id);
+    const feature = buildPOIMapFeature(poi, isStarred);
+    if (isStarred) {
+      starred.features.push(feature);
+    } else {
+      clustered.features.push(feature);
+    }
+  }
+
+  return { clustered, starred };
+}


### PR DESCRIPTION
## Summary

- Add Mapbox ShapeSource clustering for non-starred POIs while keeping starred POIs rendered individually above clusters.
- Register Lucide POI icons as Mapbox images and render them on normal/starred POI markers.
- Replace cluster counts with a category-summary marker: the cluster shows the highest-priority category icon and a small `+` when multiple category types are present.

## Why

Dense POI areas were hard to scan and individual POI colors were not enough to distinguish useful stop types. This keeps the map calmer at low zoom while surfacing the kind of stop opportunity inside a cluster.

## Notes

Cluster category priority is tuned for race use: groceries, gas stations, bakeries, toilets/showers, then water. Starred/custom POIs stay outside clusters so saved stops remain tappable.

## Verification

- `npx tsc --noEmit`
- `npm test`
- `npm run lint`
- `npm run format:check`