### PR TITLE
[codex] Backport starred POI export

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,6 +12,7 @@ import "../global.css";
 import { useOfflineStore } from "@/store/offlineStore";
 import { useRouteStore } from "@/store/routeStore";
 import { useCollectionStore } from "@/store/collectionStore";
+import { usePoiStore } from "@/store/poiStore";
 import { COLORS } from "@/theme";
 
 export { ErrorBoundary } from "expo-router";
@@ -77,6 +78,10 @@ export default function RootLayout() {
       .getState()
       .loadCollectionMetadata()
       .catch((e) => console.warn("Collection prefetch failed:", e));
+    usePoiStore
+      .getState()
+      .loadStarredItems()
+      .catch((e) => console.warn("Starred POI prefetch failed:", e));
   }, []);
 
   // Re-detect climbs if algorithm version changed

--- a/app/collection/[id].tsx
+++ b/app/collection/[id].tsx
@@ -3,6 +3,7 @@ import { View, useWindowDimensions, ActivityIndicator, Alert } from "react-nativ
 import { NestableScrollContainer } from "react-native-draggable-flatlist";
 import { useLocalSearchParams, useRouter, Stack } from "expo-router";
 import { Camera, MapView as MapboxMapView } from "@rnmapbox/maps";
+import { Share2 } from "lucide-react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { useThemeColors } from "@/theme";
@@ -24,6 +25,8 @@ import AddSegmentSheet from "@/components/collection/AddSegmentSheet";
 import CollectionOfflineSection from "@/components/collection/CollectionOfflineSection";
 import AddSavedPOISheet from "@/components/poi/AddSavedPOISheet";
 import type { SavedPOITarget } from "@/services/savedPOIService";
+import { serializeCollectionToGPX } from "@/services/gpxSerializer";
+import { shareGPXFile } from "@/utils/gpxExportShare";
 
 export default function CollectionDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -39,6 +42,7 @@ export default function CollectionDetailScreen() {
   const [stitched, setStitched] = useState<StitchedCollection | null>(null);
   const [loading, setLoading] = useState(true);
   const [isBusy, setIsBusy] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
   const [showAddSheet, setShowAddSheet] = useState(false);
   const [showAddPOI, setShowAddPOI] = useState(false);
 
@@ -246,6 +250,21 @@ export default function CollectionDetailScreen() {
     return stitchPOIs(stitched.segments, poisByRoute);
   }, [stitched, poisByRouteId, starredPOIIds]);
 
+  const handleExportGPX = useCallback(async () => {
+    if (!collection || !stitched) return;
+    setIsExporting(true);
+    try {
+      const gpx = serializeCollectionToGPX(collection.name, stitched, {
+        poisAsWaypoints: collectionPOIs,
+      });
+      await shareGPXFile(gpx, collection.name);
+    } catch {
+      Alert.alert("Export Failed", "Could not export this collection as GPX.");
+    } finally {
+      setIsExporting(false);
+    }
+  }, [collection, stitched, collectionPOIs]);
+
   const savedPOITargets = useMemo<SavedPOITarget[]>(() => {
     if (!stitched) return [];
     return stitched.segments
@@ -372,8 +391,14 @@ export default function CollectionDetailScreen() {
         </View>
 
         {stitched && stitched.segments.length > 0 && (
-          <View className="px-4 mt-3">
+          <View className="px-4 mt-3 gap-3">
             <Button variant="secondary" onPress={() => setShowAddPOI(true)} label="Add POI" />
+            <Button variant="secondary" onPress={handleExportGPX} disabled={isExporting}>
+              <Share2 size={18} color={colors.accent} />
+              <Text className="ml-2 text-primary font-barlow-semibold text-[15px]">
+                {isExporting ? "Exporting..." : "Export GPX"}
+              </Text>
+            </Button>
           </View>
         )}
 

--- a/app/route/[id].tsx
+++ b/app/route/[id].tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useState, useMemo, useRef } from "react";
-import { View, ScrollView, useWindowDimensions, ActivityIndicator } from "react-native";
+import { View, ScrollView, useWindowDimensions, ActivityIndicator, Alert } from "react-native";
 import { useLocalSearchParams, Stack } from "expo-router";
 import { Camera, MapView as MapboxMapView } from "@rnmapbox/maps";
+import { Share2 } from "lucide-react-native";
 import { Text } from "@/components/ui/text";
 import { Button } from "@/components/ui/button";
 import { useThemeColors } from "@/theme";
@@ -26,6 +27,8 @@ import StatBox from "@/components/common/StatBox";
 import DataSection from "@/components/route/DataSection";
 import AddSavedPOISheet from "@/components/poi/AddSavedPOISheet";
 import type { SavedPOITarget } from "@/services/savedPOIService";
+import { serializeRouteToGPX } from "@/services/gpxSerializer";
+import { shareGPXFile } from "@/utils/gpxExportShare";
 
 const EMPTY_CLIMBS: Climb[] = [];
 
@@ -40,6 +43,7 @@ export default function RouteDetailScreen() {
   const [route, setRoute] = useState<RouteWithPoints | null>(null);
   const [loading, setLoading] = useState(true);
   const [showAddPOI, setShowAddPOI] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
 
   const getRouteDetail = useRouteStore((s) => s.getRouteDetail);
   const snappedPosition = useRouteStore((s) => s.snappedPosition);
@@ -111,6 +115,19 @@ export default function RouteDetailScreen() {
     },
     [updateRouteGeometryZoom],
   );
+
+  const handleExportGPX = useCallback(async () => {
+    if (!route) return;
+    setIsExporting(true);
+    try {
+      const gpx = serializeRouteToGPX(route, { poisAsWaypoints: chartPOIs });
+      await shareGPXFile(gpx, route.name);
+    } catch {
+      Alert.alert("Export Failed", "Could not export this route as GPX.");
+    } finally {
+      setIsExporting(false);
+    }
+  }, [route, chartPOIs]);
 
   if (loading) {
     return (
@@ -201,8 +218,14 @@ export default function RouteDetailScreen() {
           />
         </View>
 
-        <View className="px-4 mt-4">
+        <View className="px-4 mt-4 gap-3">
           <Button variant="secondary" onPress={() => setShowAddPOI(true)} label="Add POI" />
+          <Button variant="secondary" onPress={handleExportGPX} disabled={isExporting}>
+            <Share2 size={18} color={colors.accent} />
+            <Text className="ml-2 text-primary font-barlow-semibold text-[15px]">
+              {isExporting ? "Exporting..." : "Export GPX"}
+            </Text>
+          </Button>
         </View>
 
         {/* Data: Map tiles, Google Places, OSM */}

--- a/db/database.ts
+++ b/db/database.ts
@@ -272,11 +272,21 @@ export async function deletePOIsForRoute(routeId: string): Promise<void> {
   });
 }
 
-export async function deletePOIsBySource(routeId: string, source: POISource): Promise<void> {
+interface DeletePOIsBySourceOptions {
+  deleteStarredItems?: boolean;
+}
+
+export async function deletePOIsBySource(
+  routeId: string,
+  source: POISource,
+  options: DeletePOIsBySourceOptions = {},
+): Promise<void> {
   const where = and(eq(pois.routeId, routeId), eq(pois.source, source));
-  const poiIds = db.select({ id: pois.id }).from(pois).where(where).all();
+  const poiIds = options.deleteStarredItems
+    ? db.select({ id: pois.id }).from(pois).where(where).all()
+    : [];
   db.transaction((tx) => {
-    if (poiIds.length > 0) {
+    if (options.deleteStarredItems && poiIds.length > 0) {
       tx.delete(starredItems)
         .where(
           and(

--- a/db/database.ts
+++ b/db/database.ts
@@ -2,7 +2,15 @@ import { drizzle } from "drizzle-orm/expo-sqlite";
 import { migrate } from "drizzle-orm/expo-sqlite/migrator";
 import { openDatabaseSync } from "expo-sqlite";
 import { sql, eq, and, inArray, desc, asc, count, max } from "drizzle-orm";
-import { routes, routePoints, pois, collections, collectionSegments, climbs } from "./schema";
+import {
+  routes,
+  routePoints,
+  pois,
+  starredItems,
+  collections,
+  collectionSegments,
+  climbs,
+} from "./schema";
 import migrations from "../drizzle/migrations";
 import type {
   Route,
@@ -11,6 +19,8 @@ import type {
   POI,
   POICategory,
   POISource,
+  StarredEntityType,
+  StarredItem,
   Collection,
   CollectionSegment,
   Climb,
@@ -23,7 +33,7 @@ expoDb.execSync("PRAGMA journal_mode = WAL;");
 expoDb.execSync("PRAGMA foreign_keys = ON;");
 
 export const db = drizzle(expoDb, {
-  schema: { routes, routePoints, pois, collections, collectionSegments, climbs },
+  schema: { routes, routePoints, pois, starredItems, collections, collectionSegments, climbs },
 });
 
 // Apply schema from drizzle/migrations.ts (generated from db/schema.ts via `npm run db:migrate`)
@@ -140,8 +150,25 @@ export async function getRoutePoints(routeId: string): Promise<RoutePoint[]> {
 }
 
 export async function deleteRoute(routeId: string): Promise<void> {
-  // Foreign keys with ON DELETE CASCADE handle route_points, pois, and race_segments
-  db.delete(routes).where(eq(routes.id, routeId)).run();
+  // Foreign keys with ON DELETE CASCADE handle route_points, pois, climbs, and collection_segments.
+  // Starred items are generic, so explicitly remove stars for this route's POIs first.
+  const poiIds = db.select({ id: pois.id }).from(pois).where(eq(pois.routeId, routeId)).all();
+  db.transaction((tx) => {
+    if (poiIds.length > 0) {
+      tx.delete(starredItems)
+        .where(
+          and(
+            eq(starredItems.entityType, "poi"),
+            inArray(
+              starredItems.entityId,
+              poiIds.map((row) => row.id),
+            ),
+          ),
+        )
+        .run();
+    }
+    tx.delete(routes).where(eq(routes.id, routeId)).run();
+  });
 }
 
 export async function updateRouteVisibility(routeId: string, isVisible: boolean): Promise<void> {
@@ -226,13 +253,44 @@ export async function getPOIsForRoute(
 }
 
 export async function deletePOIsForRoute(routeId: string): Promise<void> {
-  db.delete(pois).where(eq(pois.routeId, routeId)).run();
+  const poiIds = db.select({ id: pois.id }).from(pois).where(eq(pois.routeId, routeId)).all();
+  db.transaction((tx) => {
+    if (poiIds.length > 0) {
+      tx.delete(starredItems)
+        .where(
+          and(
+            eq(starredItems.entityType, "poi"),
+            inArray(
+              starredItems.entityId,
+              poiIds.map((row) => row.id),
+            ),
+          ),
+        )
+        .run();
+    }
+    tx.delete(pois).where(eq(pois.routeId, routeId)).run();
+  });
 }
 
 export async function deletePOIsBySource(routeId: string, source: POISource): Promise<void> {
-  db.delete(pois)
-    .where(and(eq(pois.routeId, routeId), eq(pois.source, source)))
-    .run();
+  const where = and(eq(pois.routeId, routeId), eq(pois.source, source));
+  const poiIds = db.select({ id: pois.id }).from(pois).where(where).all();
+  db.transaction((tx) => {
+    if (poiIds.length > 0) {
+      tx.delete(starredItems)
+        .where(
+          and(
+            eq(starredItems.entityType, "poi"),
+            inArray(
+              starredItems.entityId,
+              poiIds.map((row) => row.id),
+            ),
+          ),
+        )
+        .run();
+    }
+    tx.delete(pois).where(where).run();
+  });
 }
 
 export async function updatePOITags(poiId: string, tags: Record<string, string>): Promise<void> {
@@ -240,7 +298,12 @@ export async function updatePOITags(poiId: string, tags: Record<string, string>)
 }
 
 export async function deletePOI(poiId: string): Promise<void> {
-  db.delete(pois).where(eq(pois.id, poiId)).run();
+  db.transaction((tx) => {
+    tx.delete(starredItems)
+      .where(and(eq(starredItems.entityType, "poi"), eq(starredItems.entityId, poiId)))
+      .run();
+    tx.delete(pois).where(eq(pois.id, poiId)).run();
+  });
 }
 
 export async function hasPOIsForRoute(routeId: string): Promise<boolean> {
@@ -265,6 +328,39 @@ export async function getPOICountsBySource(
     else if (row.source === "osm") osm += row.cnt;
   }
   return { osm, google };
+}
+
+// --- Starred Item CRUD ---
+
+export async function getStarredItems(entityType?: StarredEntityType): Promise<StarredItem[]> {
+  if (entityType) {
+    return db
+      .select()
+      .from(starredItems)
+      .where(eq(starredItems.entityType, entityType))
+      .orderBy(asc(starredItems.createdAt))
+      .all();
+  }
+
+  return db.select().from(starredItems).orderBy(asc(starredItems.createdAt)).all();
+}
+
+export async function setStarredItem(
+  entityType: StarredEntityType,
+  entityId: string,
+  starred: boolean,
+): Promise<void> {
+  if (starred) {
+    db.insert(starredItems)
+      .values({ entityType, entityId, createdAt: new Date().toISOString() })
+      .onConflictDoNothing()
+      .run();
+    return;
+  }
+
+  db.delete(starredItems)
+    .where(and(eq(starredItems.entityType, entityType), eq(starredItems.entityId, entityId)))
+    .run();
 }
 
 // --- Climb CRUD ---

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -7,7 +7,7 @@ import {
   unique,
   primaryKey,
 } from "drizzle-orm/sqlite-core";
-import type { POICategory, POISource } from "@/types";
+import type { POICategory, POISource, StarredEntityType } from "@/types";
 
 // --- Climbs ---
 
@@ -90,6 +90,18 @@ export const pois = sqliteTable(
     index("idx_pois_route_source").on(table.routeId, table.source),
     unique("uq_pois_route_source").on(table.routeId, table.sourceId),
   ],
+);
+
+// --- Starred Items ---
+
+export const starredItems = sqliteTable(
+  "starred_items",
+  {
+    entityType: text("entityType").notNull().$type<StarredEntityType>(),
+    entityId: text("entityId").notNull(),
+    createdAt: text("createdAt").notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.entityType, table.entityId] })],
 );
 
 // --- Collections ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,6 +60,20 @@ type POICategory =
   | "other";
 ```
 
+### Starred Items
+
+```typescript
+type StarredEntityType = "poi";
+
+interface StarredItem {
+  entityType: StarredEntityType;
+  entityId: string;
+  createdAt: string;
+}
+```
+
+Starred POIs are stored in SQLite in `starred_items`, not only in MMKV. The app still keeps an in-memory `starredPOIIds` set in `poiStore` for fast rendering and map/list reactivity. Existing MMKV `starredPOIIds` values are migrated into SQLite on app startup.
+
 ### Power Model
 
 ```typescript
@@ -92,6 +106,7 @@ ETA computation: for each route segment, solve `P = (Crr × m × g × cos(θ) + 
 - Stored in SQLite with spatial indexing
 - ~1–5 MB per 1000 km route corridor
 - Saved custom POIs use `source: "custom"` and store notes, Google place IDs, and Google Maps links in `tags`. They can be created from the iOS share sheet or manual coordinates, and are not removed by clearing or refetching fetched OSM/Google data.
+- Starred fetched/custom POIs are stored separately in SQLite so they persist across app restarts and can be exported.
 
 ### Elevation Data
 
@@ -143,3 +158,7 @@ For standalone routes, effective distance equals raw distance. For collections, 
 ### Climb Detection
 
 Runs on import, stored per-route. Algorithm: smooth elevation (200m window), find rising segments with dip absorption (descent < 20% of accumulated gain), qualify (50m+ gain, 2.5%+ avg gradient). Difficulty: Climbbybike method (gradient² × length, summed). For stitched collections, cross-segment climbs are merged at display time.
+
+### GPX Export
+
+Routes and stitched collections export as GPX 1.1 tracks. Starred POIs and saved custom POIs can be included as GPX `<wpt>` entries, but they are emitted as on-route cue points interpolated from `DisplayPOI.effectiveDistanceMeters`, not as an imported route-waypoint data model. The waypoint name keeps the POI name/category and off-route distance; the description keeps the actual POI coordinates and available notes/address context.

--- a/docs/features.md
+++ b/docs/features.md
@@ -54,7 +54,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - FULL horizon switches riding POI views to full-route planning
 - POI list sorted by distance along route
 - POI text search (filter by name)
-- Starred POIs
+- Starred POIs persisted in SQLite
 - Saved custom POIs from iOS share sheet or manual coordinates, route-scoped and starred by default
 - Opening hours: open/closed status, color-coded, "open now" filter
 - Category filters (multi-select)
@@ -83,3 +83,9 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - "Prepare for offline" per route/collection
 - Storage management — space used per route, cleanup
 - All features except weather work fully offline
+
+## Export
+
+- Export standalone routes and stitched collections as GPX tracks
+- Include starred and saved custom POIs as on-route GPX waypoint cues for bike-computer workflows
+- Share exported GPX files through the native iOS share sheet

--- a/drizzle/0002_add_starred_items.sql
+++ b/drizzle/0002_add_starred_items.sql
@@ -1,0 +1,6 @@
+CREATE TABLE `starred_items` (
+	`entityType` text NOT NULL,
+	`entityId` text NOT NULL,
+	`createdAt` text NOT NULL,
+	PRIMARY KEY(`entityType`, `entityId`)
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1774960400000,
       "tag": "0001_add_climbs",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1777986756000,
+      "tag": "0002_add_starred_items",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.ts
+++ b/drizzle/migrations.ts
@@ -6,6 +6,7 @@ export default {
     entries: [
       { idx: 0, when: 1774960304141, tag: "0000_misty_true_believers", breakpoints: true },
       { idx: 1, when: 1774960400000, tag: "0001_add_climbs", breakpoints: true },
+      { idx: 2, when: 1777986756000, tag: "0002_add_starred_items", breakpoints: true },
     ],
   },
   migrations: {
@@ -88,6 +89,13 @@ CREATE TABLE \`routes\` (
 );
 --> statement-breakpoint
 CREATE INDEX \`idx_climbs_route_distance\` ON \`climbs\` (\`routeId\`,\`startDistanceMeters\`);
+`,
+    m0002: `CREATE TABLE \`starred_items\` (
+	\`entityType\` text NOT NULL,
+	\`entityId\` text NOT NULL,
+	\`createdAt\` text NOT NULL,
+	PRIMARY KEY(\`entityType\`, \`entityId\`)
+);
 `,
   },
 };

--- a/services/gpxSerializer.ts
+++ b/services/gpxSerializer.ts
@@ -1,0 +1,163 @@
+import { POI_CATEGORIES } from "@/constants";
+import type {
+  DisplayPOI,
+  POICategory,
+  RoutePoint,
+  RouteWithPoints,
+  StitchedCollection,
+} from "@/types";
+import { interpolateRoutePointAtDistance } from "@/utils/geo";
+
+export interface GPXSerializerOptions {
+  poisAsWaypoints?: DisplayPOI[];
+}
+
+const POI_WAYPOINT_SYMBOLS: Record<POICategory, string> = {
+  water: "Water",
+  groceries: "Food",
+  gas_station: "Food",
+  bakery: "Food",
+  coffee: "Cafe",
+  restaurant: "Restaurant",
+  bar_pub: "Water",
+  toilet_shower: "Generic",
+  shelter: "Camping",
+  bus_stop: "Camping",
+  camp_site: "Camping",
+  pharmacy: "Generic",
+  hospital_er: "Generic",
+  defibrillator: "Generic",
+  emergency_phone: "Generic",
+  ambulance_station: "Generic",
+  bike_shop: "Generic",
+  repair_station: "Generic",
+  pump_air: "Generic",
+  train_station: "Generic",
+  sports: "Camping",
+  cemetery: "Water",
+  school: "Camping",
+  other: "Generic",
+};
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function formatCoordinate(value: number): string {
+  return Number(value.toFixed(6)).toString();
+}
+
+function serializeTrackPoint(point: RoutePoint): string {
+  const attributes = `lat="${formatCoordinate(point.latitude)}" lon="${formatCoordinate(point.longitude)}"`;
+
+  if (point.elevationMeters == null) {
+    return `      <trkpt ${attributes} />`;
+  }
+
+  return `      <trkpt ${attributes}>\n        <ele>${point.elevationMeters}</ele>\n      </trkpt>`;
+}
+
+function getPoiCategoryLabel(category: POICategory): string {
+  return POI_CATEGORIES.find((meta) => meta.key === category)?.label ?? "POI";
+}
+
+function formatOffRouteDistance(distanceMeters: number): string {
+  if (distanceMeters >= 1000) {
+    return `${(distanceMeters / 1000).toFixed(1)} km off route`;
+  }
+
+  return `${Math.round(distanceMeters)} m off route`;
+}
+
+function buildWaypointDescription(poi: DisplayPOI): string {
+  const parts = [
+    `${getPoiCategoryLabel(poi.category)} stop`,
+    `Off route: ${Math.round(poi.distanceFromRouteMeters)} m`,
+    `POI coordinates: ${formatCoordinate(poi.latitude)}, ${formatCoordinate(poi.longitude)}`,
+  ];
+
+  const notes = poi.tags.notes?.trim();
+  if (notes) parts.push(`Notes: ${notes}`);
+
+  const address = poi.tags.formatted_address?.trim();
+  if (address) parts.push(`Address: ${address}`);
+
+  return parts.join("; ");
+}
+
+function serializePOIWaypoint(poi: DisplayPOI, points: RoutePoint[]): string | null {
+  const cuePoint = interpolateRoutePointAtDistance(points, poi.effectiveDistanceMeters);
+  if (!cuePoint) return null;
+
+  const categoryLabel = getPoiCategoryLabel(poi.category);
+  const offRouteSuffix =
+    poi.distanceFromRouteMeters > 0
+      ? ` (${formatOffRouteDistance(poi.distanceFromRouteMeters)})`
+      : "";
+  const name = `${poi.name ?? categoryLabel}${offRouteSuffix}`;
+  const symbol = POI_WAYPOINT_SYMBOLS[poi.category] ?? "Generic";
+
+  return [
+    `  <wpt lat="${formatCoordinate(cuePoint.latitude)}" lon="${formatCoordinate(cuePoint.longitude)}">`,
+    `    <name>${escapeXml(name)}</name>`,
+    `    <desc>${escapeXml(buildWaypointDescription(poi))}</desc>`,
+    `    <sym>${escapeXml(symbol)}</sym>`,
+    `    <type>${escapeXml(symbol)}</type>`,
+    "  </wpt>",
+  ].join("\n");
+}
+
+function serializeWaypoints(points: RoutePoint[], options: GPXSerializerOptions): string {
+  const waypoints = (options.poisAsWaypoints ?? [])
+    .map((poi) => serializePOIWaypoint(poi, points))
+    .filter((waypoint): waypoint is string => waypoint != null);
+
+  return waypoints.length > 0 ? `${waypoints.join("\n")}\n` : "";
+}
+
+function serializeTrackGPX(
+  name: string,
+  points: RoutePoint[],
+  options: GPXSerializerOptions = {},
+): string {
+  const trackPoints = points.map(serializeTrackPoint).join("\n");
+  const waypoints = serializeWaypoints(points, options);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="Ultra Companion" xmlns="http://www.topografix.com/GPX/1/1">
+${waypoints}  <trk>
+    <name>${escapeXml(name)}</name>
+    <trkseg>
+${trackPoints}
+    </trkseg>
+  </trk>
+</gpx>`;
+}
+
+export function serializeRouteToGPX(
+  route: RouteWithPoints,
+  options: GPXSerializerOptions = {},
+): string {
+  if (route.points.length === 0) {
+    throw new Error("Cannot serialize GPX for route with no points");
+  }
+
+  return serializeTrackGPX(route.name, route.points, options);
+}
+
+export function serializeCollectionToGPX(
+  collectionName: string,
+  collection: StitchedCollection,
+  options: GPXSerializerOptions = {},
+): string {
+  if (collection.points.length === 0) {
+    throw new Error("Cannot serialize GPX for collection with no points");
+  }
+
+  return serializeTrackGPX(collectionName, collection.points, options);
+}

--- a/store/poiStore.ts
+++ b/store/poiStore.ts
@@ -400,7 +400,7 @@ export const usePoiStore = create<POIState>((set, get) => ({
 
   clearSource: async (routeId, source) => {
     nextFetchGeneration(routeId, source);
-    await deletePOIsBySource(routeId, source);
+    await deletePOIsBySource(routeId, source, { deleteStarredItems: true });
     clearSourceInfo(routeId, source);
 
     // Reload remaining POIs
@@ -578,8 +578,8 @@ export const usePoiStore = create<POIState>((set, get) => ({
 
   clearPOIs: async (routeId) => {
     invalidateRouteFetches(routeId);
-    await deletePOIsBySource(routeId, "google");
-    await deletePOIsBySource(routeId, "osm");
+    await deletePOIsBySource(routeId, "google", { deleteStarredItems: true });
+    await deletePOIsBySource(routeId, "osm", { deleteStarredItems: true });
     clearSourceInfo(routeId, "osm");
     clearSourceInfo(routeId, "google");
     const pois = await getPOIsForRoute(routeId);

--- a/store/poiStore.ts
+++ b/store/poiStore.ts
@@ -22,10 +22,14 @@ import {
   insertPOIs,
   updatePOITags,
   deletePOI,
+  getStarredItems,
+  setStarredItem,
 } from "@/db/database";
 import { fetchOsmPOIs, fetchGooglePOIs } from "@/services/poiFetcher";
 import { getOpeningHoursStatus } from "@/services/openingHoursParser";
 import { usePanelStore } from "./panelStore";
+
+const LEGACY_STARRED_POI_IDS_KEY = "starredPOIIds";
 
 let storage: MMKV | null = null;
 
@@ -204,11 +208,6 @@ function buildRouteScrubPatch(
   const removedIds = new Set((removed ?? []).map((p) => p.id));
   const nextStarred = new Set([...s.starredPOIIds].filter((id) => !removedIds.has(id)));
   const starredChanged = nextStarred.size !== s.starredPOIIds.size;
-  if (starredChanged) {
-    try {
-      getStorage().set("starredPOIIds", JSON.stringify([...nextStarred]));
-    } catch {}
-  }
 
   let sourceInfo: typeof s.sourceInfo;
   if (mode === "remove") {
@@ -247,6 +246,7 @@ interface POIState {
   selectedPOI: DisplayPOI | null;
 
   // Actions
+  loadStarredItems: () => Promise<void>;
   loadPOIs: (routeId: string) => Promise<void>;
   fetchSource: (
     routeId: string,
@@ -266,7 +266,8 @@ interface POIState {
   setCorridorWidth: (widthM: number) => void;
   setAllCategories: (enabled: boolean) => void;
   toggleShowOpenOnly: () => void;
-  toggleStarred: (poiId: string) => void;
+  setStarred: (poiId: string, starred: boolean) => Promise<void>;
+  toggleStarred: (poiId: string) => Promise<void>;
   isStarred: (poiId: string) => boolean;
   getStarredPOIs: (routeId: string) => POI[];
   clearPOIs: (routeId: string) => Promise<void>;
@@ -287,9 +288,28 @@ export const usePoiStore = create<POIState>((set, get) => ({
   discoveryCategories: parseDiscoveryCategories(readString("discoveryCategories")),
   corridorWidthM: Number(readString("corridorWidthM")) || DEFAULT_CORRIDOR_WIDTH_M,
   showOpenOnly: readString("showOpenOnly") === "true",
-  starredPOIIds: parseStarredIds(readString("starredPOIIds")),
+  starredPOIIds: parseStarredIds(readString(LEGACY_STARRED_POI_IDS_KEY)),
   sourceInfo: {},
   selectedPOI: null,
+
+  loadStarredItems: async () => {
+    const legacyStarredIds = parseStarredIds(readString(LEGACY_STARRED_POI_IDS_KEY));
+    if (legacyStarredIds.size > 0) {
+      try {
+        for (const poiId of legacyStarredIds) {
+          await setStarredItem("poi", poiId, true);
+        }
+        getStorage().remove(LEGACY_STARRED_POI_IDS_KEY);
+      } catch (error) {
+        console.warn("Failed to migrate legacy starred POIs:", error);
+      }
+    }
+
+    const items = await getStarredItems("poi");
+    set({
+      starredPOIIds: new Set([...items.map((item) => item.entityId), ...legacyStarredIds]),
+    });
+  },
 
   loadPOIs: async (routeId) => {
     // Read from DB to derive counts. Merge with in-memory sourceInfo so we
@@ -388,9 +408,15 @@ export const usePoiStore = create<POIState>((set, get) => ({
     set((s) => {
       const droppedSelection =
         s.selectedPOI?.routeId === routeId && s.selectedPOI?.source === source;
+      const currentRoutePois = s.pois[routeId] ?? [];
+      const removedIds = new Set(
+        currentRoutePois.filter((p) => p.source === source).map((p) => p.id),
+      );
+      const nextStarred = new Set([...s.starredPOIIds].filter((id) => !removedIds.has(id)));
       return {
         pois: { ...s.pois, [routeId]: pois },
         selectedPOI: droppedSelection ? null : s.selectedPOI,
+        starredPOIIds: nextStarred,
         sourceInfo: {
           ...s.sourceInfo,
           [routeId]: {
@@ -404,12 +430,10 @@ export const usePoiStore = create<POIState>((set, get) => ({
 
   addCustomPOI: async (poi) => {
     await insertPOIs([poi]);
+    await setStarredItem("poi", poi.id, true);
     const pois = await getPOIsForRoute(poi.routeId);
     set((s) => {
       const nextStarred = new Set([...s.starredPOIIds, poi.id]);
-      try {
-        getStorage().set("starredPOIIds", JSON.stringify([...nextStarred]));
-      } catch {}
       return {
         pois: { ...s.pois, [poi.routeId]: pois },
         starredPOIIds: nextStarred,
@@ -446,9 +470,6 @@ export const usePoiStore = create<POIState>((set, get) => ({
     set((s) => {
       const nextStarred = new Set(s.starredPOIIds);
       nextStarred.delete(poiId);
-      try {
-        getStorage().set("starredPOIIds", JSON.stringify([...nextStarred]));
-      } catch {}
       return {
         pois: { ...s.pois, [routeId]: pois },
         starredPOIIds: nextStarred,
@@ -523,18 +544,27 @@ export const usePoiStore = create<POIState>((set, get) => ({
     set({ showOpenOnly: next });
   },
 
-  toggleStarred: (poiId) => {
-    const current = get().starredPOIIds;
-    const next = new Set(current);
-    if (next.has(poiId)) {
-      next.delete(poiId);
-    } else {
-      next.add(poiId);
-    }
-    try {
-      getStorage().set("starredPOIIds", JSON.stringify([...next]));
-    } catch {}
+  setStarred: async (poiId, starred) => {
+    const previous = get().starredPOIIds;
+    const next = new Set(previous);
+    if (starred) next.add(poiId);
+    else next.delete(poiId);
+
     set({ starredPOIIds: next });
+    try {
+      await setStarredItem("poi", poiId, starred);
+    } catch (error) {
+      set({ starredPOIIds: previous });
+      throw error;
+    }
+  },
+
+  toggleStarred: async (poiId) => {
+    try {
+      await get().setStarred(poiId, !get().isStarred(poiId));
+    } catch (error) {
+      console.warn("Failed to update starred POI:", error);
+    }
   },
 
   isStarred: (poiId) => get().starredPOIIds.has(poiId),
@@ -559,9 +589,6 @@ export const usePoiStore = create<POIState>((set, get) => ({
         currentRoutePois.filter((p) => p.source !== "custom").map((p) => p.id),
       );
       const nextStarred = new Set([...s.starredPOIIds].filter((id) => !removedIds.has(id)));
-      try {
-        getStorage().set("starredPOIIds", JSON.stringify([...nextStarred]));
-      } catch {}
       const selectedPOI =
         s.selectedPOI?.routeId === routeId && s.selectedPOI.source !== "custom"
           ? null

--- a/tests/mocks/database.ts
+++ b/tests/mocks/database.ts
@@ -9,12 +9,14 @@ import type {
   getCollectionSegments,
   getPOICountsBySource,
   getPOIsForRoute,
+  getStarredItems,
   getRoute,
   getRoutePoints,
   getRouteWithPoints,
   insertPOIs,
   insertRoute,
   setActiveRoute,
+  setStarredItem,
   updateClimbName,
   updatePOITags,
   updateRouteVisibility,
@@ -30,12 +32,14 @@ export const databaseMocks = {
   getCollectionSegments: vi.fn<typeof getCollectionSegments>(),
   getPOICountsBySource: vi.fn<typeof getPOICountsBySource>(),
   getPOIsForRoute: vi.fn<typeof getPOIsForRoute>(),
+  getStarredItems: vi.fn<typeof getStarredItems>(),
   getRoute: vi.fn<typeof getRoute>(),
   getRoutePoints: vi.fn<typeof getRoutePoints>(),
   getRouteWithPoints: vi.fn<typeof getRouteWithPoints>(),
   insertPOIs: vi.fn<typeof insertPOIs>(),
   insertRoute: vi.fn<typeof insertRoute>(),
   setActiveRoute: vi.fn<typeof setActiveRoute>(),
+  setStarredItem: vi.fn<typeof setStarredItem>(),
   updateClimbName: vi.fn<typeof updateClimbName>(),
   updatePOITags: vi.fn<typeof updatePOITags>(),
   updateRouteVisibility: vi.fn<typeof updateRouteVisibility>(),
@@ -51,12 +55,14 @@ export function resetDatabaseMocks(): void {
   databaseMocks.getCollectionSegments.mockResolvedValue([]);
   databaseMocks.getPOICountsBySource.mockResolvedValue({ osm: 0, google: 0 });
   databaseMocks.getPOIsForRoute.mockResolvedValue([]);
+  databaseMocks.getStarredItems.mockResolvedValue([]);
   databaseMocks.getRoute.mockResolvedValue(null);
   databaseMocks.getRoutePoints.mockResolvedValue([]);
   databaseMocks.getRouteWithPoints.mockResolvedValue(null);
   databaseMocks.insertPOIs.mockResolvedValue(undefined);
   databaseMocks.insertRoute.mockResolvedValue(undefined);
   databaseMocks.setActiveRoute.mockResolvedValue(undefined);
+  databaseMocks.setStarredItem.mockResolvedValue(undefined);
   databaseMocks.updateClimbName.mockResolvedValue(undefined);
   databaseMocks.updatePOITags.mockResolvedValue(undefined);
   databaseMocks.updateRouteVisibility.mockResolvedValue(undefined);

--- a/tests/services/gpxSerializer.test.ts
+++ b/tests/services/gpxSerializer.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { serializeCollectionToGPX, serializeRouteToGPX } from "@/services/gpxSerializer";
+import { toDisplayPOI } from "@/services/displayDistance";
+import { buildStitchedCollection } from "@/tests/fixtures/collection";
+import { buildPoi } from "@/tests/fixtures/poi";
+import { buildRoutePoint } from "@/tests/fixtures/route";
+import type { RouteWithPoints } from "@/types";
+
+const points = [buildRoutePoint(0, 0), buildRoutePoint(1000, 1), buildRoutePoint(2000, 2)];
+
+const route: RouteWithPoints = {
+  id: "route-1",
+  name: "A&B <Route>",
+  fileName: "route.gpx",
+  color: "#fff",
+  isActive: false,
+  isVisible: true,
+  totalDistanceMeters: 2000,
+  totalAscentMeters: 0,
+  totalDescentMeters: 0,
+  pointCount: points.length,
+  createdAt: "2026-05-05T00:00:00.000Z",
+  points,
+};
+
+describe("gpxSerializer", () => {
+  it("serializes a route track and escapes route names", () => {
+    const gpx = serializeRouteToGPX(route);
+
+    expect(gpx).toContain("<name>A&amp;B &lt;Route&gt;</name>");
+    expect(gpx).toContain('<trkpt lat="0" lon="0">');
+    expect(gpx).toContain('<trkpt lat="0" lon="2">');
+  });
+
+  it("exports starred POIs as on-route waypoint cues", () => {
+    const poi = toDisplayPOI(
+      buildPoi("poi-1", "route-1", 1500, {
+        name: "Cafe & Fuel",
+        category: "coffee",
+        latitude: 48.1,
+        longitude: 17.2,
+        distanceFromRouteMeters: 250,
+        tags: { notes: "24h window" },
+      }),
+    );
+
+    const gpx = serializeRouteToGPX(route, { poisAsWaypoints: [poi] });
+
+    expect(gpx).toContain('<wpt lat="0" lon="1.5">');
+    expect(gpx).toContain("<name>Cafe &amp; Fuel (250 m off route)</name>");
+    expect(gpx).toContain("<sym>Cafe</sym>");
+    expect(gpx).toContain("POI coordinates: 48.1, 17.2");
+    expect(gpx).toContain("Notes: 24h window");
+  });
+
+  it("uses stitched display distances for collection waypoint cues", () => {
+    const collection = buildStitchedCollection({ points });
+    const poi = toDisplayPOI(buildPoi("poi-2", "route-2", 500), 1000);
+
+    const gpx = serializeCollectionToGPX("Collection", collection, { poisAsWaypoints: [poi] });
+
+    expect(gpx).toContain("<name>Collection</name>");
+    expect(gpx).toContain('<wpt lat="0" lon="1.5">');
+  });
+
+  it("rejects empty route exports", () => {
+    expect(() => serializeRouteToGPX({ ...route, points: [], pointCount: 0 })).toThrow(
+      "Cannot serialize GPX for route with no points",
+    );
+  });
+});

--- a/tests/services/poiFetcher.test.ts
+++ b/tests/services/poiFetcher.test.ts
@@ -5,7 +5,12 @@ vi.mock("@/db/database", () => ({
   insertPOIs: vi.fn(),
 }));
 
-import { associateAndFilter } from "@/services/poiFetcher";
+vi.mock("@/services/overpassClient", () => ({
+  fetchAllPOIs: vi.fn().mockResolvedValue([]),
+}));
+
+import { deletePOIsBySource } from "@/db/database";
+import { associateAndFilter, fetchOsmPOIs } from "@/services/poiFetcher";
 import type { RoutePoint } from "@/types";
 
 const routePoints: RoutePoint[] = [
@@ -20,6 +25,12 @@ const routePoints: RoutePoint[] = [
 ];
 
 describe("poiFetcher", () => {
+  it("refreshes fetched POIs without deleting persisted stars", async () => {
+    await fetchOsmPOIs("route-1", routePoints, 1000);
+
+    expect(vi.mocked(deletePOIsBySource).mock.calls[0]).toEqual(["route-1", "osm"]);
+  });
+
   it("filters associated POIs with category-specific corridor widths", () => {
     const pois = associateAndFilter(
       [

--- a/tests/store/poiStore.test.ts
+++ b/tests/store/poiStore.test.ts
@@ -63,8 +63,12 @@ describe("poiStore starred POIs", () => {
 
     await usePoiStore.getState().clearPOIs("route-1");
 
-    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "google");
-    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "osm");
+    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "google", {
+      deleteStarredItems: true,
+    });
+    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "osm", {
+      deleteStarredItems: true,
+    });
     expect([...usePoiStore.getState().starredPOIIds]).toEqual(["custom-1"]);
   });
 
@@ -79,7 +83,9 @@ describe("poiStore starred POIs", () => {
 
     await usePoiStore.getState().clearSource("route-1", "osm");
 
-    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "osm");
+    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "osm", {
+      deleteStarredItems: true,
+    });
     expect([...usePoiStore.getState().starredPOIIds]).toEqual(["google-1"]);
   });
 });

--- a/tests/store/poiStore.test.ts
+++ b/tests/store/poiStore.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { usePoiStore } from "@/store/poiStore";
+import { databaseMocks } from "@/tests/mocks/database";
+import { buildPoi } from "@/tests/fixtures/poi";
+
+function resetPoiStoreState() {
+  usePoiStore.setState({
+    pois: {},
+    sourceInfo: {},
+    starredPOIIds: new Set(),
+    selectedPOI: null,
+  });
+}
+
+describe("poiStore starred POIs", () => {
+  beforeEach(() => {
+    resetPoiStoreState();
+  });
+
+  it("loads starred POI ids from SQLite", async () => {
+    databaseMocks.getStarredItems.mockResolvedValueOnce([
+      { entityType: "poi", entityId: "poi-1", createdAt: "2026-05-05T00:00:00.000Z" },
+      { entityType: "poi", entityId: "poi-2", createdAt: "2026-05-05T00:01:00.000Z" },
+    ]);
+
+    await usePoiStore.getState().loadStarredItems();
+
+    expect(databaseMocks.getStarredItems).toHaveBeenCalledWith("poi");
+    expect([...usePoiStore.getState().starredPOIIds]).toEqual(["poi-1", "poi-2"]);
+  });
+
+  it("persists star toggles optimistically", async () => {
+    await usePoiStore.getState().toggleStarred("poi-1");
+
+    expect(databaseMocks.setStarredItem).toHaveBeenCalledWith("poi", "poi-1", true);
+    expect(usePoiStore.getState().isStarred("poi-1")).toBe(true);
+
+    await usePoiStore.getState().toggleStarred("poi-1");
+
+    expect(databaseMocks.setStarredItem).toHaveBeenLastCalledWith("poi", "poi-1", false);
+    expect(usePoiStore.getState().isStarred("poi-1")).toBe(false);
+  });
+
+  it("stars custom POIs by default in persistent storage", async () => {
+    const poi = buildPoi("custom-1", "route-1", 500, { source: "custom" });
+    databaseMocks.getPOIsForRoute.mockResolvedValueOnce([poi]);
+
+    await usePoiStore.getState().addCustomPOI(poi);
+
+    expect(databaseMocks.insertPOIs).toHaveBeenCalledWith([poi]);
+    expect(databaseMocks.setStarredItem).toHaveBeenCalledWith("poi", "custom-1", true);
+    expect(usePoiStore.getState().isStarred("custom-1")).toBe(true);
+  });
+
+  it("removes stars for cleared fetched POIs but preserves custom POI stars", async () => {
+    const fetched = buildPoi("fetched-1", "route-1", 500, { source: "osm" });
+    const custom = buildPoi("custom-1", "route-1", 600, { source: "custom" });
+    usePoiStore.setState({
+      pois: { "route-1": [fetched, custom] },
+      starredPOIIds: new Set(["fetched-1", "custom-1"]),
+    });
+    databaseMocks.getPOIsForRoute.mockResolvedValueOnce([custom]);
+
+    await usePoiStore.getState().clearPOIs("route-1");
+
+    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "google");
+    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "osm");
+    expect([...usePoiStore.getState().starredPOIIds]).toEqual(["custom-1"]);
+  });
+
+  it("removes stars when clearing one fetched source", async () => {
+    const osm = buildPoi("osm-1", "route-1", 500, { source: "osm" });
+    const google = buildPoi("google-1", "route-1", 600, { source: "google" });
+    usePoiStore.setState({
+      pois: { "route-1": [osm, google] },
+      starredPOIIds: new Set(["osm-1", "google-1"]),
+    });
+    databaseMocks.getPOIsForRoute.mockResolvedValueOnce([google]);
+
+    await usePoiStore.getState().clearSource("route-1", "osm");
+
+    expect(databaseMocks.deletePOIsBySource).toHaveBeenCalledWith("route-1", "osm");
+    expect([...usePoiStore.getState().starredPOIIds]).toEqual(["google-1"]);
+  });
+});

--- a/tests/utils/gpxExportShare.test.ts
+++ b/tests/utils/gpxExportShare.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { shareMock } = vi.hoisted(() => ({ shareMock: vi.fn() }));
+
+vi.mock("expo-file-system", () => ({
+  File: class MockFile {
+    uri: string;
+
+    constructor(cache: string, filename: string) {
+      this.uri = `${cache}/${filename}`;
+    }
+
+    write = vi.fn();
+  },
+  Paths: { cache: "cache" },
+}));
+
+vi.mock("react-native", () => ({
+  Share: { share: shareMock },
+}));
+
+import { getSafeGPXFilename, shareGPXFile } from "@/utils/gpxExportShare";
+
+describe("gpxExportShare", () => {
+  it("sanitizes export filenames and keeps an existing GPX extension", () => {
+    expect(getSafeGPXFilename("Race Segment 01")).toBe("Race_Segment_01.gpx");
+    expect(getSafeGPXFilename("route.GPX")).toBe("route.GPX");
+    expect(getSafeGPXFilename("")).toBe("ultra-route.gpx");
+  });
+
+  it("writes a GPX file to cache and opens the share sheet", async () => {
+    shareMock.mockResolvedValueOnce({ action: "sharedAction" });
+
+    await shareGPXFile("<gpx />", "My Route");
+
+    expect(shareMock).toHaveBeenCalledWith({
+      url: "cache/My_Route.gpx",
+      title: "My_Route.gpx",
+    });
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -175,6 +175,14 @@ export interface DisplayPOI extends POI {
   effectiveDistanceMeters: DisplayDistanceMeters;
 }
 
+export type StarredEntityType = "poi";
+
+export interface StarredItem {
+  entityType: StarredEntityType;
+  entityId: string;
+  createdAt: string;
+}
+
 export interface POICategoryMeta {
   key: POICategory;
   label: string;

--- a/utils/gpxExportShare.ts
+++ b/utils/gpxExportShare.ts
@@ -1,0 +1,20 @@
+import { File, Paths } from "expo-file-system";
+import { Share } from "react-native";
+
+export function getSafeGPXFilename(name: string): string {
+  const base = name.trim() || "ultra-route";
+  const sanitized = base.replace(/[^a-z0-9.\-_]/gi, "_");
+  return sanitized.toLowerCase().endsWith(".gpx") ? sanitized : `${sanitized}.gpx`;
+}
+
+export async function shareGPXFile(gpxContent: string, filename: string): Promise<void> {
+  const safeFilename = getSafeGPXFilename(filename);
+  const file = new File(Paths.cache, safeFilename);
+
+  file.write(gpxContent);
+
+  await Share.share({
+    url: file.uri,
+    title: safeFilename,
+  });
+}


### PR DESCRIPTION
## Summary

Backports Batch 2 from the fork plan while keeping Ultra's current POI/custom-POI architecture intact.

- Add SQLite-backed `starred_items` persistence for POI stars, including migration from the legacy MMKV `starredPOIIds` value.
- Preserve existing `starredPOIIds` store behavior for fast map/list/detail rendering.
- Add GPX export for standalone routes and stitched collections.
- Include starred and saved custom POIs as on-route GPX waypoint cues for bike-computer workflows, without adding route-waypoint import/storage.
- Add route and collection detail export buttons, docs updates, and targeted tests.

## Impact

Starred stop choices now survive app restarts in SQLite and can be shared onward as GPX-compatible stop cues. Fetched POI cleanup also removes stale stars for deleted fetched POIs while preserving saved custom POIs.

## Verification

- `npx tsc --noEmit`
- `npm test`
- `npm run lint`
- `npm run format:check`
- Commit hook ran `oxfmt`, `oxlint --fix`, and `tsc --noEmit`.

AXe smoke test was attempted and captured `.axe-screenshots/01-map.png`, but the script failed on an existing stale label: `Toggle weather` was not found.