### PR TITLE
Add Upcoming ETA timeline

### DIFF
--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -11,6 +11,7 @@ import { SHEET_COMPACT_RATIO, SHEET_EXPANDED_RATIO } from "@/constants";
 import { useThemeColors } from "@/theme";
 import { useMapStyle } from "@/hooks/useMapStyle";
 import { useRouteGeometryZoom } from "@/hooks/useRouteGeometryZoom";
+import { useActiveRouteTiming } from "@/hooks/useActiveRouteTiming";
 import { GPS_STALE_THRESHOLD_MS } from "@/constants";
 import MapControls from "./MapControls";
 import RouteLayer from "./RouteLayer";
@@ -23,7 +24,6 @@ import { displayPOIsForActiveRoute } from "@/services/activePOIs";
 import { resolveActiveClimb } from "@/utils/climbSelect";
 import { getClimbMapBounds, getZoomLevelToFitBounds } from "@/utils/climbGeometry";
 import { isClimbAtLeastDifficulty } from "@/constants/climbHelpers";
-import { activeRouteTiming } from "@/utils/activeRouteTiming";
 import { resolveActiveRouteProgress } from "@/utils/routeProgress";
 import { plannedStopsFromPOIs } from "@/services/plannedStops";
 import {
@@ -110,11 +110,7 @@ export default function MapScreen() {
   // Unified active context — works for both standalone routes and collections
   const activeData = useActiveRouteData();
   const activeRoutePoints = activeData?.points ?? null;
-  const collections = useCollectionStore((s) => s.collections);
-  const timing = useMemo(
-    () => activeRouteTiming(activeData, collections),
-    [activeData, collections],
-  );
+  const timing = useActiveRouteTiming(activeData);
   const activeRouteIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const plannedStops = useMemo(
     () =>

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -19,10 +19,13 @@ import POILayer from "./POILayer";
 import ClimbHighlightLayer from "./ClimbHighlightLayer";
 import TemperatureRouteOverlay from "./TemperatureRouteOverlay";
 import TabbedBottomPanel from "./TabbedBottomPanel";
+import { displayPOIsForActiveRoute } from "@/services/activePOIs";
 import { resolveActiveClimb } from "@/utils/climbSelect";
 import { getClimbMapBounds, getZoomLevelToFitBounds } from "@/utils/climbGeometry";
 import { isClimbAtLeastDifficulty } from "@/constants/climbHelpers";
+import { activeRouteTiming } from "@/utils/activeRouteTiming";
 import { resolveActiveRouteProgress } from "@/utils/routeProgress";
+import { plannedStopsFromPOIs } from "@/services/plannedStops";
 import {
   createRidingHorizonWindow,
   filterClimbsToRidingHorizon,
@@ -94,6 +97,7 @@ export default function MapScreen() {
   const recordSnapHistory = useRouteStore((s) => s.recordSnapHistory);
   const clearRouteProgress = useRouteStore((s) => s.clearRouteProgress);
   const loadCollections = useCollectionStore((s) => s.loadCollections);
+  const allPois = usePoiStore((s) => s.pois);
   const loadPOIs = usePoiStore((s) => s.loadPOIs);
   const computeETAForRoute = useEtaStore((s) => s.computeETAForRoute);
   const cumulativeTime = useEtaStore((s) => s.cumulativeTime);
@@ -106,22 +110,26 @@ export default function MapScreen() {
   // Unified active context — works for both standalone routes and collections
   const activeData = useActiveRouteData();
   const activeRoutePoints = activeData?.points ?? null;
-  const activeCollection = useCollectionStore((s) =>
-    activeData?.type === "collection"
-      ? s.collections.find((collection) => collection.id === activeData.id)
-      : null,
+  const collections = useCollectionStore((s) => s.collections);
+  const timing = useMemo(
+    () => activeRouteTiming(activeData, collections),
+    [activeData, collections],
   );
-  const activePlannedStartMs = activeCollection?.plannedStartMs ?? null;
-  const activeForecastStartMs =
-    activePlannedStartMs != null && activePlannedStartMs > Date.now() ? activePlannedStartMs : null;
   const activeRouteIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
+  const plannedStops = useMemo(
+    () =>
+      plannedStopsFromPOIs(
+        displayPOIsForActiveRoute(activeRouteIds, activeData?.segments ?? null, allPois),
+      ),
+    [activeRouteIds, activeData?.segments, allPois],
+  );
   const activeRouteIdsKey = useMemo(() => activeRouteIds.join(","), [activeRouteIds]);
   const activeRouteProgress = useMemo(
     () =>
       resolveActiveRouteProgress(activeData, snappedPosition, {
-        plannedStartMs: activePlannedStartMs,
+        plannedStartMs: timing.plannedStartMs,
       }),
-    [activeData, snappedPosition, activePlannedStartMs],
+    [activeData, snappedPosition, timing.plannedStartMs],
   );
   const activeProgressDistanceMeters = activeRouteProgress?.distanceAlongRouteMeters ?? null;
   const climbHorizonWindow = useMemo(
@@ -206,7 +214,8 @@ export default function MapScreen() {
         activeRoutePoints,
         activeRouteProgress.distanceAlongRouteMeters,
         cumulativeTime,
-        activeForecastStartMs,
+        timing.futureStartMs,
+        plannedStops,
       );
     }
     // Intentional: fire on id/progress changes, not full object identities
@@ -217,7 +226,8 @@ export default function MapScreen() {
     isConnected,
     cumulativeTime,
     fetchWeather,
-    activeForecastStartMs,
+    timing.futureStartMs,
+    plannedStops,
   ]);
 
   const applyRouteSnap = useCallback(

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -33,6 +33,10 @@ import { POI_ICON_MAP } from "@/constants/poiIcons";
 import { getCategoryMeta, ohStatusColorKey } from "@/constants/poiHelpers";
 import { formatDistance, formatDuration, formatETA } from "@/utils/formatters";
 import { getOpeningHoursStatus, isOpenAt, getDaySchedules } from "@/services/openingHoursParser";
+import {
+  departureTimeAfterPlannedStop,
+  getPlannedStopDurationMinutes,
+} from "@/services/plannedStops";
 import { stitchPOIs } from "@/services/stitchingService";
 import { toDisplayPOIForSegments, toDisplayPOIs } from "@/services/displayDistance";
 import { getETAToDistanceFromDistance as resolveETAToDistance } from "@/services/etaCalculator";
@@ -597,9 +601,74 @@ function POIDetailStat({ label, value }: { label: string; value: string }) {
       <Text className="text-[12px] font-barlow-medium text-muted-foreground" numberOfLines={1}>
         {label}
       </Text>
-      <Text className="text-[20px] font-barlow-sc-semibold text-foreground" numberOfLines={1}>
+      <Text
+        className="text-[20px] font-barlow-sc-semibold text-foreground"
+        numberOfLines={1}
+        adjustsFontSizeToFit
+        minimumFontScale={0.75}
+      >
         {value}
       </Text>
+    </View>
+  );
+}
+
+function parsePlannedStopMinutes(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return 0;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
+  return Math.round(parsed);
+}
+
+function PlannedStopMinutesInput({
+  valueMinutes,
+  onCommit,
+}: {
+  valueMinutes: number;
+  onCommit: (minutes: number) => void;
+}) {
+  const colors = useThemeColors();
+  const [draft, setDraft] = useState(valueMinutes > 0 ? String(valueMinutes) : "");
+
+  useEffect(() => {
+    setDraft(valueMinutes > 0 ? String(valueMinutes) : "");
+  }, [valueMinutes]);
+
+  const commitDraft = useCallback(() => {
+    const minutes = parsePlannedStopMinutes(draft);
+    if (minutes == null) {
+      Alert.alert("Invalid Stop Time", "Enter a non-negative number of minutes.");
+      setDraft(valueMinutes > 0 ? String(valueMinutes) : "");
+      return;
+    }
+    setDraft(minutes > 0 ? String(minutes) : "");
+    if (minutes !== valueMinutes) onCommit(minutes);
+  }, [draft, onCommit, valueMinutes]);
+
+  return (
+    <View className="mt-3">
+      <Text className="text-[12px] font-barlow-semibold text-muted-foreground mb-1">
+        Planned stop
+      </Text>
+      <View
+        className="min-h-[48px] flex-row items-center rounded-lg border bg-background px-3"
+        style={{ borderColor: colors.border }}
+      >
+        <RNTextInput
+          className="flex-1 min-h-[48px] text-[22px] font-barlow-sc-semibold text-foreground"
+          value={draft}
+          onChangeText={(text) => setDraft(text.replace(/[^0-9]/g, ""))}
+          onBlur={commitDraft}
+          onSubmitEditing={commitDraft}
+          keyboardType="number-pad"
+          returnKeyType="done"
+          placeholder="0"
+          placeholderTextColor={colors.textTertiary}
+          accessibilityLabel="Planned stop minutes"
+        />
+        <Text className="text-[14px] font-barlow-semibold text-muted-foreground ml-2">min</Text>
+      </View>
     </View>
   );
 }
@@ -622,6 +691,7 @@ function InlinePOIDetail({
   const updatePOINotes = usePoiStore((s) => s.updatePOINotes);
   const deleteCustomPOI = usePoiStore((s) => s.deleteCustomPOI);
   const getETAToPOI = useEtaStore((s) => s.getETAToPOI);
+  const updatePlannedStopDuration = usePoiStore((s) => s.updatePlannedStopDuration);
 
   const catMeta = POI_CATEGORIES.find((c) => c.key === poi.category);
   const IconComp = catMeta ? POI_ICON_MAP[catMeta.iconName] : null;
@@ -636,6 +706,8 @@ function InlinePOIDetail({
     () => (displayPOI ? getETAToPOI(displayPOI) : null),
     [displayPOI, getETAToPOI],
   );
+  const plannedStopMinutes = getPlannedStopDurationMinutes(poi);
+  const plannedDepartureTime = departureTimeAfterPlannedStop(etaResult, plannedStopMinutes);
 
   const openingHoursRaw = poi.tags?.opening_hours;
   const ohStatus = useMemo(
@@ -660,6 +732,7 @@ function InlinePOIDetail({
   const distAheadLabel = distAhead == null ? "distance" : distAhead >= 0 ? "ahead" : "behind";
   const offRouteText =
     poi.distanceFromRouteMeters > 50 ? `${Math.round(poi.distanceFromRouteMeters)} m` : "on route";
+  const plannedStopText = plannedStopMinutes > 0 ? `${plannedStopMinutes}m` : "none";
 
   const daySchedules = useMemo(
     () => (openingHoursRaw ? getDaySchedules(openingHoursRaw) : null),
@@ -730,6 +803,13 @@ function InlinePOIDetail({
     });
   }, [websiteUrl]);
 
+  const handlePlannedStopCommit = useCallback(
+    (minutes: number) => {
+      updatePlannedStopDuration(poi.routeId, poi.id, minutes);
+    },
+    [poi.id, poi.routeId, updatePlannedStopDuration],
+  );
+
   return (
     <ScrollView className="flex-1 px-3 pt-1">
       {/* Header: back + name + star */}
@@ -787,7 +867,19 @@ function InlinePOIDetail({
           }
         />
         <POIDetailStat label="off route" value={offRouteText} />
+        <POIDetailStat label="stop" value={plannedStopText} />
       </View>
+
+      {plannedStopMinutes > 0 && plannedDepartureTime && (
+        <Text className="text-[13px] font-barlow-medium text-muted-foreground mt-2">
+          Stop {plannedStopMinutes}m · depart {formatETA(plannedDepartureTime)}
+        </Text>
+      )}
+
+      <PlannedStopMinutesInput
+        valueMinutes={plannedStopMinutes}
+        onCommit={handlePlannedStopCommit}
+      />
 
       {etaOpenStatus !== null && (
         <Text

--- a/components/map/TabbedBottomPanel.tsx
+++ b/components/map/TabbedBottomPanel.tsx
@@ -14,6 +14,7 @@ import { useThemeColors } from "@/theme";
 import { usePanelStore } from "@/store/panelStore";
 import { SHEET_COMPACT_RATIO, SHEET_EXPANDED_RATIO } from "@/constants";
 import ProfileTabContent from "./ProfileTabContent";
+import UpcomingTabContent from "./UpcomingTabContent";
 import WeatherPanel from "./WeatherPanel";
 import ClimbTabContent from "./ClimbTabContent";
 import POITabContent from "./POITabContent";
@@ -36,6 +37,7 @@ interface TabDef {
 
 const ALL_TABS: TabDef[] = [
   { key: "profile", label: "Profile" },
+  { key: "upcoming", label: "Upcoming" },
   { key: "weather", label: "Weather" },
   { key: "climbs", label: "Climbs" },
   { key: "pois", label: "POIs" },
@@ -163,6 +165,9 @@ export default function TabbedBottomPanel({ activeData }: TabbedBottomPanelProps
                       <Text
                         className="text-[15px] font-barlow-semibold"
                         style={{ color: isActive ? colors.accent : colors.textTertiary }}
+                        numberOfLines={1}
+                        adjustsFontSizeToFit
+                        minimumFontScale={0.82}
                       >
                         {tab.label}
                       </Text>
@@ -189,6 +194,7 @@ export default function TabbedBottomPanel({ activeData }: TabbedBottomPanelProps
               height={effectiveContentHeight}
             />
           )}
+          {panelTab === "upcoming" && <UpcomingTabContent activeData={activeData} />}
           {panelTab === "weather" && <WeatherPanel activeData={activeData} />}
           {panelTab === "climbs" && <ClimbTabContent activeData={activeData} />}
           {panelTab === "pois" && <POITabContent activeData={activeData} />}

--- a/components/map/UpcomingTabContent.tsx
+++ b/components/map/UpcomingTabContent.tsx
@@ -12,12 +12,12 @@ import {
 } from "@/constants/climbHelpers";
 import { useThemeColors } from "@/theme";
 import { useClimbStore } from "@/store/climbStore";
-import { useCollectionStore } from "@/store/collectionStore";
 import { useEtaStore } from "@/store/etaStore";
 import { usePanelStore } from "@/store/panelStore";
 import { usePoiStore } from "@/store/poiStore";
 import { useRouteStore } from "@/store/routeStore";
 import { useSettingsStore } from "@/store/settingsStore";
+import { useActiveRouteTiming } from "@/hooks/useActiveRouteTiming";
 import { displayPOIsForActiveRoute } from "@/services/activePOIs";
 import {
   buildUpcomingTimeline,
@@ -31,7 +31,6 @@ import {
   plannedStopsFromPOIs,
 } from "@/services/plannedStops";
 import { formatDistance, formatDuration, formatElevation, formatETA } from "@/utils/formatters";
-import { activeRouteTiming } from "@/utils/activeRouteTiming";
 import { resolveActiveRouteProgress } from "@/utils/routeProgress";
 import {
   createRidingHorizonWindow,
@@ -67,11 +66,8 @@ export default function UpcomingTabContent({ activeData }: UpcomingTabContentPro
   const setSelectedClimb = useClimbStore((s) => s.setSelectedClimb);
   const cumulativeTime = useEtaStore((s) => s.cumulativeTime);
   const panelMode = usePanelStore((s) => s.panelMode);
-  const collections = useCollectionStore((s) => s.collections);
-  const timing = useMemo(
-    () => activeRouteTiming(activeData, collections),
-    [activeData, collections],
-  );
+  const setPanelTab = usePanelStore((s) => s.setPanelTab);
+  const timing = useActiveRouteTiming(activeData);
 
   const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
   const segments = activeData?.segments ?? null;
@@ -168,9 +164,10 @@ export default function UpcomingTabContent({ activeData }: UpcomingTabContentPro
         event.kind === "climb-top"
       ) {
         setSelectedClimb(event.climb);
+        setPanelTab("climbs");
       }
     },
-    [setSelectedClimb, setSelectedPOI],
+    [setPanelTab, setSelectedClimb, setSelectedPOI],
   );
 
   const renderEvent = useCallback<ListRenderItem<UpcomingEvent>>(
@@ -279,11 +276,8 @@ const UpcomingEventRow = React.memo(function UpcomingEventRow({
   const departureTime =
     event.kind === "poi" ? departureTimeAfterPlannedStop(eta, plannedStopMinutes) : null;
   const hasStopInterval = plannedStopMinutes > 0 && eta != null && departureTime != null;
-  const clockLabel = hasStopInterval
-    ? `${formatETA(eta.eta)}-${formatETA(departureTime)}`
-    : eta
-      ? formatETA(eta.eta)
-      : "--:--";
+  const clockLabel = eta ? formatETA(eta.eta) : "--:--";
+  const departureLabel = departureTime ? formatETA(departureTime) : null;
   const ridingTimeLabel =
     eta && eta.ridingTimeSeconds > 0 ? `~${formatDuration(eta.ridingTimeSeconds)}` : "no ETA";
   const isPressable =
@@ -296,6 +290,7 @@ const UpcomingEventRow = React.memo(function UpcomingEventRow({
     content.title,
     content.subtitle,
     eta ? `ETA ${clockLabel}` : null,
+    hasStopInterval && departureLabel ? `depart ${departureLabel}` : null,
     `${distanceLabel} ahead`,
   ]
     .filter(Boolean)
@@ -309,15 +304,15 @@ const UpcomingEventRow = React.memo(function UpcomingEventRow({
       accessibilityRole={isPressable ? "button" : "text"}
       accessibilityLabel={accessibilityLabel}
     >
-      <View className={hasStopInterval ? "w-[92px]" : "w-[70px]"}>
-        <Text
-          className={`${
-            hasStopInterval ? "text-[17px]" : "text-[20px]"
-          } font-barlow-sc-semibold text-foreground`}
-          numberOfLines={1}
-        >
+      <View className="w-[70px]">
+        <Text className="text-[20px] font-barlow-sc-semibold text-foreground" numberOfLines={1}>
           {clockLabel}
         </Text>
+        {hasStopInterval && departureLabel && (
+          <Text className="text-[20px] font-barlow-sc-semibold text-foreground" numberOfLines={1}>
+            {departureLabel}
+          </Text>
+        )}
         <Text className="text-[12px] font-barlow-sc-medium text-muted-foreground" numberOfLines={1}>
           {ridingTimeLabel}
         </Text>
@@ -343,8 +338,13 @@ const UpcomingEventRow = React.memo(function UpcomingEventRow({
         </Text>
       </View>
 
-      <View className="ml-2 items-end w-[62px]">
-        <Text className="text-[18px] font-barlow-sc-semibold text-foreground" numberOfLines={1}>
+      <View className="ml-2 items-end w-[92px]">
+        <Text
+          className="text-[18px] font-barlow-sc-semibold text-foreground"
+          numberOfLines={1}
+          adjustsFontSizeToFit
+          minimumFontScale={0.72}
+        >
           {distanceLabel}
         </Text>
         <Text className="text-[11px] font-barlow-medium text-muted-foreground" numberOfLines={1}>
@@ -390,11 +390,7 @@ function eventContent(
       const difficulty = getClimbDifficulty(event.climb.difficultyScore);
       const color = climbDifficultyColor(event.climb.difficultyScore);
       const titlePrefix =
-        event.kind === "climb-start"
-          ? "Climb starts"
-          : event.kind === "climb-top"
-            ? "Climb top"
-            : "Climb";
+        event.kind === "climb-start" ? "START" : event.kind === "climb-top" ? "END" : "Climb";
       return {
         title: `${titlePrefix}: ${event.climb.name ?? "Climb"}`,
         subtitle: `${CLIMB_DIFFICULTY_LABELS[difficulty]} · ${formatDistance(

--- a/components/map/UpcomingTabContent.tsx
+++ b/components/map/UpcomingTabContent.tsx
@@ -1,0 +1,424 @@
+import React, { useCallback, useMemo } from "react";
+import { FlatList, TouchableOpacity, View, type ListRenderItem } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Clock3, Flag, GitBranch, MapPin, Mountain } from "lucide-react-native";
+import { Text } from "@/components/ui/text";
+import { POI_ICON_MAP } from "@/constants/poiIcons";
+import { getCategoryMeta, ohStatusColorKey } from "@/constants/poiHelpers";
+import {
+  CLIMB_DIFFICULTY_LABELS,
+  climbDifficultyColor,
+  getClimbDifficulty,
+} from "@/constants/climbHelpers";
+import { useThemeColors } from "@/theme";
+import { useClimbStore } from "@/store/climbStore";
+import { useCollectionStore } from "@/store/collectionStore";
+import { useEtaStore } from "@/store/etaStore";
+import { usePanelStore } from "@/store/panelStore";
+import { usePoiStore } from "@/store/poiStore";
+import { useRouteStore } from "@/store/routeStore";
+import { useSettingsStore } from "@/store/settingsStore";
+import { displayPOIsForActiveRoute } from "@/services/activePOIs";
+import {
+  buildUpcomingTimeline,
+  resolveUpcomingHorizonETA,
+  type UpcomingEvent,
+} from "@/services/upcomingTimeline";
+import { getOpeningHoursStatus } from "@/services/openingHoursParser";
+import {
+  departureTimeAfterPlannedStop,
+  getPlannedStopDurationMinutes,
+  plannedStopsFromPOIs,
+} from "@/services/plannedStops";
+import { formatDistance, formatDuration, formatElevation, formatETA } from "@/utils/formatters";
+import { activeRouteTiming } from "@/utils/activeRouteTiming";
+import { resolveActiveRouteProgress } from "@/utils/routeProgress";
+import {
+  createRidingHorizonWindow,
+  ridingHorizonLabelForMode,
+  ridingHorizonMetersForMode,
+  ridingHorizonScopeLabelForMode,
+} from "@/utils/ridingHorizon";
+import type { ActiveRouteData, PanelMode, UnitSystem } from "@/types";
+
+interface UpcomingTabContentProps {
+  activeData: ActiveRouteData | null;
+}
+
+const INITIAL_RENDER_COUNT = 10;
+const LIST_MAX_BATCH = 8;
+const LIST_WINDOW_SIZE = 5;
+const LIST_BATCHING_PERIOD_MS = 50;
+
+function eventKeyExtractor(event: UpcomingEvent): string {
+  return event.id;
+}
+
+export default function UpcomingTabContent({ activeData }: UpcomingTabContentProps) {
+  const colors = useThemeColors();
+  const { bottom: safeBottom } = useSafeAreaInsets();
+  const units = useSettingsStore((s) => s.units);
+  const snappedPosition = useRouteStore((s) => s.snappedPosition);
+  const allPois = usePoiStore((s) => s.pois);
+  const starredPOIIds = usePoiStore((s) => s.starredPOIIds);
+  const setSelectedPOI = usePoiStore((s) => s.setSelectedPOI);
+  const allClimbs = useClimbStore((s) => s.climbs);
+  const getClimbsForDisplay = useClimbStore((s) => s.getClimbsForDisplay);
+  const setSelectedClimb = useClimbStore((s) => s.setSelectedClimb);
+  const cumulativeTime = useEtaStore((s) => s.cumulativeTime);
+  const panelMode = usePanelStore((s) => s.panelMode);
+  const collections = useCollectionStore((s) => s.collections);
+  const timing = useMemo(
+    () => activeRouteTiming(activeData, collections),
+    [activeData, collections],
+  );
+
+  const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
+  const segments = activeData?.segments ?? null;
+  const routePoints = activeData?.points ?? null;
+  const totalDistanceMeters = activeData?.totalDistanceMeters ?? 0;
+  const activeRouteProgress = useMemo(
+    () =>
+      resolveActiveRouteProgress(activeData, snappedPosition, {
+        plannedStartMs: timing.plannedStartMs,
+      }),
+    [activeData, snappedPosition, timing.plannedStartMs],
+  );
+  const currentDistanceMeters = activeRouteProgress?.distanceAlongRouteMeters ?? null;
+  const ridingHorizonMeters = ridingHorizonMetersForMode(panelMode);
+  const horizonWindow = useMemo(
+    () =>
+      createRidingHorizonWindow(currentDistanceMeters, ridingHorizonMeters, {
+        totalDistanceMeters,
+      }),
+    [currentDistanceMeters, ridingHorizonMeters, totalDistanceMeters],
+  );
+
+  const displayPOIs = useMemo(() => {
+    return displayPOIsForActiveRoute(routeIds, segments, allPois);
+  }, [routeIds, segments, allPois]);
+
+  const displayClimbs = useMemo(
+    () => getClimbsForDisplay(routeIds, segments),
+    // allClimbs is a reactivity trigger: getClimbsForDisplay reads store via get() and is not itself reactive
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [routeIds, segments, allClimbs, getClimbsForDisplay],
+  );
+  const plannedStops = useMemo(() => plannedStopsFromPOIs(displayPOIs), [displayPOIs]);
+
+  const events = useMemo(
+    () =>
+      buildUpcomingTimeline({
+        pois: displayPOIs,
+        starredPOIIds,
+        climbs: displayClimbs,
+        segments,
+        totalDistanceMeters,
+        currentDistanceMeters,
+        horizonWindow,
+        routePoints,
+        cumulativeTime,
+        etaStartTimeMs: timing.futureStartMs,
+        plannedStops,
+      }),
+    [
+      displayPOIs,
+      starredPOIIds,
+      displayClimbs,
+      segments,
+      totalDistanceMeters,
+      currentDistanceMeters,
+      horizonWindow,
+      routePoints,
+      cumulativeTime,
+      timing.futureStartMs,
+      plannedStops,
+    ],
+  );
+
+  const horizonETA = useMemo(
+    () =>
+      resolveUpcomingHorizonETA({
+        totalDistanceMeters,
+        currentDistanceMeters,
+        horizonWindow,
+        routePoints,
+        cumulativeTime,
+        etaStartTimeMs: timing.futureStartMs,
+        plannedStops,
+      }),
+    [
+      totalDistanceMeters,
+      currentDistanceMeters,
+      horizonWindow,
+      routePoints,
+      cumulativeTime,
+      timing.futureStartMs,
+      plannedStops,
+    ],
+  );
+
+  const handleEventPress = useCallback(
+    (event: UpcomingEvent) => {
+      if (event.kind === "poi") {
+        setSelectedPOI(event.poi);
+      } else if (
+        event.kind === "climb-span" ||
+        event.kind === "climb-start" ||
+        event.kind === "climb-top"
+      ) {
+        setSelectedClimb(event.climb);
+      }
+    },
+    [setSelectedClimb, setSelectedPOI],
+  );
+
+  const renderEvent = useCallback<ListRenderItem<UpcomingEvent>>(
+    ({ item }) => (
+      <UpcomingEventRow
+        event={item}
+        currentDistanceMeters={currentDistanceMeters}
+        units={units}
+        onPress={handleEventPress}
+      />
+    ),
+    [currentDistanceMeters, units, handleEventPress],
+  );
+
+  const scopeLabel = ridingHorizonScopeLabelForMode(panelMode);
+
+  return (
+    <View className="flex-1">
+      <UpcomingHeader
+        panelMode={panelMode}
+        eventCount={events.length}
+        horizonEtaSeconds={horizonETA?.ridingTimeSeconds ?? null}
+      />
+
+      <FlatList
+        data={events}
+        keyExtractor={eventKeyExtractor}
+        renderItem={renderEvent}
+        showsVerticalScrollIndicator={false}
+        initialNumToRender={INITIAL_RENDER_COUNT}
+        maxToRenderPerBatch={LIST_MAX_BATCH}
+        updateCellsBatchingPeriod={LIST_BATCHING_PERIOD_MS}
+        windowSize={LIST_WINDOW_SIZE}
+        removeClippedSubviews
+        contentContainerStyle={{ paddingBottom: safeBottom }}
+        ListEmptyComponent={
+          <View className="items-center justify-center px-5 py-12">
+            <Clock3 size={24} color={colors.textTertiary} />
+            <Text className="text-[13px] text-muted-foreground font-barlow-medium mt-2 text-center">
+              No important events in {scopeLabel}
+            </Text>
+            <Text className="text-[11px] text-muted-foreground mt-1 text-center">
+              Star POIs you want to see here during the ride.
+            </Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}
+
+function UpcomingHeader({
+  panelMode,
+  eventCount,
+  horizonEtaSeconds,
+}: {
+  panelMode: PanelMode;
+  eventCount: number;
+  horizonEtaSeconds: number | null;
+}) {
+  const colors = useThemeColors();
+  const label =
+    panelMode === "full-route" ? "To finish" : `Next ${ridingHorizonLabelForMode(panelMode)}`;
+  const etaLabel = horizonEtaSeconds != null ? ` · ~${formatDuration(horizonEtaSeconds)}` : "";
+
+  return (
+    <View
+      className="flex-row items-center justify-between px-3"
+      style={{ height: 52, borderBottomWidth: 1, borderBottomColor: colors.borderSubtle }}
+    >
+      <View className="flex-1 min-w-0">
+        <Text className="text-[15px] font-barlow-semibold text-foreground" numberOfLines={1}>
+          {label}
+          {etaLabel}
+        </Text>
+        <Text className="text-[11px] font-barlow-medium text-muted-foreground" numberOfLines={1}>
+          {eventCount} timeline events
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const UpcomingEventRow = React.memo(function UpcomingEventRow({
+  event,
+  currentDistanceMeters,
+  units,
+  onPress,
+}: {
+  event: UpcomingEvent;
+  currentDistanceMeters: number | null;
+  units: UnitSystem;
+  onPress: (event: UpcomingEvent) => void;
+}) {
+  const colors = useThemeColors();
+  const distanceAhead =
+    currentDistanceMeters != null
+      ? event.distanceMeters - currentDistanceMeters
+      : event.distanceMeters;
+  const distanceLabel =
+    distanceAhead >= 0
+      ? formatDistance(distanceAhead, units)
+      : `-${formatDistance(Math.abs(distanceAhead), units)}`;
+  const eta = event.eta;
+  const plannedStopMinutes = event.kind === "poi" ? getPlannedStopDurationMinutes(event.poi) : 0;
+  const departureTime =
+    event.kind === "poi" ? departureTimeAfterPlannedStop(eta, plannedStopMinutes) : null;
+  const hasStopInterval = plannedStopMinutes > 0 && eta != null && departureTime != null;
+  const clockLabel = hasStopInterval
+    ? `${formatETA(eta.eta)}-${formatETA(departureTime)}`
+    : eta
+      ? formatETA(eta.eta)
+      : "--:--";
+  const ridingTimeLabel =
+    eta && eta.ridingTimeSeconds > 0 ? `~${formatDuration(eta.ridingTimeSeconds)}` : "no ETA";
+  const isPressable =
+    event.kind === "poi" ||
+    event.kind === "climb-span" ||
+    event.kind === "climb-start" ||
+    event.kind === "climb-top";
+  const content = eventContent(event, units, colors);
+  const accessibilityLabel = [
+    content.title,
+    content.subtitle,
+    eta ? `ETA ${clockLabel}` : null,
+    `${distanceLabel} ahead`,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <TouchableOpacity
+      className="flex-row items-center px-3 py-2.5 border-b border-border"
+      disabled={!isPressable}
+      onPress={() => onPress(event)}
+      accessibilityRole={isPressable ? "button" : "text"}
+      accessibilityLabel={accessibilityLabel}
+    >
+      <View className={hasStopInterval ? "w-[92px]" : "w-[70px]"}>
+        <Text
+          className={`${
+            hasStopInterval ? "text-[17px]" : "text-[20px]"
+          } font-barlow-sc-semibold text-foreground`}
+          numberOfLines={1}
+        >
+          {clockLabel}
+        </Text>
+        <Text className="text-[12px] font-barlow-sc-medium text-muted-foreground" numberOfLines={1}>
+          {ridingTimeLabel}
+        </Text>
+      </View>
+
+      <View
+        className="w-[42px] h-[42px] rounded-full items-center justify-center mx-2"
+        style={{ backgroundColor: content.color + "1A" }}
+      >
+        {content.icon}
+      </View>
+
+      <View className="flex-1 min-w-0">
+        <Text className="text-[15px] font-barlow-semibold text-foreground" numberOfLines={1}>
+          {content.title}
+        </Text>
+        <Text
+          className="text-[13px] font-barlow-medium"
+          style={{ color: content.subtitleColor ?? colors.textSecondary }}
+          numberOfLines={1}
+        >
+          {content.subtitle}
+        </Text>
+      </View>
+
+      <View className="ml-2 items-end w-[62px]">
+        <Text className="text-[18px] font-barlow-sc-semibold text-foreground" numberOfLines={1}>
+          {distanceLabel}
+        </Text>
+        <Text className="text-[11px] font-barlow-medium text-muted-foreground" numberOfLines={1}>
+          {distanceAhead >= 0 ? "ahead" : "behind"}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+});
+
+function eventContent(
+  event: UpcomingEvent,
+  units: UnitSystem,
+  colors: ReturnType<typeof useThemeColors>,
+) {
+  switch (event.kind) {
+    case "poi": {
+      const meta = getCategoryMeta(event.poi.category);
+      const IconComp = meta ? POI_ICON_MAP[meta.iconName] : MapPin;
+      const ohStatus = event.poi.tags.opening_hours
+        ? getOpeningHoursStatus(event.poi.tags.opening_hours)
+        : null;
+      const ohColorKey = ohStatusColorKey(ohStatus);
+      const ohColor = ohColorKey ? colors[ohColorKey] : colors.textSecondary;
+      const offRoute =
+        event.poi.distanceFromRouteMeters > 50
+          ? ` · ${Math.round(event.poi.distanceFromRouteMeters)} m off`
+          : "";
+      const status = ohStatus
+        ? `${ohStatus.label}${ohStatus.detail ? ` · ${ohStatus.detail}` : ""}`
+        : (meta?.label ?? "POI");
+      return {
+        title: event.poi.name ?? meta?.label ?? "Unnamed POI",
+        subtitle: `${status}${offRoute}`,
+        subtitleColor: ohStatus ? ohColor : meta?.color,
+        color: meta?.color ?? colors.textTertiary,
+        icon: <IconComp size={20} color={meta?.color ?? colors.textPrimary} />,
+      };
+    }
+    case "climb-span":
+    case "climb-start":
+    case "climb-top": {
+      const difficulty = getClimbDifficulty(event.climb.difficultyScore);
+      const color = climbDifficultyColor(event.climb.difficultyScore);
+      const titlePrefix =
+        event.kind === "climb-start"
+          ? "Climb starts"
+          : event.kind === "climb-top"
+            ? "Climb top"
+            : "Climb";
+      return {
+        title: `${titlePrefix}: ${event.climb.name ?? "Climb"}`,
+        subtitle: `${CLIMB_DIFFICULTY_LABELS[difficulty]} · ${formatDistance(
+          event.climb.lengthMeters,
+          units,
+        )} · +${formatElevation(event.climb.totalAscentMeters, units)}`,
+        subtitleColor: color,
+        color,
+        icon: <Mountain size={20} color={color} />,
+      };
+    }
+    case "segment-transition":
+      return {
+        title: `End ${event.fromSegment.routeName}`,
+        subtitle: `Start ${event.toSegment.routeName}`,
+        color: colors.info,
+        icon: <GitBranch size={20} color={colors.info} />,
+      };
+    case "finish":
+      return {
+        title: event.label,
+        subtitle: "End of active route",
+        color: colors.accent,
+        icon: <Flag size={20} color={colors.accent} />,
+      };
+  }
+}

--- a/components/map/WeatherPanel.tsx
+++ b/components/map/WeatherPanel.tsx
@@ -26,7 +26,9 @@ import { useRouteStore } from "@/store/routeStore";
 import { useEtaStore } from "@/store/etaStore";
 import { useOfflineStore } from "@/store/offlineStore";
 import { useCollectionStore } from "@/store/collectionStore";
+import { usePoiStore } from "@/store/poiStore";
 import { formatTimeAgo } from "@/utils/formatters";
+import { activeRouteTiming } from "@/utils/activeRouteTiming";
 import { ridingHorizonMetersForMode } from "@/utils/ridingHorizon";
 import { temperatureGradientColor } from "@/utils/temperatureOverlay";
 import {
@@ -37,6 +39,8 @@ import {
   type WeatherSeverity,
 } from "@/utils/weatherCodes";
 import { classifyWind } from "@/services/weatherService";
+import { displayPOIsForActiveRoute } from "@/services/activePOIs";
+import { plannedStopsFromPOIs } from "@/services/plannedStops";
 import type { ActiveRouteData, WeatherPoint, WindRelative } from "@/types";
 
 type TimelineListItem =
@@ -371,16 +375,17 @@ function buildRefreshContext(activeData: ActiveRouteData | null) {
   if (!activeData?.points.length) return null;
   const cumulativeTime = useEtaStore.getState().cumulativeTime;
   if (!cumulativeTime) return null;
-  const activeCollection = useCollectionStore
-    .getState()
-    .collections.find((collection) => collection.id === activeData.id && collection.isActive);
-  const plannedStartMs =
-    activeData.type === "collection" ? (activeCollection?.plannedStartMs ?? null) : null;
-  const forecastStartMs =
-    plannedStartMs != null && plannedStartMs > Date.now() ? plannedStartMs : null;
+  const timing = activeRouteTiming(activeData, useCollectionStore.getState().collections);
+  const plannedStops = plannedStopsFromPOIs(
+    displayPOIsForActiveRoute(
+      activeData.routeIds,
+      activeData.segments,
+      usePoiStore.getState().pois,
+    ),
+  );
   const snapped = useRouteStore.getState().snappedPosition;
   const isValidSnap =
-    forecastStartMs == null &&
+    timing.futureStartMs == null &&
     snapped?.routeId === activeData.id &&
     snapped.distanceFromRouteMeters <= 1000;
 
@@ -389,7 +394,8 @@ function buildRefreshContext(activeData: ActiveRouteData | null) {
     points: activeData.points,
     fromDistanceAlongRouteMeters: isValidSnap ? snapped.distanceAlongRouteMeters : 0,
     cumulativeTime,
-    plannedStartMs: forecastStartMs,
+    plannedStartMs: timing.futureStartMs,
+    plannedStops,
   };
 }
 
@@ -407,11 +413,11 @@ function ForecastStatus({
   const lastRefreshOutcome = useWeatherStore((s) => s.lastRefreshOutcome);
   const lastRefreshMessage = useWeatherStore((s) => s.lastRefreshMessage);
   const isConnected = useOfflineStore((s) => s.isConnected);
-  const activeCollection = useCollectionStore((s) =>
-    s.collections.find((collection) => collection.id === activeData?.id && collection.isActive),
+  const collections = useCollectionStore((s) => s.collections);
+  const timing = useMemo(
+    () => activeRouteTiming(activeData, collections),
+    [activeData, collections],
   );
-  const plannedStartMs =
-    activeData?.type === "collection" ? (activeCollection?.plannedStartMs ?? null) : null;
 
   const statusBase =
     fetchStatus === "fetching"
@@ -435,8 +441,8 @@ function ForecastStatus({
       <View className="flex-row items-center px-3">
         <View className="flex-1 flex-row min-w-0">
           <Text className="text-[13px] font-barlow-medium text-muted-foreground" numberOfLines={1}>
-            {plannedStartMs != null
-              ? `${statusBase} · start ${formatStartLabel(plannedStartMs)}`
+            {timing.plannedStartMs != null
+              ? `${statusBase} · start ${formatStartLabel(timing.plannedStartMs)}`
               : statusBase}
           </Text>
           {statusSuffix && (
@@ -582,6 +588,7 @@ export default function WeatherPanel({ activeData }: { activeData: ActiveRouteDa
       context.fromDistanceAlongRouteMeters,
       context.cumulativeTime,
       context.plannedStartMs,
+      context.plannedStops,
     );
   }, [activeData, recordManualRefreshUnavailable, refreshWeatherNow]);
 

--- a/components/map/WeatherPanel.tsx
+++ b/components/map/WeatherPanel.tsx
@@ -27,6 +27,7 @@ import { useEtaStore } from "@/store/etaStore";
 import { useOfflineStore } from "@/store/offlineStore";
 import { useCollectionStore } from "@/store/collectionStore";
 import { usePoiStore } from "@/store/poiStore";
+import { useActiveRouteTiming } from "@/hooks/useActiveRouteTiming";
 import { formatTimeAgo } from "@/utils/formatters";
 import { activeRouteTiming } from "@/utils/activeRouteTiming";
 import { ridingHorizonMetersForMode } from "@/utils/ridingHorizon";
@@ -413,11 +414,7 @@ function ForecastStatus({
   const lastRefreshOutcome = useWeatherStore((s) => s.lastRefreshOutcome);
   const lastRefreshMessage = useWeatherStore((s) => s.lastRefreshMessage);
   const isConnected = useOfflineStore((s) => s.isConnected);
-  const collections = useCollectionStore((s) => s.collections);
-  const timing = useMemo(
-    () => activeRouteTiming(activeData, collections),
-    [activeData, collections],
-  );
+  const timing = useActiveRouteTiming(activeData);
 
   const statusBase =
     fetchStatus === "fetching"

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,6 +34,16 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Elevation profile follows the global riding horizon
 - Segment boundary markers for stitched collections
 
+## Upcoming Timeline
+
+- ETA-first bottom-panel tab for important events in the selected riding horizon
+- Shows starred and saved POIs, climbs, collection segment transitions, and route/collection finish
+- Keeps V1 quiet by excluding unstarred POIs and category focus/search controls
+- Uses the same 10km / 25km / 50km / 100km / 200km / FULL horizon as the ride view
+- Displays clock ETA and riding time when available, with distance-first fallback when ETA is unavailable
+- Includes POIs with planned stop durations even when unstarred, so downstream ETA shifts are visible
+- Models climbs as spans, splitting moderate/hard climbs or climbs with important POIs into start/top context
+
 ## Climb Detection
 
 - Auto-detected from elevation data on import
@@ -56,6 +66,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - POI text search (filter by name)
 - Starred POIs persisted in SQLite
 - Saved custom POIs from iOS share sheet or manual coordinates, route-scoped and starred by default
+- Planned stop duration presets on POI detail for rider-intended stop time
 - Opening hours: open/closed status, color-coded, "open now" filter
 - Category filters (multi-select)
 
@@ -65,6 +76,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Terrain-aware — accounts for climbs, descents, flats
 - Configurable: power output, total weight, advanced params (CdA, Crr, max descent speed)
 - ETA displayed on POI cards, POI list items, and climb list
+- Downstream ETAs include prior planned POI stop durations while preserving arrival ETA to the stop itself
 - Fully offline — pure math on elevation data
 
 ## Weather
@@ -72,6 +84,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Current weather at position
 - Forecast at waypoints along route (~50km spacing)
 - Weather timeline — conditions at estimated future positions within the selected riding horizon (uses ETA calculator)
+- Route weather projections include prior planned POI stop durations
 - Wind indicator: headwind/tailwind/crosswind relative to route direction
 - Cached when online, shows "last updated" timestamp
 

--- a/hooks/useActiveRouteTiming.ts
+++ b/hooks/useActiveRouteTiming.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from "react";
+import { useCollectionStore } from "@/store/collectionStore";
+import { activeRouteTiming } from "@/utils/activeRouteTiming";
+import type { ActiveRouteData } from "@/types";
+
+const MAX_CLOCK_REFRESH_MS = 60_000;
+const START_TRANSITION_GRACE_MS = 1_000;
+
+export function useActiveRouteTiming(activeData: ActiveRouteData | null) {
+  const collections = useCollectionStore((s) => s.collections);
+  const plannedStartMs =
+    activeData?.type === "collection"
+      ? (collections.find((collection) => collection.id === activeData.id)?.plannedStartMs ?? null)
+      : null;
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (plannedStartMs == null) return;
+
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const schedule = () => {
+      const now = Date.now();
+      if (plannedStartMs + START_TRANSITION_GRACE_MS <= now) {
+        return;
+      }
+      const msUntilStart = plannedStartMs - now + START_TRANSITION_GRACE_MS;
+      const delayMs = Math.max(1_000, Math.min(MAX_CLOCK_REFRESH_MS, msUntilStart));
+      timeout = setTimeout(() => {
+        setNowMs(Date.now());
+        schedule();
+      }, delayMs);
+    };
+
+    setNowMs(Date.now());
+    schedule();
+
+    return () => {
+      if (timeout) clearTimeout(timeout);
+    };
+  }, [plannedStartMs]);
+
+  return useMemo(
+    () => activeRouteTiming(activeData, collections, nowMs),
+    [activeData, collections, nowMs],
+  );
+}

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,6 +1,90 @@
+const path = require("path");
 const { getDefaultConfig } = require("expo/metro-config");
 const { withNativeWind } = require("nativewind/metro");
 
-const config = getDefaultConfig(__dirname);
+const projectRoot = __dirname;
+const config = getDefaultConfig(projectRoot);
 
-module.exports = withNativeWind(config, { input: "./global.css" });
+function normalizeNativeWindChangeEvent(event) {
+  if (!event || !Array.isArray(event.eventsQueue)) {
+    return event;
+  }
+
+  const addedFiles = new Map();
+  const modifiedFiles = new Map();
+  const removedFiles = new Map();
+
+  for (const change of event.eventsQueue) {
+    if (!change.filePath) {
+      continue;
+    }
+
+    const canonicalPath = path.relative(projectRoot, change.filePath);
+    const metadata = {
+      isSymlink: false,
+      modifiedTime: change.metadata?.modifiedTime ?? Date.now(),
+    };
+
+    if (change.type === "add") {
+      addedFiles.set(canonicalPath, metadata);
+    } else if (change.type === "delete" || change.type === "remove") {
+      removedFiles.set(canonicalPath, metadata);
+    } else {
+      modifiedFiles.set(canonicalPath, metadata);
+    }
+  }
+
+  return {
+    changes: {
+      addedDirectories: new Set(),
+      removedDirectories: new Set(),
+      addedFiles,
+      modifiedFiles,
+      removedFiles,
+    },
+    logger: null,
+    rootDir: projectRoot,
+  };
+}
+
+// NativeWind 4.2 emits Metro <=0.82 virtual style change payloads.
+function withNativeWindMetro83ChangeEventFix(metroConfig) {
+  const originalEnhanceMiddleware = metroConfig.server?.enhanceMiddleware;
+
+  return {
+    ...metroConfig,
+    server: {
+      ...metroConfig.server,
+      enhanceMiddleware(middleware, metroServer) {
+        const bundler = metroServer.getBundler().getBundler();
+
+        bundler.getDependencyGraph().then((graph) => {
+          const haste = graph?._haste;
+
+          if (!haste || haste.__nativewindMetro83ChangeEventFix) {
+            return;
+          }
+
+          const originalEmit = haste.emit.bind(haste);
+
+          haste.emit = (eventName, event) => {
+            return originalEmit(
+              eventName,
+              eventName === "change" ? normalizeNativeWindChangeEvent(event) : event,
+            );
+          };
+
+          haste.__nativewindMetro83ChangeEventFix = true;
+        });
+
+        return originalEnhanceMiddleware
+          ? originalEnhanceMiddleware(middleware, metroServer)
+          : middleware;
+      },
+    },
+  };
+}
+
+module.exports = withNativeWindMetro83ChangeEventFix(
+  withNativeWind(config, { input: "./global.css" }),
+);

--- a/services/activePOIs.ts
+++ b/services/activePOIs.ts
@@ -1,0 +1,13 @@
+import { toDisplayPOIs } from "@/services/displayDistance";
+import { stitchPOIs } from "@/services/stitchingService";
+import type { DisplayPOI, POI, StitchedSegmentInfo } from "@/types";
+
+export function displayPOIsForActiveRoute(
+  routeIds: string[],
+  segments: StitchedSegmentInfo[] | null,
+  poisByRoute: Record<string, POI[]>,
+): DisplayPOI[] {
+  if (routeIds.length === 0) return [];
+  if (segments) return stitchPOIs(segments, poisByRoute);
+  return routeIds.flatMap((routeId) => toDisplayPOIs(poisByRoute[routeId] ?? []));
+}

--- a/services/plannedStops.ts
+++ b/services/plannedStops.ts
@@ -1,0 +1,93 @@
+import type { DisplayDistanceMeters, DisplayPOI, ETAResult } from "@/types";
+
+export const PLANNED_STOP_DURATION_MINUTES_TAG = "planned_stop_duration_minutes";
+
+export interface PlannedStop {
+  poiId: string;
+  distanceMeters: DisplayDistanceMeters;
+  durationSeconds: number;
+}
+
+export function getPlannedStopDurationMinutes(
+  poiOrTags: Pick<DisplayPOI, "tags"> | Record<string, string>,
+): number {
+  const maybeTags = (poiOrTags as { tags?: unknown }).tags;
+  const tags =
+    maybeTags != null && typeof maybeTags === "object"
+      ? (maybeTags as Record<string, string>)
+      : (poiOrTags as Record<string, string>);
+  const raw = tags[PLANNED_STOP_DURATION_MINUTES_TAG];
+  if (!raw) return 0;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return 0;
+  return parsed;
+}
+
+export function setPlannedStopDurationTag(
+  tags: Record<string, string>,
+  durationMinutes: number,
+): Record<string, string> {
+  const next = { ...tags };
+  const normalized = Math.max(0, Math.round(durationMinutes));
+  if (normalized > 0) {
+    next[PLANNED_STOP_DURATION_MINUTES_TAG] = String(normalized);
+  } else {
+    delete next[PLANNED_STOP_DURATION_MINUTES_TAG];
+  }
+  return next;
+}
+
+export function plannedStopsFromPOIs(pois: DisplayPOI[]): PlannedStop[] {
+  return pois
+    .map((poi) => {
+      const durationMinutes = getPlannedStopDurationMinutes(poi);
+      if (durationMinutes <= 0) return null;
+      return {
+        poiId: poi.id,
+        distanceMeters: poi.effectiveDistanceMeters,
+        durationSeconds: durationMinutes * 60,
+      };
+    })
+    .filter((stop): stop is PlannedStop => stop != null)
+    .sort((a, b) => a.distanceMeters - b.distanceMeters);
+}
+
+export function plannedStopOffsetSecondsBeforeDistance(
+  plannedStops: readonly PlannedStop[] | null | undefined,
+  currentDistanceMeters: number,
+  targetDistanceMeters: number,
+): number {
+  if (!plannedStops?.length || targetDistanceMeters <= currentDistanceMeters) return 0;
+  let totalSeconds = 0;
+  for (const stop of plannedStops) {
+    if (stop.distanceMeters <= currentDistanceMeters) continue;
+    if (stop.distanceMeters >= targetDistanceMeters) continue;
+    totalSeconds += stop.durationSeconds;
+  }
+  return totalSeconds;
+}
+
+export function applyPlannedStopOffsetToETA(
+  eta: ETAResult | null,
+  offsetSeconds: number,
+  etaStartTimeMs?: number | null,
+): ETAResult | null {
+  if (!eta || offsetSeconds <= 0) return eta;
+  const ridingTimeSeconds = eta.ridingTimeSeconds + offsetSeconds;
+  return {
+    ...eta,
+    ridingTimeSeconds,
+    eta:
+      etaStartTimeMs != null
+        ? new Date(etaStartTimeMs + ridingTimeSeconds * 1000)
+        : new Date(eta.eta.getTime() + offsetSeconds * 1000),
+  };
+}
+
+export function departureTimeAfterPlannedStop(
+  eta: ETAResult | null,
+  durationMinutes: number,
+): Date | null {
+  if (!eta || durationMinutes <= 0) return null;
+  return new Date(eta.eta.getTime() + durationMinutes * 60_000);
+}

--- a/services/upcomingTimeline.ts
+++ b/services/upcomingTimeline.ts
@@ -1,0 +1,362 @@
+import { getClimbDifficulty } from "@/constants/climbHelpers";
+import { getETAToDistanceFromDistance } from "@/services/etaCalculator";
+import {
+  applyPlannedStopOffsetToETA,
+  getPlannedStopDurationMinutes,
+  plannedStopOffsetSecondsBeforeDistance,
+  type PlannedStop,
+} from "@/services/plannedStops";
+import {
+  isDistanceInWindow,
+  isDistanceRangeInWindow,
+  type DistanceWindow,
+} from "@/utils/ridingHorizon";
+import type {
+  DisplayClimb,
+  DisplayDistanceMeters,
+  DisplayPOI,
+  ETAResult,
+  RoutePoint,
+  StitchedSegmentInfo,
+} from "@/types";
+
+export type UpcomingEventKind =
+  | "poi"
+  | "climb-span"
+  | "climb-start"
+  | "climb-top"
+  | "segment-transition"
+  | "finish";
+
+interface UpcomingEventBase {
+  id: string;
+  kind: UpcomingEventKind;
+  distanceMeters: DisplayDistanceMeters;
+  eta: ETAResult | null;
+}
+
+export interface UpcomingPOIEvent extends UpcomingEventBase {
+  kind: "poi";
+  poi: DisplayPOI;
+}
+
+export interface UpcomingClimbSpanEvent extends UpcomingEventBase {
+  kind: "climb-span";
+  climb: DisplayClimb;
+}
+
+export interface UpcomingClimbPointEvent extends UpcomingEventBase {
+  kind: "climb-start" | "climb-top";
+  climb: DisplayClimb;
+}
+
+export interface UpcomingSegmentTransitionEvent extends UpcomingEventBase {
+  kind: "segment-transition";
+  fromSegment: StitchedSegmentInfo;
+  toSegment: StitchedSegmentInfo;
+}
+
+export interface UpcomingFinishEvent extends UpcomingEventBase {
+  kind: "finish";
+  label: string;
+}
+
+export type UpcomingEvent =
+  | UpcomingPOIEvent
+  | UpcomingClimbSpanEvent
+  | UpcomingClimbPointEvent
+  | UpcomingSegmentTransitionEvent
+  | UpcomingFinishEvent;
+
+export interface BuildUpcomingTimelineInput {
+  pois: DisplayPOI[];
+  starredPOIIds: ReadonlySet<string>;
+  climbs: DisplayClimb[];
+  segments: StitchedSegmentInfo[] | null;
+  totalDistanceMeters: number;
+  currentDistanceMeters: number | null;
+  horizonWindow?: DistanceWindow;
+  routePoints?: RoutePoint[] | null;
+  cumulativeTime?: number[] | null;
+  etaStartTimeMs?: number | null;
+  plannedStops?: readonly PlannedStop[] | null;
+}
+
+const EVENT_ORDER: Record<UpcomingEventKind, number> = {
+  "climb-start": 0,
+  "segment-transition": 1,
+  poi: 2,
+  "climb-span": 3,
+  "climb-top": 4,
+  finish: 5,
+};
+
+export function buildUpcomingTimeline({
+  pois,
+  starredPOIIds,
+  climbs,
+  segments,
+  totalDistanceMeters,
+  currentDistanceMeters,
+  horizonWindow,
+  routePoints,
+  cumulativeTime,
+  etaStartTimeMs,
+  plannedStops,
+}: BuildUpcomingTimelineInput): UpcomingEvent[] {
+  const anchorDistanceMeters = Math.max(0, currentDistanceMeters ?? 0);
+  const events: UpcomingEvent[] = [];
+  const importantPOIs = getImportantPOIs(pois, starredPOIIds, horizonWindow, anchorDistanceMeters);
+
+  for (const poi of importantPOIs) {
+    events.push({
+      id: `poi:${poi.id}`,
+      kind: "poi",
+      distanceMeters: poi.effectiveDistanceMeters,
+      eta: resolveETA(
+        cumulativeTime,
+        routePoints,
+        anchorDistanceMeters,
+        poi.effectiveDistanceMeters,
+        etaStartTimeMs,
+        plannedStops,
+      ),
+      poi,
+    });
+  }
+
+  for (const climb of climbs) {
+    if (
+      !isDistanceRangeInUpcomingWindow(
+        climb.effectiveStartDistanceMeters,
+        climb.effectiveEndDistanceMeters,
+        horizonWindow,
+        anchorDistanceMeters,
+      )
+    ) {
+      continue;
+    }
+
+    const hasImportantPOIInside = importantPOIs.some(
+      (poi) =>
+        poi.effectiveDistanceMeters >= climb.effectiveStartDistanceMeters &&
+        poi.effectiveDistanceMeters <= climb.effectiveEndDistanceMeters,
+    );
+    const shouldSplit =
+      getClimbDifficulty(climb.difficultyScore) !== "low" || hasImportantPOIInside;
+
+    if (shouldSplit) {
+      if (
+        isPointInUpcomingWindow(
+          climb.effectiveStartDistanceMeters,
+          horizonWindow,
+          anchorDistanceMeters,
+        )
+      ) {
+        events.push({
+          id: `climb-start:${climb.id}`,
+          kind: "climb-start",
+          distanceMeters: climb.effectiveStartDistanceMeters,
+          eta: resolveETA(
+            cumulativeTime,
+            routePoints,
+            anchorDistanceMeters,
+            climb.effectiveStartDistanceMeters,
+            etaStartTimeMs,
+            plannedStops,
+          ),
+          climb,
+        });
+      }
+      if (
+        isPointInUpcomingWindow(
+          climb.effectiveEndDistanceMeters,
+          horizonWindow,
+          anchorDistanceMeters,
+        )
+      ) {
+        events.push({
+          id: `climb-top:${climb.id}`,
+          kind: "climb-top",
+          distanceMeters: climb.effectiveEndDistanceMeters,
+          eta: resolveETA(
+            cumulativeTime,
+            routePoints,
+            anchorDistanceMeters,
+            climb.effectiveEndDistanceMeters,
+            etaStartTimeMs,
+            plannedStops,
+          ),
+          climb,
+        });
+      }
+      continue;
+    }
+
+    events.push({
+      id: `climb-span:${climb.id}`,
+      kind: "climb-span",
+      distanceMeters: climb.effectiveStartDistanceMeters,
+      eta: resolveETA(
+        cumulativeTime,
+        routePoints,
+        anchorDistanceMeters,
+        climb.effectiveStartDistanceMeters,
+        etaStartTimeMs,
+        plannedStops,
+      ),
+      climb,
+    });
+  }
+
+  if (segments) {
+    for (let i = 0; i < segments.length - 1; i++) {
+      const fromSegment = segments[i];
+      const toSegment = segments[i + 1];
+      const distanceMeters = toSegment.distanceOffsetMeters as DisplayDistanceMeters;
+      if (!isPointInUpcomingWindow(distanceMeters, horizonWindow, anchorDistanceMeters)) continue;
+      events.push({
+        id: `segment:${fromSegment.routeId}:${toSegment.routeId}:${toSegment.position}`,
+        kind: "segment-transition",
+        distanceMeters,
+        eta: resolveETA(
+          cumulativeTime,
+          routePoints,
+          anchorDistanceMeters,
+          distanceMeters,
+          etaStartTimeMs,
+          plannedStops,
+        ),
+        fromSegment,
+        toSegment,
+      });
+    }
+  }
+
+  const finishDistanceMeters = totalDistanceMeters as DisplayDistanceMeters;
+  if (
+    totalDistanceMeters > 0 &&
+    isPointInUpcomingWindow(finishDistanceMeters, horizonWindow, anchorDistanceMeters)
+  ) {
+    events.push({
+      id: "finish",
+      kind: "finish",
+      distanceMeters: finishDistanceMeters,
+      eta: resolveETA(
+        cumulativeTime,
+        routePoints,
+        anchorDistanceMeters,
+        finishDistanceMeters,
+        etaStartTimeMs,
+        plannedStops,
+      ),
+      label: segments ? "Collection finish" : "Route finish",
+    });
+  }
+
+  return events.sort(compareUpcomingEvents);
+}
+
+export function resolveUpcomingHorizonETA({
+  totalDistanceMeters,
+  currentDistanceMeters,
+  horizonWindow,
+  routePoints,
+  cumulativeTime,
+  etaStartTimeMs,
+  plannedStops,
+}: Pick<
+  BuildUpcomingTimelineInput,
+  | "totalDistanceMeters"
+  | "currentDistanceMeters"
+  | "horizonWindow"
+  | "routePoints"
+  | "cumulativeTime"
+  | "etaStartTimeMs"
+  | "plannedStops"
+>): ETAResult | null {
+  const anchorDistanceMeters = Math.max(0, currentDistanceMeters ?? 0);
+  const targetDistanceMeters = horizonWindow?.endDistanceMeters ?? totalDistanceMeters;
+  if (targetDistanceMeters == null || targetDistanceMeters <= anchorDistanceMeters) return null;
+  return resolveETA(
+    cumulativeTime,
+    routePoints,
+    anchorDistanceMeters,
+    Math.min(totalDistanceMeters, targetDistanceMeters) as DisplayDistanceMeters,
+    etaStartTimeMs,
+    plannedStops,
+  );
+}
+
+function getImportantPOIs(
+  pois: DisplayPOI[],
+  starredPOIIds: ReadonlySet<string>,
+  horizonWindow: DistanceWindow | undefined,
+  anchorDistanceMeters: number,
+): DisplayPOI[] {
+  return pois
+    .filter(
+      (poi) =>
+        poi.source === "custom" ||
+        starredPOIIds.has(poi.id) ||
+        getPlannedStopDurationMinutes(poi) > 0,
+    )
+    .filter((poi) =>
+      isPointInUpcomingWindow(poi.effectiveDistanceMeters, horizonWindow, anchorDistanceMeters),
+    )
+    .sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
+}
+
+function isPointInUpcomingWindow(
+  distanceMeters: number,
+  horizonWindow: DistanceWindow | undefined,
+  anchorDistanceMeters: number,
+): boolean {
+  if (horizonWindow) return isDistanceInWindow(distanceMeters, horizonWindow);
+  return distanceMeters >= anchorDistanceMeters;
+}
+
+function isDistanceRangeInUpcomingWindow(
+  startDistanceMeters: number,
+  endDistanceMeters: number,
+  horizonWindow: DistanceWindow | undefined,
+  anchorDistanceMeters: number,
+): boolean {
+  if (horizonWindow)
+    return isDistanceRangeInWindow(startDistanceMeters, endDistanceMeters, horizonWindow);
+  return endDistanceMeters >= anchorDistanceMeters;
+}
+
+function resolveETA(
+  cumulativeTime: number[] | null | undefined,
+  routePoints: RoutePoint[] | null | undefined,
+  currentDistanceMeters: number,
+  targetDistanceMeters: DisplayDistanceMeters,
+  etaStartTimeMs?: number | null,
+  plannedStops?: readonly PlannedStop[] | null,
+): ETAResult | null {
+  if (!cumulativeTime || !routePoints?.length) return null;
+  const eta = getETAToDistanceFromDistance(
+    cumulativeTime,
+    routePoints,
+    currentDistanceMeters,
+    targetDistanceMeters,
+  );
+  const stopOffsetSeconds = plannedStopOffsetSecondsBeforeDistance(
+    plannedStops,
+    currentDistanceMeters,
+    targetDistanceMeters,
+  );
+  const withStops = applyPlannedStopOffsetToETA(eta, stopOffsetSeconds, etaStartTimeMs);
+  if (!withStops || etaStartTimeMs == null) return withStops;
+  return {
+    ...withStops,
+    eta: new Date(etaStartTimeMs + withStops.ridingTimeSeconds * 1000),
+  };
+}
+
+function compareUpcomingEvents(a: UpcomingEvent, b: UpcomingEvent): number {
+  const distanceDelta = a.distanceMeters - b.distanceMeters;
+  if (distanceDelta !== 0) return distanceDelta;
+  return EVENT_ORDER[a.kind] - EVENT_ORDER[b.kind];
+}

--- a/services/weatherService.ts
+++ b/services/weatherService.ts
@@ -6,6 +6,11 @@ import {
 } from "@/constants";
 import { fetchForecasts, type HourlyForecast } from "./weatherClient";
 import { getETAToDistanceFromDistance } from "./etaCalculator";
+import {
+  applyPlannedStopOffsetToETA,
+  plannedStopOffsetSecondsBeforeDistance,
+  type PlannedStop,
+} from "./plannedStops";
 import { computeBearing, interpolateRoutePointAtDistance } from "@/utils/geo";
 
 const POST_FINISH_FORECAST_HOURS = 5;
@@ -30,6 +35,7 @@ type WeatherDisplaySample = WeatherWaypoint & {
 
 export interface WeatherTimelineOptions {
   projectionStartTime?: Date;
+  plannedStops?: readonly PlannedStop[];
 }
 
 export interface WeatherTimelineBuildResult {
@@ -158,41 +164,85 @@ function ridingTimeToRoutePosition(
   cumulativeTime: number[],
   points: RoutePoint[],
   fromDistanceAlongRouteM: number,
-  ridingTimeSeconds: number,
+  elapsedTimeSeconds: number,
+  plannedStops?: readonly PlannedStop[],
 ): WeatherWaypoint | null {
   if (points.length === 0 || cumulativeTime.length === 0) return null;
   const startDist = validRouteStartDistance(points, fromDistanceAlongRouteM);
   if (startDist == null) return null;
 
   const routeEndMeters = points[points.length - 1].distanceFromStartMeters;
-  const fromTime = getRouteTimeAtDistance(cumulativeTime, points, startDist);
-  if (fromTime == null) return null;
-  const targetTime = fromTime + Math.max(0, ridingTimeSeconds);
+  const targetElapsedSeconds = Math.max(0, elapsedTimeSeconds);
+  if (!plannedStops?.length) {
+    const fromTime = getRouteTimeAtDistance(cumulativeTime, points, startDist);
+    if (fromTime == null) return null;
+    const targetTime = fromTime + targetElapsedSeconds;
 
-  for (let index = 1; index < points.length; index++) {
-    const prevTime = cumulativeTime[index - 1];
-    const nextTime = cumulativeTime[index];
-    if (nextTime < targetTime) continue;
+    for (let index = 1; index < points.length; index++) {
+      const prevTime = cumulativeTime[index - 1];
+      const nextTime = cumulativeTime[index];
+      if (nextTime < targetTime) continue;
 
-    const prevPoint = points[index - 1];
-    const nextPoint = points[index];
-    const timeDelta = nextTime - prevTime;
-    const progress = timeDelta > 0 ? (targetTime - prevTime) / timeDelta : 0;
-    const clampedProgress = Math.max(0, Math.min(1, progress));
-    const routeDistanceMeters =
-      prevPoint.distanceFromStartMeters +
-      (nextPoint.distanceFromStartMeters - prevPoint.distanceFromStartMeters) * clampedProgress;
+      const prevPoint = points[index - 1];
+      const nextPoint = points[index];
+      const timeDelta = nextTime - prevTime;
+      const progress = timeDelta > 0 ? (targetTime - prevTime) / timeDelta : 0;
+      const clampedProgress = Math.max(0, Math.min(1, progress));
+      const routeDistanceMeters =
+        prevPoint.distanceFromStartMeters +
+        (nextPoint.distanceFromStartMeters - prevPoint.distanceFromStartMeters) * clampedProgress;
 
-    if (routeDistanceMeters < startDist) continue;
+      if (routeDistanceMeters < startDist) continue;
 
+      return {
+        latitude: prevPoint.latitude + (nextPoint.latitude - prevPoint.latitude) * clampedProgress,
+        longitude:
+          prevPoint.longitude + (nextPoint.longitude - prevPoint.longitude) * clampedProgress,
+        distanceAlongRouteM: routeDistanceMeters - startDist,
+        routeDistanceMeters,
+        index,
+        segmentIndex: Math.max(0, index - 1),
+      };
+    }
+  }
+
+  if (targetElapsedSeconds <= 0) {
+    const start = interpolateRoutePointAtDistance(points, startDist);
+    return start
+      ? {
+          latitude: start.latitude,
+          longitude: start.longitude,
+          distanceAlongRouteM: 0,
+          routeDistanceMeters: startDist,
+          index: start.nearestIndex,
+          segmentIndex: start.segmentIndex,
+        }
+      : null;
+  }
+
+  let lo = startDist;
+  let hi = routeEndMeters;
+  for (let i = 0; i < 24; i++) {
+    const mid = lo + (hi - lo) / 2;
+    const eta = etaToDistanceWithStops(cumulativeTime, points, startDist, mid, plannedStops);
+    if ((eta?.ridingTimeSeconds ?? 0) < targetElapsedSeconds) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+
+  const routeDistanceMeters = hi;
+  if (routeDistanceMeters < routeEndMeters) {
+    const point = interpolateRoutePointAtDistance(points, routeDistanceMeters);
+    if (!point) return null;
     return {
-      latitude: prevPoint.latitude + (nextPoint.latitude - prevPoint.latitude) * clampedProgress,
-      longitude:
-        prevPoint.longitude + (nextPoint.longitude - prevPoint.longitude) * clampedProgress,
+      latitude: point.latitude,
+      longitude: point.longitude,
       distanceAlongRouteM: routeDistanceMeters - startDist,
       routeDistanceMeters,
-      index,
-      segmentIndex: Math.max(0, index - 1),
+      index: point.nearestIndex,
+      segmentIndex: point.segmentIndex,
     };
   }
 
@@ -221,10 +271,11 @@ function routeDisplaySamples(
   cumulativeTime: number[],
   points: RoutePoint[],
   fromDistanceAlongRouteM: number,
-  finishRidingTimeSeconds: number,
+  finishElapsedTimeSeconds: number,
+  plannedStops?: readonly PlannedStop[],
 ): WeatherDisplaySample[] {
   const samples: WeatherDisplaySample[] = [];
-  const finishSeconds = Math.max(0, finishRidingTimeSeconds);
+  const finishSeconds = Math.max(0, finishElapsedTimeSeconds);
   const routeEndMeters = points[points.length - 1]?.distanceFromStartMeters ?? 0;
 
   const addSample = (ridingTimeSeconds: number, sampleKind: WeatherSampleKind) => {
@@ -233,6 +284,7 @@ function routeDisplaySamples(
       points,
       fromDistanceAlongRouteM,
       ridingTimeSeconds,
+      plannedStops,
     );
     if (!position) return;
     const distanceKey = Math.round(position.routeDistanceMeters / 100);
@@ -259,11 +311,12 @@ function routeDisplaySamples(
     routeDistanceMeters < routeEndMeters;
     routeDistanceMeters += ROUTE_DISPLAY_SAMPLE_DISTANCE_M
   ) {
-    const eta = getETAToDistanceFromDistance(
+    const eta = etaToDistanceWithStops(
       cumulativeTime,
       points,
       fromDistanceAlongRouteM,
       routeDistanceMeters,
+      plannedStops,
     );
     if (eta) addSample(eta.ridingTimeSeconds, "distance");
   }
@@ -276,6 +329,27 @@ function routeDisplaySamples(
   }
 
   return samples.sort((a, b) => a.routeDistanceMeters - b.routeDistanceMeters);
+}
+
+function etaToDistanceWithStops(
+  cumulativeTime: number[],
+  points: RoutePoint[],
+  fromDistanceAlongRouteM: number,
+  targetDistanceAlongRouteM: number,
+  plannedStops?: readonly PlannedStop[],
+) {
+  const eta = getETAToDistanceFromDistance(
+    cumulativeTime,
+    points,
+    fromDistanceAlongRouteM,
+    targetDistanceAlongRouteM,
+  );
+  const offsetSeconds = plannedStopOffsetSecondsBeforeDistance(
+    plannedStops,
+    fromDistanceAlongRouteM,
+    targetDistanceAlongRouteM,
+  );
+  return applyPlannedStopOffsetToETA(eta, offsetSeconds);
 }
 
 function hasForecastCoverage(
@@ -324,21 +398,23 @@ export async function fetchWeatherForecastsForRoute(
   if (waypoints.length === 0) return [];
 
   const routeEndMeters = points[points.length - 1].distanceFromStartMeters;
-  const finishEta = getETAToDistanceFromDistance(
+  const finishEta = etaToDistanceWithStops(
     cumulativeTime,
     points,
     fromDistanceAlongRouteM,
     routeEndMeters,
+    options.plannedStops,
   );
   const maxRidingTimeSeconds =
     finishEta?.ridingTimeSeconds ??
     Math.max(
       ...waypoints.map((waypoint) => {
-        const eta = getETAToDistanceFromDistance(
+        const eta = etaToDistanceWithStops(
           cumulativeTime,
           points,
           fromDistanceAlongRouteM,
           waypoint.routeDistanceMeters,
+          options.plannedStops,
         );
         return eta?.ridingTimeSeconds ?? 0;
       }),
@@ -364,11 +440,12 @@ export function buildWeatherTimelineFromForecasts(
   if (waypoints.length === 0 || forecasts.length === 0) return emptyBuildResult(forecasts);
 
   const waypointETAs = waypoints.map((waypoint) => {
-    const eta = getETAToDistanceFromDistance(
+    const eta = etaToDistanceWithStops(
       cumulativeTime,
       points,
       startDist,
       waypoint.routeDistanceMeters,
+      options.plannedStops,
     );
     return {
       waypoint,
@@ -378,7 +455,13 @@ export function buildWeatherTimelineFromForecasts(
   });
 
   const routeEndMeters = points[points.length - 1].distanceFromStartMeters;
-  const finishEta = getETAToDistanceFromDistance(cumulativeTime, points, startDist, routeEndMeters);
+  const finishEta = etaToDistanceWithStops(
+    cumulativeTime,
+    points,
+    startDist,
+    routeEndMeters,
+    options.plannedStops,
+  );
   const maxRidingTimeSeconds =
     finishEta?.ridingTimeSeconds ?? Math.max(...waypointETAs.map((wp) => wp.ridingTimeSeconds));
 
@@ -401,6 +484,7 @@ export function buildWeatherTimelineFromForecasts(
     points,
     startDist,
     maxRidingTimeSeconds,
+    options.plannedStops,
   );
 
   for (let index = 0; index < displaySamples.length; index++) {

--- a/services/weatherService.ts
+++ b/services/weatherService.ts
@@ -207,24 +207,35 @@ function ridingTimeToRoutePosition(
   }
 
   if (targetElapsedSeconds <= 0) {
-    const start = interpolateRoutePointAtDistance(points, startDist);
-    return start
-      ? {
-          latitude: start.latitude,
-          longitude: start.longitude,
-          distanceAlongRouteM: 0,
-          routeDistanceMeters: startDist,
-          index: start.nearestIndex,
-          segmentIndex: start.segmentIndex,
-        }
-      : null;
+    return waypointAtRouteDistance(points, startDist, startDist);
+  }
+
+  const stopPlan = plannedStops ?? [];
+  for (const stop of stopPlan) {
+    if (stop.distanceMeters <= startDist || stop.distanceMeters >= routeEndMeters) continue;
+    const arrivalEta = etaToDistanceWithStops(
+      cumulativeTime,
+      points,
+      startDist,
+      stop.distanceMeters,
+      stopPlan,
+    );
+    if (!arrivalEta) continue;
+    const stopArrivalSeconds = arrivalEta.ridingTimeSeconds;
+    const stopDepartureSeconds = stopArrivalSeconds + stop.durationSeconds;
+    if (
+      targetElapsedSeconds >= stopArrivalSeconds &&
+      targetElapsedSeconds <= stopDepartureSeconds
+    ) {
+      return waypointAtRouteDistance(points, startDist, stop.distanceMeters);
+    }
   }
 
   let lo = startDist;
   let hi = routeEndMeters;
   for (let i = 0; i < 24; i++) {
     const mid = lo + (hi - lo) / 2;
-    const eta = etaToDistanceWithStops(cumulativeTime, points, startDist, mid, plannedStops);
+    const eta = etaToDistanceWithStops(cumulativeTime, points, startDist, mid, stopPlan);
     if ((eta?.ridingTimeSeconds ?? 0) < targetElapsedSeconds) {
       lo = mid;
     } else {
@@ -255,6 +266,23 @@ function ridingTimeToRoutePosition(
     routeDistanceMeters: routeEndMeters,
     index: finish.nearestIndex,
     segmentIndex: finish.segmentIndex,
+  };
+}
+
+function waypointAtRouteDistance(
+  points: RoutePoint[],
+  startDist: number,
+  routeDistanceMeters: number,
+): WeatherWaypoint | null {
+  const point = interpolateRoutePointAtDistance(points, routeDistanceMeters);
+  if (!point) return null;
+  return {
+    latitude: point.latitude,
+    longitude: point.longitude,
+    distanceAlongRouteM: routeDistanceMeters - startDist,
+    routeDistanceMeters,
+    index: point.nearestIndex,
+    segmentIndex: point.segmentIndex,
   };
 }
 

--- a/store/etaStore.ts
+++ b/store/etaStore.ts
@@ -8,11 +8,19 @@ import type {
   DisplayPOI,
 } from "@/types";
 import { DEFAULT_POWER_CONFIG } from "@/constants";
+import { displayPOIsForActiveRoute } from "@/services/activePOIs";
 import { computeRouteETA, getETAToDistanceFromDistance } from "@/services/etaCalculator";
 import { toDisplayPOIForSegments } from "@/services/displayDistance";
+import { futureStartMs } from "@/utils/activeRouteTiming";
+import {
+  applyPlannedStopOffsetToETA,
+  plannedStopOffsetSecondsBeforeDistance,
+  plannedStopsFromPOIs,
+} from "@/services/plannedStops";
 import { resolveRouteProgress } from "@/utils/routeProgress";
 import { useRouteStore } from "./routeStore";
 import { useCollectionStore } from "./collectionStore";
+import { usePoiStore } from "./poiStore";
 
 let storage: MMKV | null = null;
 
@@ -37,6 +45,24 @@ function plannedStartForRoute(routeId: string): number | null {
   if (stitched?.collectionId !== routeId) return null;
   const collection = collectionState.collections.find((c) => c.id === routeId);
   return collection?.plannedStartMs ?? null;
+}
+
+function plannedStopsForRoute(routeId: string) {
+  const poiState = usePoiStore.getState();
+  const collectionState = useCollectionStore.getState();
+  const stitched = collectionState.activeStitchedCollection;
+
+  if (stitched?.collectionId === routeId) {
+    return plannedStopsFromPOIs(
+      displayPOIsForActiveRoute(
+        stitched.segments.map((segment) => segment.routeId),
+        stitched.segments,
+        poiState.pois,
+      ),
+    );
+  }
+
+  return plannedStopsFromPOIs(displayPOIsForActiveRoute([routeId], null, poiState.pois));
 }
 
 interface ETAState {
@@ -115,13 +141,22 @@ export const useEtaStore = create<ETAState>((set, get) => ({
     );
     if (!result) return null;
 
-    if (plannedStartMs != null && plannedStartMs > Date.now()) {
+    const etaStartMs = futureStartMs(plannedStartMs);
+    const stopOffsetSeconds = plannedStopOffsetSecondsBeforeDistance(
+      plannedStopsForRoute(routeId),
+      routeProgress.distanceAlongRouteMeters,
+      targetDistM,
+    );
+    const withStops = applyPlannedStopOffsetToETA(result, stopOffsetSeconds, etaStartMs);
+    if (!withStops) return null;
+
+    if (etaStartMs != null) {
       return {
-        ...result,
-        eta: new Date(plannedStartMs + result.ridingTimeSeconds * 1000),
+        ...withStops,
+        eta: new Date(etaStartMs + withStops.ridingTimeSeconds * 1000),
       };
     }
 
-    return result;
+    return withStops;
   },
 }));

--- a/store/panelStore.ts
+++ b/store/panelStore.ts
@@ -36,7 +36,13 @@ interface PanelState {
 
 const DEFAULT_PANEL_MODE: PanelMode = "upcoming-50";
 
-const PANEL_TABS: ReadonlySet<PanelTab> = new Set(["profile", "weather", "climbs", "pois"]);
+const PANEL_TABS: ReadonlySet<PanelTab> = new Set([
+  "profile",
+  "upcoming",
+  "weather",
+  "climbs",
+  "pois",
+]);
 
 function readPanelMode(): PanelMode {
   const raw = readString("panelMode");

--- a/store/poiStore.ts
+++ b/store/poiStore.ts
@@ -27,6 +27,7 @@ import {
 } from "@/db/database";
 import { fetchOsmPOIs, fetchGooglePOIs } from "@/services/poiFetcher";
 import { getOpeningHoursStatus } from "@/services/openingHoursParser";
+import { setPlannedStopDurationTag } from "@/services/plannedStops";
 import { usePanelStore } from "./panelStore";
 
 const LEGACY_STARRED_POI_IDS_KEY = "starredPOIIds";
@@ -256,6 +257,11 @@ interface POIState {
   clearSource: (routeId: string, source: POIFetchedSource) => Promise<void>;
   addCustomPOI: (poi: POI) => Promise<void>;
   updatePOINotes: (routeId: string, poiId: string, notes: string) => Promise<void>;
+  updatePlannedStopDuration: (
+    routeId: string,
+    poiId: string,
+    durationMinutes: number,
+  ) => Promise<void>;
   deleteCustomPOI: (routeId: string, poiId: string) => Promise<void>;
   toggleCategory: (category: POICategory) => void;
   setEnabledCategories: (categories: POICategory[]) => void;
@@ -451,6 +457,25 @@ export const usePoiStore = create<POIState>((set, get) => ({
     if (trimmed) nextTags.notes = trimmed;
     else delete nextTags.notes;
 
+    await updatePOITags(poiId, nextTags);
+    const pois = await getPOIsForRoute(routeId);
+
+    set((s) => {
+      const selectedPOI =
+        s.selectedPOI?.id === poiId ? { ...s.selectedPOI, tags: nextTags } : s.selectedPOI;
+      return {
+        pois: { ...s.pois, [routeId]: pois },
+        selectedPOI,
+      };
+    });
+  },
+
+  updatePlannedStopDuration: async (routeId, poiId, durationMinutes) => {
+    const routePois = get().pois[routeId] ?? (await getPOIsForRoute(routeId));
+    const poi = routePois.find((p) => p.id === poiId);
+    if (!poi) return;
+
+    const nextTags = setPlannedStopDurationTag(poi.tags, durationMinutes);
     await updatePOITags(poiId, nextTags);
     const pois = await getPOIsForRoute(routeId);
 

--- a/store/weatherStore.ts
+++ b/store/weatherStore.ts
@@ -7,10 +7,11 @@ import {
   fetchWeatherForecastsForRoute,
 } from "@/services/weatherService";
 import type { HourlyForecast } from "@/services/weatherClient";
+import type { PlannedStop } from "@/services/plannedStops";
 import { useOfflineStore } from "./offlineStore";
 
 let storage: MMKV | null = null;
-const WEATHER_CACHE_VERSION = 2;
+const WEATHER_CACHE_VERSION = 3;
 
 function getStorage(): MMKV {
   if (!storage) {
@@ -33,6 +34,7 @@ interface CachedWeather {
   fetchedAt: number;
   routeId: string;
   plannedStartMs: number | null;
+  plannedStopSignature: string;
   fromDistanceAlongRouteMeters: number;
   forecastFromMs: number | null;
   forecastUntilMs: number | null;
@@ -69,8 +71,20 @@ function isFresh(fetchAt: number | null): boolean {
   return fetchAt != null && Date.now() - fetchAt < WEATHER_STALE_MS;
 }
 
-function contextKey(routeId: string, plannedStartMs: number | null, fromDistanceMeters: number) {
-  return `${routeId}:${plannedStartMs ?? "now"}:${Math.round(fromDistanceMeters / 100)}`;
+function plannedStopSignature(plannedStops: readonly PlannedStop[] | null | undefined): string {
+  if (!plannedStops?.length) return "none";
+  return plannedStops
+    .map((stop) => `${Math.round(stop.distanceMeters)}:${stop.durationSeconds}`)
+    .join(",");
+}
+
+function contextKey(
+  routeId: string,
+  plannedStartMs: number | null,
+  fromDistanceMeters: number,
+  stopSignature: string,
+) {
+  return `${routeId}:${plannedStartMs ?? "now"}:${Math.round(fromDistanceMeters / 100)}:${stopSignature}`;
 }
 
 function cacheMatchesContext(
@@ -78,10 +92,12 @@ function cacheMatchesContext(
   routeId: string,
   plannedStartMs: number | null,
   fromDistanceMeters: number,
+  stopSignature: string,
 ): boolean {
   return (
     cache?.routeId === routeId &&
     cache.plannedStartMs === plannedStartMs &&
+    cache.plannedStopSignature === stopSignature &&
     Math.abs(cache.fromDistanceAlongRouteMeters - fromDistanceMeters) < 100
   );
 }
@@ -100,8 +116,13 @@ function rebuildCachedWeather(
   fromDistanceAlongRouteMeters: number,
   cumulativeTime: number[],
   plannedStartMs: number | null,
+  plannedStops: readonly PlannedStop[],
+  stopSignature: string,
 ): CachedWeather | null {
-  const options = plannedStartMs ? { projectionStartTime: new Date(plannedStartMs) } : {};
+  const options = {
+    ...(plannedStartMs ? { projectionStartTime: new Date(plannedStartMs) } : {}),
+    plannedStops,
+  };
   const buildResult = buildWeatherTimelineFromForecasts(
     points,
     fromDistanceAlongRouteMeters,
@@ -113,6 +134,7 @@ function rebuildCachedWeather(
   return {
     ...cache,
     timeline: buildResult.timeline,
+    plannedStopSignature: stopSignature,
     fromDistanceAlongRouteMeters,
     forecastFromMs: buildResult.forecastFromMs,
     forecastUntilMs: buildResult.forecastUntilMs,
@@ -136,6 +158,7 @@ interface WeatherState {
   routeCoverageUntilMeters: number | null;
   routeId: string | null;
   plannedStartMs: number | null;
+  plannedStopSignature: string;
   fromDistanceAlongRouteMeters: number | null;
 
   fetchWeather: (
@@ -144,6 +167,7 @@ interface WeatherState {
     fromDistanceAlongRouteMeters: number,
     cumulativeTime: number[],
     plannedStartMs?: number | null,
+    plannedStops?: readonly PlannedStop[],
   ) => Promise<void>;
   refreshWeatherNow: (
     routeId: string,
@@ -151,6 +175,7 @@ interface WeatherState {
     fromDistanceAlongRouteMeters: number,
     cumulativeTime: number[],
     plannedStartMs?: number | null,
+    plannedStops?: readonly PlannedStop[],
   ) => Promise<void>;
   recordManualRefreshUnavailable: (message?: string) => void;
   clearWeather: () => void;
@@ -167,6 +192,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
     cumulativeTime: number[],
     mode: "automatic" | "manual",
     plannedStartMs: number | null = null,
+    plannedStops: readonly PlannedStop[] = [],
   ): Promise<void> {
     const state = get();
     if (state.fetchStatus === "fetching") {
@@ -179,15 +205,25 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
       return;
     }
 
-    const currentContextKey = contextKey(routeId, plannedStartMs, fromDistanceAlongRouteMeters);
+    const stopSignature = plannedStopSignature(plannedStops);
+    const currentContextKey = contextKey(
+      routeId,
+      plannedStartMs,
+      fromDistanceAlongRouteMeters,
+      stopSignature,
+    );
     const cachedData = loadCache();
 
     if (
       mode === "automatic" &&
       state.timeline.length > 0 &&
       state.routeId != null &&
-      contextKey(state.routeId, state.plannedStartMs, state.fromDistanceAlongRouteMeters ?? 0) ===
-        currentContextKey &&
+      contextKey(
+        state.routeId,
+        state.plannedStartMs,
+        state.fromDistanceAlongRouteMeters ?? 0,
+        state.plannedStopSignature,
+      ) === currentContextKey &&
       isFresh(state.lastSuccessfulFetchAtMs)
     ) {
       return;
@@ -195,7 +231,13 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
 
     if (
       mode === "automatic" &&
-      cacheMatchesContext(cachedData, routeId, plannedStartMs, fromDistanceAlongRouteMeters) &&
+      cacheMatchesContext(
+        cachedData,
+        routeId,
+        plannedStartMs,
+        fromDistanceAlongRouteMeters,
+        stopSignature,
+      ) &&
       isFresh(cachedData?.fetchedAt ?? null)
     ) {
       set({
@@ -210,6 +252,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
         routeCoverageUntilMeters: cachedData?.routeCoverageUntilMeters ?? null,
         routeId,
         plannedStartMs,
+        plannedStopSignature: stopSignature,
         fromDistanceAlongRouteMeters,
       });
       return;
@@ -226,6 +269,8 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
         fromDistanceAlongRouteMeters,
         cumulativeTime,
         plannedStartMs,
+        plannedStops,
+        stopSignature,
       );
       if (rebuiltCache) {
         persistCache(rebuiltCache);
@@ -241,6 +286,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
           routeCoverageUntilMeters: rebuiltCache.routeCoverageUntilMeters,
           routeId,
           plannedStartMs,
+          plannedStopSignature: stopSignature,
           fromDistanceAlongRouteMeters,
         });
         return;
@@ -249,7 +295,13 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
 
     if (
       mode === "manual" &&
-      cacheMatchesContext(cachedData, routeId, plannedStartMs, fromDistanceAlongRouteMeters) &&
+      cacheMatchesContext(
+        cachedData,
+        routeId,
+        plannedStartMs,
+        fromDistanceAlongRouteMeters,
+        stopSignature,
+      ) &&
       isFresh(cachedData?.fetchedAt ?? null) &&
       state.lastSuccessfulFetchAtMs != null &&
       Date.now() - state.lastSuccessfulFetchAtMs < WEATHER_MANUAL_REFRESH_THROTTLE_MS
@@ -270,6 +322,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
           cachedData?.routeCoverageUntilMeters ?? state.routeCoverageUntilMeters,
         routeId,
         plannedStartMs,
+        plannedStopSignature: stopSignature,
         fromDistanceAlongRouteMeters,
       });
       return;
@@ -300,7 +353,10 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
     }
 
     try {
-      const options = plannedStartMs ? { projectionStartTime: new Date(plannedStartMs) } : {};
+      const options = {
+        ...(plannedStartMs ? { projectionStartTime: new Date(plannedStartMs) } : {}),
+        plannedStops,
+      };
       const forecasts = await fetchWeatherForecastsForRoute(
         points,
         fromDistanceAlongRouteMeters,
@@ -326,6 +382,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
         fetchedAt,
         routeId,
         plannedStartMs,
+        plannedStopSignature: stopSignature,
         fromDistanceAlongRouteMeters,
         forecastFromMs: buildResult.forecastFromMs,
         forecastUntilMs: buildResult.forecastUntilMs,
@@ -379,6 +436,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
     routeCoverageUntilMeters: hasCachedTimeline ? (cached?.routeCoverageUntilMeters ?? null) : null,
     routeId: hasCachedTimeline ? (cached?.routeId ?? null) : null,
     plannedStartMs: hasCachedTimeline ? (cached?.plannedStartMs ?? null) : null,
+    plannedStopSignature: hasCachedTimeline ? (cached?.plannedStopSignature ?? "none") : "none",
     fromDistanceAlongRouteMeters: hasCachedTimeline
       ? (cached?.fromDistanceAlongRouteMeters ?? null)
       : null,
@@ -389,6 +447,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
       fromDistanceAlongRouteMeters,
       cumulativeTime,
       plannedStartMs = null,
+      plannedStops = [],
     ) => {
       await runFetch(
         routeId,
@@ -397,6 +456,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
         cumulativeTime,
         "automatic",
         plannedStartMs,
+        plannedStops,
       );
     },
 
@@ -406,6 +466,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
       fromDistanceAlongRouteMeters,
       cumulativeTime,
       plannedStartMs = null,
+      plannedStops = [],
     ) => {
       await runFetch(
         routeId,
@@ -414,6 +475,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
         cumulativeTime,
         "manual",
         plannedStartMs,
+        plannedStops,
       );
     },
 
@@ -441,6 +503,7 @@ export const useWeatherStore = create<WeatherState>((set, get) => {
         routeCoverageUntilMeters: null,
         routeId: null,
         plannedStartMs: null,
+        plannedStopSignature: "none",
         fromDistanceAlongRouteMeters: null,
       });
     },

--- a/tests/services/plannedStops.test.ts
+++ b/tests/services/plannedStops.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyPlannedStopOffsetToETA,
+  departureTimeAfterPlannedStop,
+  getPlannedStopDurationMinutes,
+  plannedStopOffsetSecondsBeforeDistance,
+  plannedStopsFromPOIs,
+  setPlannedStopDurationTag,
+} from "@/services/plannedStops";
+import { toDisplayPOI } from "@/services/displayDistance";
+import { buildPoi } from "@/tests/fixtures/poi";
+import type { DisplayDistanceMeters } from "@/types";
+
+describe("plannedStops", () => {
+  it("parses positive integer stop durations from POI tags", () => {
+    expect(getPlannedStopDurationMinutes({ planned_stop_duration_minutes: "15" })).toBe(15);
+    expect(getPlannedStopDurationMinutes({ planned_stop_duration_minutes: "0" })).toBe(0);
+    expect(getPlannedStopDurationMinutes({ planned_stop_duration_minutes: "-5" })).toBe(0);
+    expect(getPlannedStopDurationMinutes({ planned_stop_duration_minutes: "12.5" })).toBe(0);
+    expect(getPlannedStopDurationMinutes({ planned_stop_duration_minutes: "soon" })).toBe(0);
+    expect(getPlannedStopDurationMinutes({})).toBe(0);
+  });
+
+  it("sets and clears planned stop tags", () => {
+    expect(setPlannedStopDurationTag({ notes: "shop" }, 30)).toEqual({
+      notes: "shop",
+      planned_stop_duration_minutes: "30",
+    });
+    expect(
+      setPlannedStopDurationTag({ notes: "shop", planned_stop_duration_minutes: "30" }, 0),
+    ).toEqual({ notes: "shop" });
+  });
+
+  it("stores any positive stop duration as an integer-minute string", () => {
+    for (const minutes of [5, 10, 15, 30, 45, 60, 73]) {
+      expect(setPlannedStopDurationTag({}, minutes)).toEqual({
+        planned_stop_duration_minutes: String(minutes),
+      });
+    }
+  });
+
+  it("builds planned stops from display-space POIs", () => {
+    const stops = plannedStopsFromPOIs([
+      toDisplayPOI(
+        buildPoi("late", "route-1", 100, { tags: { planned_stop_duration_minutes: "10" } }),
+        1_000,
+      ),
+      toDisplayPOI(buildPoi("none", "route-1", 200)),
+    ]);
+
+    expect(stops).toEqual([{ poiId: "late", distanceMeters: 1_100, durationSeconds: 600 }]);
+  });
+
+  it("sums only stops strictly after progress and before the target", () => {
+    const stops = [
+      { poiId: "behind", distanceMeters: 900 as DisplayDistanceMeters, durationSeconds: 300 },
+      {
+        poiId: "at-current",
+        distanceMeters: 1_000 as DisplayDistanceMeters,
+        durationSeconds: 300,
+      },
+      { poiId: "inside", distanceMeters: 1_500 as DisplayDistanceMeters, durationSeconds: 600 },
+      { poiId: "at-target", distanceMeters: 2_000 as DisplayDistanceMeters, durationSeconds: 900 },
+    ];
+
+    expect(plannedStopOffsetSecondsBeforeDistance(stops, 1_000, 2_000)).toBe(600);
+  });
+
+  it("applies stop offsets to ETA clock and elapsed time", () => {
+    const eta = {
+      distanceMeters: 2_000,
+      ridingTimeSeconds: 600,
+      eta: new Date("2026-01-01T12:10:00.000Z"),
+    };
+
+    expect(applyPlannedStopOffsetToETA(eta, 300)?.eta.toISOString()).toBe(
+      "2026-01-01T12:15:00.000Z",
+    );
+    expect(
+      applyPlannedStopOffsetToETA(
+        eta,
+        300,
+        new Date("2026-01-01T06:00:00.000Z").getTime(),
+      )?.eta.toISOString(),
+    ).toBe("2026-01-01T06:15:00.000Z");
+  });
+
+  it("derives departure time from arrival ETA and own stop duration", () => {
+    expect(
+      departureTimeAfterPlannedStop(
+        {
+          distanceMeters: 1_000,
+          ridingTimeSeconds: 300,
+          eta: new Date("2026-01-01T12:05:00.000Z"),
+        },
+        15,
+      )?.toISOString(),
+    ).toBe("2026-01-01T12:20:00.000Z");
+  });
+});

--- a/tests/services/upcomingTimeline.test.ts
+++ b/tests/services/upcomingTimeline.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildUpcomingTimeline, resolveUpcomingHorizonETA } from "@/services/upcomingTimeline";
+import { toDisplayClimb, toDisplayPOI } from "@/services/displayDistance";
+import { createRidingHorizonWindow } from "@/utils/ridingHorizon";
+import { buildClimb } from "@/tests/fixtures/climb";
+import { buildPoi } from "@/tests/fixtures/poi";
+import { buildRoutePoint } from "@/tests/fixtures/route";
+import { stitchedSegmentsFixture } from "@/tests/fixtures/collection";
+import { plannedStopsFromPOIs } from "@/services/plannedStops";
+
+describe("upcomingTimeline", () => {
+  it("clips events to the riding horizon and falls back to route start without progress", () => {
+    const window = createRidingHorizonWindow(null, 2_500, { totalDistanceMeters: 6_000 });
+    const events = buildUpcomingTimeline({
+      pois: [
+        toDisplayPOI(buildPoi("inside", "r1", 1_000)),
+        toDisplayPOI(buildPoi("outside", "r1", 3_000)),
+      ],
+      starredPOIIds: new Set(["inside", "outside"]),
+      climbs: [],
+      segments: null,
+      totalDistanceMeters: 6_000,
+      currentDistanceMeters: null,
+      horizonWindow: window,
+    });
+
+    expect(events.map((event) => event.id)).toEqual(["poi:inside"]);
+  });
+
+  it("sorts mixed events in route order", () => {
+    const events = buildUpcomingTimeline({
+      pois: [toDisplayPOI(buildPoi("water", "r1", 700))],
+      starredPOIIds: new Set(["water"]),
+      climbs: [toDisplayClimb(buildClimb("easy", "r1", 1_000, 1_300))],
+      segments: stitchedSegmentsFixture,
+      totalDistanceMeters: 2_000,
+      currentDistanceMeters: 0,
+    });
+
+    expect(events.map((event) => event.id)).toEqual([
+      "poi:water",
+      "segment:r1:r2:1",
+      "climb-span:easy",
+      "finish",
+    ]);
+  });
+
+  it("uses effective display distances for stitched collections", () => {
+    const events = buildUpcomingTimeline({
+      pois: [toDisplayPOI(buildPoi("r2-poi", "r2", 100), 1_000)],
+      starredPOIIds: new Set(["r2-poi"]),
+      climbs: [toDisplayClimb(buildClimb("r2-climb", "r2", 200, 500), 1_000)],
+      segments: stitchedSegmentsFixture,
+      totalDistanceMeters: 3_000,
+      currentDistanceMeters: 0,
+    });
+
+    expect(events.map((event) => [event.id, event.distanceMeters])).toContainEqual([
+      "poi:r2-poi",
+      1_100,
+    ]);
+    expect(events.map((event) => [event.id, event.distanceMeters])).toContainEqual([
+      "climb-span:r2-climb",
+      1_200,
+    ]);
+  });
+
+  it("excludes unstarred fetched POIs and includes saved custom POIs", () => {
+    const events = buildUpcomingTimeline({
+      pois: [
+        toDisplayPOI(buildPoi("unstarred", "r1", 500)),
+        toDisplayPOI(buildPoi("saved", "r1", 800, { source: "custom" })),
+      ],
+      starredPOIIds: new Set(),
+      climbs: [],
+      segments: null,
+      totalDistanceMeters: 2_000,
+      currentDistanceMeters: 0,
+    });
+
+    expect(events.map((event) => event.id)).toEqual(["poi:saved", "finish"]);
+  });
+
+  it("includes unstarred POIs with planned stops", () => {
+    const events = buildUpcomingTimeline({
+      pois: [
+        toDisplayPOI(
+          buildPoi("planned", "r1", 500, {
+            tags: { planned_stop_duration_minutes: "15" },
+          }),
+        ),
+      ],
+      starredPOIIds: new Set(),
+      climbs: [],
+      segments: null,
+      totalDistanceMeters: 2_000,
+      currentDistanceMeters: 0,
+    });
+
+    expect(events.map((event) => event.id)).toEqual(["poi:planned", "finish"]);
+  });
+
+  it("includes starred POIs inside the active horizon", () => {
+    const window = createRidingHorizonWindow(1_000, 1_000, { totalDistanceMeters: 5_000 });
+    const events = buildUpcomingTimeline({
+      pois: [
+        toDisplayPOI(buildPoi("behind", "r1", 900)),
+        toDisplayPOI(buildPoi("ahead", "r1", 1_600)),
+        toDisplayPOI(buildPoi("far", "r1", 2_200)),
+      ],
+      starredPOIIds: new Set(["behind", "ahead", "far"]),
+      climbs: [],
+      segments: null,
+      totalDistanceMeters: 5_000,
+      currentDistanceMeters: 1_000,
+      horizonWindow: window,
+    });
+
+    expect(events.map((event) => event.id)).toEqual(["poi:ahead"]);
+  });
+
+  it("splits moderate climbs and easy climbs with important POIs, but collapses isolated easy climbs", () => {
+    const events = buildUpcomingTimeline({
+      pois: [toDisplayPOI(buildPoi("inside-easy", "r1", 2_200))],
+      starredPOIIds: new Set(["inside-easy"]),
+      climbs: [
+        toDisplayClimb(buildClimb("easy", "r1", 1_000, 1_500, { difficultyScore: 100 })),
+        toDisplayClimb(buildClimb("medium", "r1", 3_000, 3_800, { difficultyScore: 150 })),
+        toDisplayClimb(buildClimb("easy-poi", "r1", 2_000, 2_500, { difficultyScore: 100 })),
+      ],
+      segments: null,
+      totalDistanceMeters: 5_000,
+      currentDistanceMeters: 0,
+    });
+
+    expect(events.map((event) => event.id)).toEqual([
+      "climb-span:easy",
+      "climb-start:easy-poi",
+      "poi:inside-easy",
+      "climb-top:easy-poi",
+      "climb-start:medium",
+      "climb-top:medium",
+      "finish",
+    ]);
+  });
+
+  it("keeps rows visible without ETA data", () => {
+    const events = buildUpcomingTimeline({
+      pois: [toDisplayPOI(buildPoi("water", "r1", 1_000))],
+      starredPOIIds: new Set(["water"]),
+      climbs: [],
+      segments: null,
+      totalDistanceMeters: 2_000,
+      currentDistanceMeters: 0,
+      routePoints: null,
+      cumulativeTime: null,
+    });
+
+    expect(events[0]).toMatchObject({ id: "poi:water", eta: null });
+    expect(
+      resolveUpcomingHorizonETA({
+        totalDistanceMeters: 2_000,
+        currentDistanceMeters: 0,
+        routePoints: null,
+        cumulativeTime: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("attaches ETA when cumulative route timing is available", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+
+    const routePoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+    ];
+    const events = buildUpcomingTimeline({
+      pois: [toDisplayPOI(buildPoi("water", "r1", 1_500))],
+      starredPOIIds: new Set(["water"]),
+      climbs: [],
+      segments: null,
+      totalDistanceMeters: 2_000,
+      currentDistanceMeters: 500,
+      routePoints,
+      cumulativeTime: [0, 100, 200],
+    });
+
+    expect(events[0].eta?.distanceMeters).toBe(1_000);
+    expect(events[0].eta?.ridingTimeSeconds).toBe(100);
+    expect(events[0].eta?.eta.toISOString()).toBe("2026-01-01T12:01:40.000Z");
+
+    vi.useRealTimers();
+  });
+
+  it("uses a race start datetime as the ETA clock base when provided", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T05:00:00.000Z"));
+
+    const routePoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+    ];
+    const raceStartMs = new Date("2026-01-01T06:00:00.000Z").getTime();
+    const events = buildUpcomingTimeline({
+      pois: [toDisplayPOI(buildPoi("water", "r1", 1_500))],
+      starredPOIIds: new Set(["water"]),
+      climbs: [],
+      segments: null,
+      totalDistanceMeters: 2_000,
+      currentDistanceMeters: 0,
+      routePoints,
+      cumulativeTime: [0, 100, 200],
+      etaStartTimeMs: raceStartMs,
+    });
+
+    expect(events[0].eta?.ridingTimeSeconds).toBe(150);
+    expect(events[0].eta?.eta.toISOString()).toBe("2026-01-01T06:02:30.000Z");
+    expect(
+      resolveUpcomingHorizonETA({
+        totalDistanceMeters: 2_000,
+        currentDistanceMeters: 0,
+        routePoints,
+        cumulativeTime: [0, 100, 200],
+        etaStartTimeMs: raceStartMs,
+      })?.eta.toISOString(),
+    ).toBe("2026-01-01T06:03:20.000Z");
+
+    vi.useRealTimers();
+  });
+
+  it("applies planned stop offsets only to downstream event ETAs", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+
+    const routePoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+    ];
+    const pois = [
+      toDisplayPOI(
+        buildPoi("planned", "r1", 1_000, {
+          tags: { planned_stop_duration_minutes: "15" },
+        }),
+      ),
+    ];
+    const events = buildUpcomingTimeline({
+      pois,
+      starredPOIIds: new Set(),
+      climbs: [],
+      segments: null,
+      totalDistanceMeters: 2_000,
+      currentDistanceMeters: 0,
+      routePoints,
+      cumulativeTime: [0, 100, 200],
+      plannedStops: plannedStopsFromPOIs(pois),
+    });
+
+    expect(events.find((event) => event.id === "poi:planned")?.eta?.ridingTimeSeconds).toBe(100);
+    expect(events.find((event) => event.id === "finish")?.eta?.ridingTimeSeconds).toBe(1_100);
+
+    vi.useRealTimers();
+  });
+
+  it("combines race start clock base with prior planned stops", () => {
+    const routePoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+    ];
+    const pois = [
+      toDisplayPOI(
+        buildPoi("planned", "r1", 1_000, {
+          tags: { planned_stop_duration_minutes: "15" },
+        }),
+      ),
+    ];
+    const eta = resolveUpcomingHorizonETA({
+      totalDistanceMeters: 2_000,
+      currentDistanceMeters: 0,
+      routePoints,
+      cumulativeTime: [0, 100, 200],
+      etaStartTimeMs: new Date("2026-01-01T06:00:00.000Z").getTime(),
+      plannedStops: plannedStopsFromPOIs(pois),
+    });
+
+    expect(eta?.ridingTimeSeconds).toBe(1_100);
+    expect(eta?.eta.toISOString()).toBe("2026-01-01T06:18:20.000Z");
+  });
+});

--- a/tests/services/weatherService.test.ts
+++ b/tests/services/weatherService.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildWeatherTimeline, sampleWaypoints } from "@/services/weatherService";
 import type { HourlyForecast } from "@/services/weatherClient";
-import type { RoutePoint } from "@/types";
+import type { DisplayDistanceMeters, RoutePoint } from "@/types";
 
 const { mockFetchForecasts } = vi.hoisted(() => ({
   mockFetchForecasts: vi.fn(),
@@ -138,6 +138,34 @@ describe("weatherService", () => {
       ]),
     );
     expect(mockFetchForecasts).toHaveBeenLastCalledWith(expect.any(Array), 24);
+  });
+
+  it("includes prior planned stop durations in route weather ETA times", async () => {
+    const points = [routePoint(0, 0), routePoint(10_000, 1), routePoint(20_000, 2)];
+    const cumulativeTime = [0, 3600, 7200];
+    mockFetchForecasts.mockResolvedValue(
+      points.map((sample) => forecast(sample.latitude, sample.longitude)),
+    );
+
+    const timeline = await buildWeatherTimeline(points, 0, cumulativeTime, {
+      projectionStartTime: new Date("2026-01-01T00:30:00.000Z"),
+      plannedStops: [
+        {
+          poiId: "stop",
+          distanceMeters: 10_000 as DisplayDistanceMeters,
+          durationSeconds: 1800,
+        },
+      ],
+    });
+
+    const finish = timeline.find(
+      (weatherPoint) =>
+        weatherPoint.phase === "route" && weatherPoint.sampleKinds.includes("finish"),
+    );
+    expect(finish).toMatchObject({
+      routeDistanceMeters: 20_000,
+      etaTime: "2026-01-01T03:00:00.000Z",
+    });
   });
 
   it("samples the full remaining route for all-route weather coverage", async () => {

--- a/tests/services/weatherService.test.ts
+++ b/tests/services/weatherService.test.ts
@@ -168,6 +168,35 @@ describe("weatherService", () => {
     });
   });
 
+  it("keeps weather samples during planned stops at the stop location", async () => {
+    const points = [routePoint(0, 0), routePoint(10_000, 1), routePoint(20_000, 2)];
+    const cumulativeTime = [0, 1800, 3600];
+    mockFetchForecasts.mockResolvedValue(
+      points.map((sample) => forecast(sample.latitude, sample.longitude)),
+    );
+
+    const timeline = await buildWeatherTimeline(points, 0, cumulativeTime, {
+      projectionStartTime: new Date("2026-01-01T00:00:00.000Z"),
+      plannedStops: [
+        {
+          poiId: "stop",
+          distanceMeters: 15_000 as DisplayDistanceMeters,
+          durationSeconds: 7200,
+        },
+      ],
+    });
+
+    expect(timeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sampleKind: "hourly",
+          routeDistanceMeters: 15_000,
+          etaTime: "2026-01-01T01:00:00.000Z",
+        }),
+      ]),
+    );
+  });
+
   it("samples the full remaining route for all-route weather coverage", async () => {
     const points = Array.from({ length: 14 }, (_, index) => routePoint(index * 20_000, index));
     const cumulativeTime = points.map((_, index) => index * 3600);

--- a/tests/store/poiStore.test.ts
+++ b/tests/store/poiStore.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { usePoiStore } from "@/store/poiStore";
 import { databaseMocks } from "@/tests/mocks/database";
 import { buildPoi } from "@/tests/fixtures/poi";
+import { toDisplayPOI } from "@/services/displayDistance";
 
 function resetPoiStoreState() {
   usePoiStore.setState({
@@ -87,5 +88,36 @@ describe("poiStore starred POIs", () => {
       deleteStarredItems: true,
     });
     expect([...usePoiStore.getState().starredPOIIds]).toEqual(["google-1"]);
+  });
+
+  it("updates planned stop duration tags", async () => {
+    const poi = buildPoi("poi-1", "route-1", 500, { tags: { notes: "shop" } });
+    const updated = buildPoi("poi-1", "route-1", 500, {
+      tags: { notes: "shop", planned_stop_duration_minutes: "15" },
+    });
+    usePoiStore.setState({ pois: { "route-1": [poi] }, selectedPOI: toDisplayPOI(poi) });
+    databaseMocks.getPOIsForRoute.mockResolvedValueOnce([updated]);
+
+    await usePoiStore.getState().updatePlannedStopDuration("route-1", "poi-1", 15);
+
+    expect(databaseMocks.updatePOITags).toHaveBeenCalledWith("poi-1", {
+      notes: "shop",
+      planned_stop_duration_minutes: "15",
+    });
+    expect(usePoiStore.getState().pois["route-1"]).toEqual([updated]);
+    expect(usePoiStore.getState().selectedPOI?.tags.planned_stop_duration_minutes).toBe("15");
+  });
+
+  it("clears planned stop duration tags", async () => {
+    const poi = buildPoi("poi-1", "route-1", 500, {
+      tags: { notes: "shop", planned_stop_duration_minutes: "15" },
+    });
+    const updated = buildPoi("poi-1", "route-1", 500, { tags: { notes: "shop" } });
+    usePoiStore.setState({ pois: { "route-1": [poi] } });
+    databaseMocks.getPOIsForRoute.mockResolvedValueOnce([updated]);
+
+    await usePoiStore.getState().updatePlannedStopDuration("route-1", "poi-1", 0);
+
+    expect(databaseMocks.updatePOITags).toHaveBeenCalledWith("poi-1", { notes: "shop" });
   });
 });

--- a/tests/utils/activeRouteTiming.test.ts
+++ b/tests/utils/activeRouteTiming.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { activeRouteTiming, futureStartMs } from "@/utils/activeRouteTiming";
+import type { ActiveRouteData, Collection } from "@/types";
+
+const routeData = {
+  id: "route-1",
+  type: "route",
+} as ActiveRouteData;
+
+const collectionData = {
+  id: "collection-1",
+  type: "collection",
+} as ActiveRouteData;
+
+const collections: Collection[] = [
+  {
+    id: "collection-1",
+    name: "Race",
+    isActive: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    plannedStartMs: new Date("2026-01-01T06:00:00.000Z").getTime(),
+  },
+];
+
+describe("activeRouteTiming", () => {
+  it("returns no planned start for standalone routes", () => {
+    expect(activeRouteTiming(routeData, collections)).toEqual({
+      plannedStartMs: null,
+      futureStartMs: null,
+    });
+  });
+
+  it("resolves collection planned start and future clock base", () => {
+    expect(
+      activeRouteTiming(
+        collectionData,
+        collections,
+        new Date("2026-01-01T05:00:00.000Z").getTime(),
+      ),
+    ).toEqual({
+      plannedStartMs: new Date("2026-01-01T06:00:00.000Z").getTime(),
+      futureStartMs: new Date("2026-01-01T06:00:00.000Z").getTime(),
+    });
+  });
+
+  it("keeps the planned start for display but drops the future base after start", () => {
+    expect(
+      activeRouteTiming(
+        collectionData,
+        collections,
+        new Date("2026-01-01T07:00:00.000Z").getTime(),
+      ),
+    ).toEqual({
+      plannedStartMs: new Date("2026-01-01T06:00:00.000Z").getTime(),
+      futureStartMs: null,
+    });
+  });
+
+  it("normalizes non-future starts", () => {
+    expect(
+      futureStartMs(
+        new Date("2026-01-01T06:00:00.000Z").getTime(),
+        new Date("2026-01-01T06:00:00.000Z").getTime(),
+      ),
+    ).toBeNull();
+  });
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -119,7 +119,7 @@ export type PanelMode =
   | "upcoming-200"
   | "full-route";
 
-export type PanelTab = "profile" | "weather" | "climbs" | "pois";
+export type PanelTab = "profile" | "upcoming" | "weather" | "climbs" | "pois";
 
 // --- Phase 3: POI types ---
 

--- a/utils/activeRouteTiming.ts
+++ b/utils/activeRouteTiming.ts
@@ -1,0 +1,26 @@
+import type { ActiveRouteData, Collection } from "@/types";
+
+export interface ActiveRouteTiming {
+  plannedStartMs: number | null;
+  futureStartMs: number | null;
+}
+
+export function futureStartMs(plannedStartMs: number | null | undefined, nowMs = Date.now()) {
+  return plannedStartMs != null && plannedStartMs > nowMs ? plannedStartMs : null;
+}
+
+export function activeRouteTiming(
+  activeData: Pick<ActiveRouteData, "id" | "type"> | null | undefined,
+  collections: Collection[],
+  nowMs = Date.now(),
+): ActiveRouteTiming {
+  const plannedStartMs =
+    activeData?.type === "collection"
+      ? (collections.find((collection) => collection.id === activeData.id)?.plannedStartMs ?? null)
+      : null;
+
+  return {
+    plannedStartMs,
+    futureStartMs: futureStartMs(plannedStartMs, nowMs),
+  };
+}


### PR DESCRIPTION
## Summary
- Add an Upcoming bottom-panel tab for ETA-first route events in the selected riding horizon.
- Derive timeline events from starred/saved POIs, climbs, collection segment transitions, and route/collection finish.
- Share collection planned-start timing logic across Upcoming, MapView, Weather, and ETA so pre-race timelines follow the race start datetime.
- Document the new Upcoming timeline feature.

Fixes #28

## Verification
- npm test
- npx tsc --noEmit
- npm run lint
- npm run format:check

## Note
- `./scripts/smoke-test.sh` captured the first map screenshot, then exited with code 141 before later screens. A subsequent direct simulator check was blocked because CoreSimulator access failed and escalation was declined.