### PR TITLE
[codex] stabilize map layer order

### DIFF
--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -441,7 +441,7 @@ export default function MapScreen() {
   }, [activeData, activeRoutePoints?.length]);
 
   // RNMapbox inserts native layers in mount order. Key upper overlay tiers so they remount
-  // above lower tiers when route/climb/visibility state changes.
+  // above lower tiers when route/climb/weather/visibility state changes.
   const routeStackKey = useMemo(() => {
     const ids = renderedRoutes.map(
       (route) => `${route.id}:${visibleRoutePoints[route.id]?.length ?? 0}`,
@@ -482,9 +482,15 @@ export default function MapScreen() {
   ]);
 
   const climbStackKey = `${routeStackKey}-${highlightedClimb?.id ?? "none"}`;
+  const hasWeatherTemperatureOverlay =
+    panelTab === "weather" &&
+    activeRoutePoints != null &&
+    weatherRouteId === activeData?.id &&
+    weatherTimeline.length > 1;
+  const weatherStackKey = hasWeatherTemperatureOverlay ? "weather:on" : "weather:off";
   const overlayStackKey = `${climbStackKey}-${activeContextKey ?? "none"}-markers:${
     showDistanceMarkers ? "on" : "off"
-  }-pois:${showPOIs ? "on" : "off"}`;
+  }-${weatherStackKey}-pois:${showPOIs ? "on" : "off"}`;
 
   // Center highlighted climbs without increasing zoom; zoom out only when the climb cannot fit.
   useEffect(() => {
@@ -582,17 +588,14 @@ export default function MapScreen() {
             points={activeRoutePoints}
           />
         )}
-        {panelTab === "weather" &&
-          activeRoutePoints &&
-          weatherRouteId === activeData?.id &&
-          weatherTimeline.length > 1 && (
-            <TemperatureRouteOverlay
-              key={`weather-temperature-${overlayStackKey}`}
-              points={activeRoutePoints}
-              timeline={weatherTimeline}
-              temperatureMode={weatherTemperatureMode}
-            />
-          )}
+        {hasWeatherTemperatureOverlay && activeRoutePoints && (
+          <TemperatureRouteOverlay
+            key={`weather-temperature-${overlayStackKey}`}
+            points={activeRoutePoints}
+            timeline={weatherTimeline}
+            temperatureMode={weatherTemperatureMode}
+          />
+        )}
         <RouteMarkerLayer
           key={`route-markers-${overlayStackKey}`}
           points={activeRoutePoints ?? []}


### PR DESCRIPTION
## Summary

- Keeps the map overlay stack stable when the weather temperature overlay mounts after POIs are already rendered.
- Adds weather overlay visibility to the shared overlay stack key so markers, POIs, and the location puck remount above the weather route layer in the intended order.
- Reuses a single `hasWeatherTemperatureOverlay` condition for rendering the weather temperature overlay.

## Impact

This fixes the case where opening Weather after POIs are visible could append the weather route layer above POI markers due to RNMapbox native layer insertion order.

## Verification

- Commit hook ran `oxfmt` on the changed file.
- Commit hook ran `oxlint --fix` with 0 warnings and 0 errors.
- Commit hook ran `tsc --noEmit` successfully.