### PR TITLE
[codex] patch route variants

### DIFF
--- a/app/collection/[id].tsx
+++ b/app/collection/[id].tsx
@@ -20,12 +20,26 @@ import { useCollectionStore } from "@/store/collectionStore";
 import { useSettingsStore } from "@/store/settingsStore";
 import { useClimbStore } from "@/store/climbStore";
 import { usePoiStore } from "@/store/poiStore";
-import type { Collection, CollectionSegmentWithRoute, POI, StitchedCollection } from "@/types";
+import type {
+  Collection,
+  CollectionSegmentWithRoute,
+  POI,
+  Route,
+  RoutePoint,
+  StitchedCollection,
+} from "@/types";
 import { useMapStyle } from "@/hooks/useMapStyle";
 import { useRouteGeometryZoom } from "@/hooks/useRouteGeometryZoom";
 import { formatDistance, formatElevation } from "@/utils/formatters";
 import { computeBounds } from "@/utils/geo";
-import { stitchCollection, stitchPOIs } from "@/services/stitchingService";
+import {
+  getStitchedSourceRouteIds,
+  isPatchVariantProposalPoorMatch,
+  proposePatchVariantFromPoints,
+  sliceRoutePointsByDistance,
+  stitchCollection,
+  stitchPOIs,
+} from "@/services/stitchingService";
 import ElevationProfile from "@/components/elevation/ElevationProfile";
 import RouteLayer from "@/components/map/RouteLayer";
 import StatBox from "@/components/common/StatBox";
@@ -49,6 +63,17 @@ function formatPlannedStart(plannedStartMs: number | null): string {
   });
 }
 
+interface PatchBaseSelection {
+  routeId: string;
+  routeName: string;
+  position: number;
+}
+
+interface VariantRouteOverlay {
+  route: Route;
+  points: RoutePoint[];
+}
+
 export default function CollectionDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
@@ -65,6 +90,7 @@ export default function CollectionDetailScreen() {
   const [isBusy, setIsBusy] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [showAddSheet, setShowAddSheet] = useState(false);
+  const [patchBaseSelection, setPatchBaseSelection] = useState<PatchBaseSelection | null>(null);
   const [showAddPOI, setShowAddPOI] = useState(false);
   const [showStartSheet, setShowStartSheet] = useState(false);
   const [startDraftDate, setStartDraftDate] = useState(() => new Date());
@@ -74,6 +100,7 @@ export default function CollectionDetailScreen() {
     (s) => s.getCollectionSegmentsWithRoutes,
   );
   const addSegment = useCollectionStore((s) => s.addSegment);
+  const addPatchVariant = useCollectionStore((s) => s.addPatchVariant);
   const removeSegment = useCollectionStore((s) => s.removeSegment);
   const selectVariant = useCollectionStore((s) => s.selectVariant);
   const setActiveCollection = useCollectionStore((s) => s.setActiveCollection);
@@ -98,9 +125,15 @@ export default function CollectionDetailScreen() {
         const s = await stitchCollection(id);
         // Also load points for unselected variants (for ETA display)
         const { getRoutePoints } = await import("@/db/database");
+        const stitchedSourceRouteIds = new Set(getStitchedSourceRouteIds(s.segments));
         const unselectedRouteIds = segs
           .filter((sw) => !sw.segment.isSelected && !s.pointsByRouteId[sw.route.id])
           .map((sw) => sw.route.id);
+        for (const routeId of stitchedSourceRouteIds) {
+          if (!s.pointsByRouteId[routeId] && !unselectedRouteIds.includes(routeId)) {
+            unselectedRouteIds.push(routeId);
+          }
+        }
         const unselectedPoints = await Promise.all(
           unselectedRouteIds.map((rid) => getRoutePoints(rid)),
         );
@@ -126,10 +159,38 @@ export default function CollectionDetailScreen() {
     [collection?.name],
   );
 
+  const variantRouteOverlays = useMemo<VariantRouteOverlay[]>(() => {
+    if (!stitched) return [];
+    return segmentsWithRoutes
+      .filter((sw) => !sw.segment.isSelected)
+      .map((sw) => {
+        const points = stitched.pointsByRouteId[sw.route.id] ?? null;
+        if (!points || points.length < 2) return null;
+        return {
+          route: {
+            ...sw.route,
+            id: `variant-${sw.route.id}`,
+            isActive: false,
+            isVisible: true,
+          },
+          points,
+        };
+      })
+      .filter((overlay): overlay is VariantRouteOverlay => overlay != null);
+  }, [segmentsWithRoutes, stitched]);
+
   const bounds = useMemo(() => {
     if (!stitched?.points.length) return null;
-    return computeBounds(stitched.points);
-  }, [stitched]);
+    return computeBounds([
+      ...stitched.points,
+      ...variantRouteOverlays.flatMap((overlay) => overlay.points),
+    ]);
+  }, [stitched, variantRouteOverlays]);
+
+  const selectedRouteLayerId = useMemo(
+    () => (collection ? `collection-${collection.id}` : "collection"),
+    [collection],
+  );
 
   // Fit mini map camera when bounds change (defaultSettings only applies on mount)
   useEffect(() => {
@@ -154,13 +215,50 @@ export default function CollectionDetailScreen() {
     [updateRouteGeometryZoom],
   );
 
-  // Get route points for each selected segment (for mini map RouteLayer)
-  const selectedSegmentRoutes = useMemo(() => {
-    return segmentsWithRoutes.filter((sw) => sw.segment.isSelected).map((sw) => sw.route);
-  }, [segmentsWithRoutes]);
+  const resolvedSegmentPointsByRouteId = useMemo(() => {
+    const out: Record<string, RoutePoint[]> = {};
+    if (!stitched) return out;
+    for (const segment of stitched.segments) {
+      const points = stitched.points
+        .slice(segment.startPointIndex, segment.endPointIndex + 1)
+        .map((point, idx) =>
+          Object.assign({}, point, {
+            idx,
+            distanceFromStartMeters: point.distanceFromStartMeters - segment.distanceOffsetMeters,
+          }),
+        );
+      out[segment.routeId] = points;
+    }
+    return out;
+  }, [stitched]);
 
   const existingRouteIds = useMemo(
     () => new Set(segmentsWithRoutes.map((sw) => sw.route.id)),
+    [segmentsWithRoutes],
+  );
+
+  const handleCloseAddSheet = useCallback(() => {
+    setShowAddSheet(false);
+    setPatchBaseSelection(null);
+  }, []);
+
+  const handleOpenAddSegment = useCallback(() => {
+    setPatchBaseSelection(null);
+    setShowAddSheet(true);
+  }, []);
+
+  const handleOpenPatchVariant = useCallback(
+    (baseRouteId: string, position: number) => {
+      const base = segmentsWithRoutes.find(
+        (sw) => sw.route.id === baseRouteId && sw.segment.variantKind === "full",
+      );
+      if (!base) {
+        Alert.alert("Patch Variant Failed", "Could not find the base segment for this position.");
+        return;
+      }
+      setPatchBaseSelection({ routeId: baseRouteId, routeName: base.route.name, position });
+      setShowAddSheet(true);
+    },
     [segmentsWithRoutes],
   );
 
@@ -168,12 +266,101 @@ export default function CollectionDetailScreen() {
     async (routeId: string) => {
       if (!id) return;
       setShowAddSheet(false);
+      setPatchBaseSelection(null);
       setIsBusy(true);
       await addSegment(id, routeId);
       await loadData();
       setIsBusy(false);
     },
     [id, addSegment, loadData],
+  );
+
+  const handleAddPatchVariant = useCallback(
+    async (routeId: string, baseRouteId: string, position: number) => {
+      if (!id) return;
+      setShowAddSheet(false);
+      setPatchBaseSelection(null);
+      setIsBusy(true);
+      try {
+        const { getRouteWithPoints } = await import("@/db/database");
+        const [baseRoute, patchRoute] = await Promise.all([
+          getRouteWithPoints(baseRouteId),
+          getRouteWithPoints(routeId),
+        ]);
+        if (!baseRoute || !patchRoute) {
+          Alert.alert("Patch Variant Failed", "Could not load both route geometries.");
+          return;
+        }
+
+        const proposal = proposePatchVariantFromPoints(
+          baseRoute.id,
+          patchRoute.id,
+          baseRoute.points,
+          patchRoute.points,
+        );
+        if (!proposal) {
+          Alert.alert("Patch Variant Failed", "Could not match this route onto the base segment.");
+          return;
+        }
+        if (proposal.isReversed) {
+          Alert.alert(
+            "Patch Variant Reversed",
+            "This route snaps onto the base segment in the opposite direction. Reverse the route before adding it as a patch variant.",
+          );
+          return;
+        }
+
+        const warning = isPatchVariantProposalPoorMatch(proposal)
+          ? "\n\nReview carefully: one or both endpoints are far from the base route."
+          : "";
+        Alert.alert(
+          "Add Patch Variant?",
+          `${patchRoute.name} will replace ${formatDistance(
+            proposal.replaceStartDistanceMeters,
+            units,
+          )}-${formatDistance(proposal.replaceEndDistanceMeters, units)} of ${
+            baseRoute.name
+          }.${warning}`,
+          [
+            { text: "Cancel", style: "cancel" },
+            {
+              text: "Add Variant",
+              onPress: async () => {
+                setIsBusy(true);
+                await addPatchVariant(
+                  id,
+                  routeId,
+                  baseRouteId,
+                  position,
+                  proposal.replaceStartDistanceMeters,
+                  proposal.replaceEndDistanceMeters,
+                );
+                await loadData();
+                setIsBusy(false);
+              },
+            },
+          ],
+        );
+      } finally {
+        setIsBusy(false);
+      }
+    },
+    [id, addPatchVariant, loadData, units],
+  );
+
+  const handleAddRouteFromSheet = useCallback(
+    async (routeId: string) => {
+      if (patchBaseSelection) {
+        await handleAddPatchVariant(
+          routeId,
+          patchBaseSelection.routeId,
+          patchBaseSelection.position,
+        );
+        return;
+      }
+      await handleAddSegment(routeId);
+    },
+    [handleAddPatchVariant, handleAddSegment, patchBaseSelection],
   );
 
   const handleRemoveSegment = useCallback(
@@ -280,16 +467,16 @@ export default function CollectionDetailScreen() {
 
   useEffect(() => {
     if (stitched) {
-      for (const seg of stitched.segments) {
-        loadClimbs(seg.routeId);
-        loadPOIs(seg.routeId);
+      for (const routeId of getStitchedSourceRouteIds(stitched.segments)) {
+        loadClimbs(routeId);
+        loadPOIs(routeId);
       }
     }
   }, [stitched, loadClimbs, loadPOIs]);
 
   const collectionClimbs = useMemo(() => {
     if (!stitched) return [];
-    const routeIds = stitched.segments.map((s) => s.routeId);
+    const routeIds = getStitchedSourceRouteIds(stitched.segments);
     return getClimbsForDisplay(routeIds, stitched.segments);
     // allClimbs is a reactivity trigger: getClimbsForDisplay reads store via get() and is not itself reactive
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -298,8 +485,8 @@ export default function CollectionDetailScreen() {
   const collectionPOIs = useMemo(() => {
     if (!stitched) return [];
     const poisByRoute: Record<string, POI[]> = {};
-    for (const seg of stitched.segments) {
-      poisByRoute[seg.routeId] = (poisByRouteId[seg.routeId] ?? []).filter((poi) =>
+    for (const routeId of getStitchedSourceRouteIds(stitched.segments)) {
+      poisByRoute[routeId] = (poisByRouteId[routeId] ?? []).filter((poi) =>
         starredPOIIds.has(poi.id),
       );
     }
@@ -323,12 +510,19 @@ export default function CollectionDetailScreen() {
 
   const savedPOITargets = useMemo<SavedPOITarget[]>(() => {
     if (!stitched) return [];
-    return stitched.segments
-      .map((seg) => ({
-        routeId: seg.routeId,
-        routeName: seg.routeName,
-        points: stitched.pointsByRouteId[seg.routeId] ?? [],
-      }))
+    return stitched.sourceSpans
+      .map((span) => {
+        const points = sliceRoutePointsByDistance(
+          stitched.pointsByRouteId[span.routeId] ?? [],
+          span.rawStartDistanceMeters,
+          span.rawEndDistanceMeters,
+        );
+        return {
+          routeId: span.routeId,
+          routeName: span.routeName,
+          points,
+        };
+      })
       .filter((target) => target.points.length > 0);
   }, [stitched]);
 
@@ -368,7 +562,7 @@ export default function CollectionDetailScreen() {
         contentContainerStyle={{ paddingBottom: 48 }}
       >
         {/* Mini map */}
-        {selectedSegmentRoutes.length > 0 && (
+        {stitched && stitched.points.length > 0 && collection && (
           <View className="h-[250px] mx-4 mt-4 rounded-xl overflow-hidden">
             <MapboxMapView
               style={{ flex: 1 }}
@@ -398,18 +592,32 @@ export default function CollectionDetailScreen() {
                     : undefined
                 }
               />
-              {selectedSegmentRoutes.map((route) => {
-                const points = stitched?.pointsByRouteId[route.id];
-                if (!points) return null;
-                return (
-                  <RouteLayer
-                    key={`${route.id}-${mapStyle.styleKey}`}
-                    route={{ ...route, isActive: true }}
-                    points={points}
-                    zoomLevel={routeGeometryZoom}
-                  />
-                );
-              })}
+              {variantRouteOverlays.map((overlay) => (
+                <RouteLayer
+                  key={`${overlay.route.id}-${mapStyle.styleKey}`}
+                  route={overlay.route}
+                  points={overlay.points}
+                  zoomLevel={routeGeometryZoom}
+                />
+              ))}
+              <RouteLayer
+                key={`${collection.id}-${mapStyle.styleKey}`}
+                route={{
+                  id: selectedRouteLayerId,
+                  name: collection.name,
+                  fileName: `${collection.id}.collection`,
+                  color: "#0D9488",
+                  isActive: true,
+                  isVisible: true,
+                  totalDistanceMeters: stitched.totalDistanceMeters,
+                  totalAscentMeters: stitched.totalAscentMeters,
+                  totalDescentMeters: stitched.totalDescentMeters,
+                  pointCount: stitched.points.length,
+                  createdAt: collection.createdAt,
+                }}
+                points={stitched.points}
+                zoomLevel={routeGeometryZoom}
+              />
             </MapboxMapView>
           </View>
         )}
@@ -459,14 +667,17 @@ export default function CollectionDetailScreen() {
           <SegmentList
             segmentsWithRoutes={segmentsWithRoutes}
             pointsByRouteId={stitched?.pointsByRouteId ?? {}}
+            resolvedPointsByRouteId={resolvedSegmentPointsByRouteId}
+            stitchedSegments={stitched?.segments}
             onSelectVariant={handleSelectVariant}
+            onAddPatchVariant={handleOpenPatchVariant}
             onReorder={handleReorder}
             onRemove={handleRemoveSegment}
           />
         </View>
 
         <View className="px-4 mt-3">
-          <Button variant="secondary" onPress={() => setShowAddSheet(true)} label="Add Segment" />
+          <Button variant="secondary" onPress={handleOpenAddSegment} label="Add Segment" />
         </View>
 
         {stitched && stitched.segments.length > 0 && (
@@ -520,8 +731,10 @@ export default function CollectionDetailScreen() {
 
       <AddSegmentSheet
         visible={showAddSheet}
-        onClose={() => setShowAddSheet(false)}
-        onAdd={handleAddSegment}
+        title={patchBaseSelection ? "Add Patch Variant" : "Add Segment"}
+        subtitle={patchBaseSelection ? `Base: ${patchBaseSelection.routeName}` : undefined}
+        onClose={handleCloseAddSheet}
+        onAdd={handleAddRouteFromSheet}
         existingRouteIds={existingRouteIds}
       />
 

--- a/app/collection/[id].tsx
+++ b/app/collection/[id].tsx
@@ -161,10 +161,28 @@ export default function CollectionDetailScreen() {
 
   const variantRouteOverlays = useMemo<VariantRouteOverlay[]>(() => {
     if (!stitched) return [];
+    const selectedByPosition = new Map<number, CollectionSegmentWithRoute>();
+    for (const sw of segmentsWithRoutes) {
+      if (sw.segment.isSelected) selectedByPosition.set(sw.segment.position, sw);
+    }
     return segmentsWithRoutes
       .filter((sw) => !sw.segment.isSelected)
       .map((sw) => {
-        const points = stitched.pointsByRouteId[sw.route.id] ?? null;
+        const rawPoints = stitched.pointsByRouteId[sw.route.id] ?? null;
+        const selectedVariant = selectedByPosition.get(sw.segment.position);
+        const points =
+          rawPoints &&
+          sw.segment.variantKind === "full" &&
+          selectedVariant?.segment.variantKind === "patch" &&
+          selectedVariant.segment.baseRouteId === sw.route.id &&
+          selectedVariant.segment.replaceStartDistanceMeters != null &&
+          selectedVariant.segment.replaceEndDistanceMeters != null
+            ? sliceRoutePointsByDistance(
+                rawPoints,
+                selectedVariant.segment.replaceStartDistanceMeters,
+                selectedVariant.segment.replaceEndDistanceMeters,
+              )
+            : rawPoints;
         if (!points || points.length < 2) return null;
         return {
           route: {

--- a/components/collection/AddSegmentSheet.tsx
+++ b/components/collection/AddSegmentSheet.tsx
@@ -12,6 +12,8 @@ import type { Route } from "@/types";
 
 interface AddSegmentSheetProps {
   visible: boolean;
+  title?: string;
+  subtitle?: string;
   onClose: () => void;
   onAdd: (routeId: string) => void;
   existingRouteIds: Set<string>;
@@ -19,6 +21,8 @@ interface AddSegmentSheetProps {
 
 export default function AddSegmentSheet({
   visible,
+  title = "Add Segment",
+  subtitle,
   onClose,
   onAdd,
   existingRouteIds,
@@ -46,18 +50,22 @@ export default function AddSegmentSheet({
   const renderItem = useCallback(
     ({ item: route }: { item: Route }) => {
       const isInCollection = existingRouteIds.has(route.id);
+      const disabled = isInCollection;
       return (
         <TouchableOpacity
           className="flex-row items-center px-4 py-3 min-h-[56px]"
-          onPress={() => !isInCollection && onAdd(route.id)}
-          disabled={isInCollection}
+          onPress={() => {
+            if (disabled) return;
+            onAdd(route.id);
+          }}
+          disabled={disabled}
           activeOpacity={0.7}
         >
           <View className="flex-1 mr-3">
             <Text
               className={cn(
                 "text-[15px] font-barlow-medium",
-                isInCollection ? "text-muted-foreground" : "text-foreground",
+                disabled ? "text-muted-foreground" : "text-foreground",
               )}
               numberOfLines={1}
             >
@@ -83,7 +91,14 @@ export default function AddSegmentSheet({
       style={[{ top: 48, backgroundColor: colors.background }, animatedStyle]}
     >
       <View className="flex-row items-center px-4 py-3 border-b border-border">
-        <Text className="flex-1 text-[20px] font-barlow-semibold text-foreground">Add Segment</Text>
+        <View className="flex-1 mr-3">
+          <Text className="text-[20px] font-barlow-semibold text-foreground">{title}</Text>
+          {subtitle && (
+            <Text className="text-[13px] font-barlow-medium text-muted-foreground mt-0.5">
+              {subtitle}
+            </Text>
+          )}
+        </View>
         <TouchableOpacity
           className="w-[48px] h-[48px] items-center justify-center -mr-2"
           onPress={onClose}
@@ -99,6 +114,7 @@ export default function AddSegmentSheet({
         </View>
       ) : (
         <FlatList
+          className="flex-1"
           data={sortedRoutes}
           keyExtractor={(r) => r.id}
           renderItem={renderItem}

--- a/components/collection/CollectionOfflineSection.tsx
+++ b/components/collection/CollectionOfflineSection.tsx
@@ -7,6 +7,7 @@ import { usePoiStore, type SourceInfo } from "@/store/poiStore";
 import type { POIFetchedSource, StitchedCollection } from "@/types";
 import { formatFileSize } from "@/utils/formatters";
 import { estimateDownloadSize } from "@/services/offlineTiles";
+import { getStitchedSourceRouteIds } from "@/services/stitchingService";
 import { getRoutePoints } from "@/db/database";
 
 interface CollectionOfflineSectionProps {
@@ -34,10 +35,15 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
   const [progress, setProgress] = useState({ done: 0, total: 0 });
 
   const segments = stitched.segments;
-  const segmentRouteIdsKey = useMemo(
-    () => segments.map((seg) => seg.routeId).join("\n"),
-    [segments],
-  );
+  const sourceRouteIds = useMemo(() => getStitchedSourceRouteIds(segments), [segments]);
+  const routeNameById = useMemo(() => {
+    const names: Record<string, string> = {};
+    for (const span of stitched.sourceSpans) {
+      names[span.routeId] = span.routeName;
+    }
+    return names;
+  }, [stitched.sourceSpans]);
+  const segmentRouteIdsKey = useMemo(() => sourceRouteIds.join("\n"), [sourceRouteIds]);
 
   useEffect(() => {
     if (!segmentRouteIdsKey) return;
@@ -56,9 +62,9 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
     let poiReadyCount = 0;
     let offlineReadyCount = 0;
 
-    for (const seg of segments) {
-      const info = routeInfo[seg.routeId];
-      const sources = allSourceInfo[seg.routeId];
+    for (const routeId of sourceRouteIds) {
+      const info = routeInfo[routeId];
+      const sources = allSourceInfo[routeId];
       const poiReady = isSourceReady(sources?.osm) && isSourceReady(sources?.google);
       if (info?.status === "complete") {
         readyCount++;
@@ -70,7 +76,7 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
       }
       if (poiReady) poiReadyCount++;
       if (info?.status === "complete" && poiReady) offlineReadyCount++;
-      totalPOIs += allPois[seg.routeId]?.length ?? 0;
+      totalPOIs += allPois[routeId]?.length ?? 0;
     }
 
     // Estimate from stitched points (rough)
@@ -78,7 +84,7 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
 
     return {
       readyCount,
-      total: segments.length,
+      total: sourceRouteIds.length,
       downloadedBytes,
       estimatedBytes,
       totalPOIs,
@@ -87,51 +93,51 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
       poiReadyCount,
       offlineReadyCount,
     };
-  }, [segments, routeInfo, allPois, allSourceInfo, stitched.points]);
+  }, [sourceRouteIds, routeInfo, allPois, allSourceInfo, stitched.points]);
 
   const allTilesReady = stats.readyCount === stats.total && stats.total > 0;
   const allOfflineReady = stats.offlineReadyCount === stats.total && stats.total > 0;
 
   const poiErrors = useMemo(() => {
     const out: { routeName: string; source: POIFetchedSource; error: string }[] = [];
-    for (const seg of segments) {
-      const src = allSourceInfo[seg.routeId];
-      if (src?.osm?.error)
-        out.push({ routeName: seg.routeName, source: "osm", error: src.osm.error });
-      if (src?.google?.error)
-        out.push({ routeName: seg.routeName, source: "google", error: src.google.error });
+    for (const routeId of sourceRouteIds) {
+      const src = allSourceInfo[routeId];
+      const routeName = routeNameById[routeId] ?? "segment";
+      if (src?.osm?.error) out.push({ routeName, source: "osm", error: src.osm.error });
+      if (src?.google?.error) out.push({ routeName, source: "google", error: src.google.error });
     }
     return out;
-  }, [segments, allSourceInfo]);
+  }, [sourceRouteIds, routeNameById, allSourceInfo]);
 
   // Pick the first actively-fetching source across segments. Only one runs at
   // a time (prepareRouteOffline serializes), so this is the progress we show.
   const activePoiFetch = useMemo(() => {
-    for (const seg of segments) {
-      const src = allSourceInfo[seg.routeId];
+    for (const routeId of sourceRouteIds) {
+      const src = allSourceInfo[routeId];
+      const routeName = routeNameById[routeId] ?? "segment";
       if (src?.google?.status === "fetching") {
         return {
-          routeName: seg.routeName,
+          routeName,
           source: "google" as const,
           progress: src.google.progress,
         };
       }
       if (src?.osm?.status === "fetching") {
-        return { routeName: seg.routeName, source: "osm" as const, progress: src.osm.progress };
+        return { routeName, source: "osm" as const, progress: src.osm.progress };
       }
     }
     return null;
-  }, [segments, allSourceInfo]);
+  }, [sourceRouteIds, routeNameById, allSourceInfo]);
 
   const activeTileDownload = useMemo(() => {
-    for (const seg of segments) {
-      const info = routeInfo[seg.routeId];
+    for (const routeId of sourceRouteIds) {
+      const info = routeInfo[routeId];
       if (info?.status === "downloading") {
-        return { routeName: seg.routeName, info };
+        return { routeName: routeNameById[routeId] ?? "segment", info };
       }
     }
     return null;
-  }, [segments, routeInfo]);
+  }, [sourceRouteIds, routeNameById, routeInfo]);
 
   const isPreparing = isDownloading || stats.anyDownloading || stats.anySourceFetching;
   const currentSegmentLabel =
@@ -158,32 +164,38 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
 
   const handleDownloadAll = useCallback(async () => {
     setIsDownloading(true);
-    setProgress({ done: 0, total: segments.length });
+    setProgress({ done: 0, total: sourceRouteIds.length });
 
-    for (let i = 0; i < segments.length; i++) {
-      const seg = segments[i];
-      const info = routeInfo[seg.routeId];
-      const sources = allSourceInfo[seg.routeId];
+    for (let i = 0; i < sourceRouteIds.length; i++) {
+      const routeId = sourceRouteIds[i];
+      const info = routeInfo[routeId];
+      const sources = allSourceInfo[routeId];
       const segmentReady =
         info?.status === "complete" &&
         isSourceReady(sources?.osm) &&
         isSourceReady(sources?.google);
       if (segmentReady) {
-        setProgress({ done: i + 1, total: segments.length });
+        setProgress({ done: i + 1, total: sourceRouteIds.length });
         continue;
       }
       try {
-        const points =
-          stitched.pointsByRouteId?.[seg.routeId] ?? (await getRoutePoints(seg.routeId));
-        await prepareRouteOffline(seg.routeId, points);
+        const points = stitched.pointsByRouteId?.[routeId] ?? (await getRoutePoints(routeId));
+        await prepareRouteOffline(routeId, points);
       } catch (error) {
-        console.warn(`Failed to prepare segment ${seg.routeName}:`, error);
+        console.warn(`Failed to prepare segment ${routeNameById[routeId] ?? routeId}:`, error);
       }
-      setProgress({ done: i + 1, total: segments.length });
+      setProgress({ done: i + 1, total: sourceRouteIds.length });
     }
 
     setIsDownloading(false);
-  }, [segments, routeInfo, allSourceInfo, stitched.pointsByRouteId, prepareRouteOffline]);
+  }, [
+    sourceRouteIds,
+    routeInfo,
+    allSourceInfo,
+    stitched.pointsByRouteId,
+    routeNameById,
+    prepareRouteOffline,
+  ]);
 
   const clearPOIs = usePoiStore((s) => s.clearPOIs);
 
@@ -197,15 +209,15 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
           text: "Delete All",
           style: "destructive",
           onPress: async () => {
-            for (const seg of segments) {
-              await deleteOfflineData(seg.routeId);
-              await clearPOIs(seg.routeId);
+            for (const routeId of sourceRouteIds) {
+              await deleteOfflineData(routeId);
+              await clearPOIs(routeId);
             }
           },
         },
       ],
     );
-  }, [segments, deleteOfflineData, clearPOIs]);
+  }, [sourceRouteIds, deleteOfflineData, clearPOIs]);
 
   const handleDeleteAllPOIs = useCallback(() => {
     Alert.alert(
@@ -217,14 +229,14 @@ export default function CollectionOfflineSection({ stitched }: CollectionOffline
           text: "Delete Fetched POIs",
           style: "destructive",
           onPress: async () => {
-            for (const seg of segments) {
-              await clearPOIs(seg.routeId);
+            for (const routeId of sourceRouteIds) {
+              await clearPOIs(routeId);
             }
           },
         },
       ],
     );
-  }, [segments, clearPOIs]);
+  }, [sourceRouteIds, clearPOIs]);
 
   return (
     <View>

--- a/components/collection/SegmentList.tsx
+++ b/components/collection/SegmentList.tsx
@@ -6,7 +6,7 @@ import {
   RenderItemParams,
 } from "react-native-draggable-flatlist";
 import { Text } from "@/components/ui/text";
-import { GripVertical, X, ChevronRight } from "lucide-react-native";
+import { GripVertical, X, ChevronRight, Plus } from "lucide-react-native";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/cn";
 import { useThemeColors } from "@/theme";
@@ -14,8 +14,16 @@ import { useRouter } from "expo-router";
 import { useSettingsStore } from "@/store/settingsStore";
 import { useEtaStore } from "@/store/etaStore";
 import { computeRouteTotalETA } from "@/services/etaCalculator";
+import { buildPatchVariantRoutePoints, routeEndDistance } from "@/services/stitchingService";
 import { formatDistance, formatElevation, formatDuration } from "@/utils/formatters";
-import type { CollectionSegmentWithRoute, PowerModelConfig, RoutePoint } from "@/types";
+import { computeSliceAscentFromDistance } from "@/utils/geo";
+import type {
+  CollectionSegmentWithRoute,
+  PowerModelConfig,
+  RoutePoint,
+  StitchedSegmentInfo,
+  UnitSystem,
+} from "@/types";
 
 /** A position slot: one or more variants grouped together */
 interface PositionGroup {
@@ -27,6 +35,19 @@ interface PositionGroup {
 interface SegmentTimeCacheEntry {
   points: RoutePoint[];
   configKey: string;
+  ridingTime: number | null;
+}
+
+interface SegmentMetrics {
+  distanceMeters: number;
+  ascentMeters: number;
+  ridingTime: number | null;
+  points: RoutePoint[] | null;
+}
+
+interface VariantDiff {
+  distanceMeters: number;
+  ascentMeters: number;
   ridingTime: number | null;
 }
 
@@ -42,10 +63,109 @@ function powerConfigCacheKey(config: PowerModelConfig): string {
   ].join(":");
 }
 
+function buildPatchVariantPoints(
+  sw: CollectionSegmentWithRoute,
+  pointsByRouteId: Record<string, RoutePoint[]>,
+): RoutePoint[] | null {
+  const { baseRouteId, replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
+  if (
+    sw.segment.variantKind !== "patch" ||
+    !baseRouteId ||
+    replaceStartDistanceMeters == null ||
+    replaceEndDistanceMeters == null
+  ) {
+    return null;
+  }
+
+  const basePoints = pointsByRouteId[baseRouteId];
+  const patchPoints = pointsByRouteId[sw.route.id];
+  if (!basePoints || !patchPoints || basePoints.length < 2 || patchPoints.length < 2) return null;
+
+  const out = buildPatchVariantRoutePoints(
+    basePoints,
+    patchPoints,
+    replaceStartDistanceMeters,
+    replaceEndDistanceMeters,
+  );
+  return out.length >= 2 ? out : null;
+}
+
+function getSegmentMetricPoints(
+  sw: CollectionSegmentWithRoute,
+  pointsByRouteId: Record<string, RoutePoint[]>,
+  resolvedPointsByRouteId: Record<string, RoutePoint[]>,
+): RoutePoint[] | null {
+  const resolved = resolvedPointsByRouteId[sw.route.id];
+  if (resolved?.length >= 2) return resolved;
+  if (sw.segment.variantKind === "patch") return buildPatchVariantPoints(sw, pointsByRouteId);
+  return pointsByRouteId[sw.route.id] ?? null;
+}
+
+function getSegmentDistanceMeters(sw: CollectionSegmentWithRoute, points: RoutePoint[] | null) {
+  if (points?.length) return routeEndDistance(points);
+  const { replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
+  if (
+    sw.segment.variantKind === "patch" &&
+    sw.baseRoute &&
+    replaceStartDistanceMeters != null &&
+    replaceEndDistanceMeters != null
+  ) {
+    return (
+      replaceStartDistanceMeters +
+      sw.route.totalDistanceMeters +
+      Math.max(0, sw.baseRoute.totalDistanceMeters - replaceEndDistanceMeters)
+    );
+  }
+  return sw.route.totalDistanceMeters;
+}
+
+function getSegmentAscentMeters(
+  sw: CollectionSegmentWithRoute,
+  pointsByRouteId: Record<string, RoutePoint[]>,
+) {
+  const { baseRouteId, replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
+  if (
+    sw.segment.variantKind === "patch" &&
+    baseRouteId &&
+    replaceStartDistanceMeters != null &&
+    replaceEndDistanceMeters != null
+  ) {
+    const basePoints = pointsByRouteId[baseRouteId];
+    if (basePoints?.length) {
+      const baseEnd = routeEndDistance(basePoints);
+      return (
+        computeSliceAscentFromDistance(basePoints, 0, replaceStartDistanceMeters) +
+        sw.route.totalAscentMeters +
+        computeSliceAscentFromDistance(basePoints, replaceEndDistanceMeters, baseEnd)
+      );
+    }
+  }
+  return sw.route.totalAscentMeters;
+}
+
+function formatSignedDistanceDelta(deltaMeters: number, units: UnitSystem) {
+  if (Math.abs(deltaMeters) < 1) return "±0 m";
+  return `${deltaMeters > 0 ? "+" : "-"}${formatDistance(Math.abs(deltaMeters), units)}`;
+}
+
+function formatSignedElevationDelta(deltaMeters: number, units: UnitSystem) {
+  if (Math.abs(deltaMeters) < 1) return "±0 m";
+  return `${deltaMeters > 0 ? "+" : "-"}${formatElevation(Math.abs(deltaMeters), units)}`;
+}
+
+function formatSignedDurationDelta(deltaSeconds: number | null) {
+  if (deltaSeconds == null) return null;
+  if (Math.abs(deltaSeconds) < 30) return "±0m";
+  return `${deltaSeconds > 0 ? "+" : "-"}${formatDuration(Math.abs(deltaSeconds))}`;
+}
+
 interface SegmentListProps {
   segmentsWithRoutes: CollectionSegmentWithRoute[];
   pointsByRouteId: Record<string, RoutePoint[]>;
+  resolvedPointsByRouteId?: Record<string, RoutePoint[]>;
+  stitchedSegments?: StitchedSegmentInfo[];
   onSelectVariant: (routeId: string) => void;
+  onAddPatchVariant: (baseRouteId: string, position: number) => void;
   onReorder: (orderedPositions: { routeId: string; position: number }[]) => Promise<void>;
   onRemove: (routeId: string) => void;
 }
@@ -73,6 +193,8 @@ function SegmentRow({
   hasVariants,
   posIdx,
   ridingTime,
+  stitchedInfo,
+  variantDiff,
   drag,
   onSelect,
   onRemove,
@@ -82,6 +204,8 @@ function SegmentRow({
   hasVariants: boolean;
   posIdx: number;
   ridingTime: number | null;
+  stitchedInfo?: StitchedSegmentInfo;
+  variantDiff?: VariantDiff;
   drag?: () => void;
   onSelect: () => void;
   onRemove: () => void;
@@ -89,6 +213,27 @@ function SegmentRow({
   const colors = useThemeColors();
   const units = useSettingsStore((s) => s.units);
   const router = useRouter();
+  const displayDistanceMeters = stitchedInfo?.segmentDistanceMeters ?? sw.route.totalDistanceMeters;
+  const displayAscentMeters = stitchedInfo?.segmentAscentMeters ?? sw.route.totalAscentMeters;
+  const etaDiff = variantDiff ? formatSignedDurationDelta(variantDiff.ridingTime) : null;
+  const variantDiffText = variantDiff
+    ? [
+        etaDiff ? `ETA ${etaDiff}` : null,
+        `Dist ${formatSignedDistanceDelta(variantDiff.distanceMeters, units)}`,
+        `Gain ${formatSignedElevationDelta(variantDiff.ascentMeters, units)}`,
+      ]
+        .filter(Boolean)
+        .join("  ·  ")
+    : null;
+  const patchContext =
+    sw.segment.variantKind === "patch" &&
+    sw.segment.replaceStartDistanceMeters != null &&
+    sw.segment.replaceEndDistanceMeters != null
+      ? `replaces ${formatDistance(sw.segment.replaceStartDistanceMeters, units)}-${formatDistance(
+          sw.segment.replaceEndDistanceMeters,
+          units,
+        )}${sw.baseRoute ? ` of ${sw.baseRoute.name}` : ""}`
+      : null;
 
   return (
     <View
@@ -142,16 +287,30 @@ function SegmentRow({
           {!hasVariants && `${posIdx + 1}. `}
           {sw.route.name}
         </Text>
-        <Text className="text-[12px] text-muted-foreground font-barlow-sc-medium mt-0.5">
-          {formatDistance(sw.route.totalDistanceMeters, units)}
-          {"  ·  "}↑ {formatElevation(sw.route.totalAscentMeters, units)}
-          {ridingTime != null && (
-            <>
-              {"  ·  "}
-              {formatDuration(ridingTime)}
-            </>
-          )}
-        </Text>
+        {hasVariants && variantDiffText ? (
+          <Text className="text-[12px] text-muted-foreground font-barlow-sc-medium mt-0.5">
+            {variantDiffText}
+          </Text>
+        ) : (
+          <Text className="text-[12px] text-muted-foreground font-barlow-sc-medium mt-0.5">
+            {formatDistance(displayDistanceMeters, units)}
+            {"  ·  "}↑ {formatElevation(displayAscentMeters, units)}
+            {ridingTime != null && (
+              <>
+                {"  ·  "}
+                {formatDuration(ridingTime)}
+              </>
+            )}
+          </Text>
+        )}
+        {patchContext && (
+          <Text
+            className="text-[12px] text-muted-foreground font-barlow-medium mt-0.5"
+            numberOfLines={1}
+          >
+            {patchContext}
+          </Text>
+        )}
       </TouchableOpacity>
 
       {/* Right: chevron + remove */}
@@ -177,7 +336,10 @@ function SegmentRow({
 export default function SegmentList({
   segmentsWithRoutes,
   pointsByRouteId,
+  resolvedPointsByRouteId = {},
+  stitchedSegments = [],
   onSelectVariant,
+  onAddPatchVariant,
   onReorder,
   onRemove,
 }: SegmentListProps) {
@@ -189,41 +351,65 @@ export default function SegmentList({
   const serverGroups = useMemo(() => groupByPosition(segmentsWithRoutes), [segmentsWithRoutes]);
   const [localGroups, setLocalGroups] = useState<PositionGroup[]>(serverGroups);
   const [isSaving, setIsSaving] = useState(false);
+  const stitchedInfoByRouteId = useMemo(() => {
+    const out: Record<string, StitchedSegmentInfo> = {};
+    for (const segment of stitchedSegments) {
+      out[segment.routeId] = segment;
+    }
+    return out;
+  }, [stitchedSegments]);
 
   const powerConfigKey = useMemo(() => powerConfigCacheKey(powerConfig), [powerConfig]);
-  const ridingTimesByRouteId = useMemo(() => {
+  const metricsByRouteId = useMemo(() => {
     const cache = segmentTimeCacheRef.current;
     const activeRouteIds = new Set<string>();
-    const times: Record<string, number | null> = {};
+    const metrics: Record<string, SegmentMetrics> = {};
 
     for (const sw of segmentsWithRoutes) {
       const routeId = sw.route.id;
-      if (routeId in times) continue;
+      if (routeId in metrics) continue;
       activeRouteIds.add(routeId);
 
-      const points = pointsByRouteId[routeId];
+      const points = getSegmentMetricPoints(sw, pointsByRouteId, resolvedPointsByRouteId);
+      const distanceMeters = getSegmentDistanceMeters(sw, points);
+      const ascentMeters = getSegmentAscentMeters(sw, pointsByRouteId);
       if (!points || points.length < 2) {
-        times[routeId] = null;
+        metrics[routeId] = {
+          distanceMeters,
+          ascentMeters,
+          ridingTime: null,
+          points,
+        };
         continue;
       }
 
       const cached = cache.get(routeId);
       if (cached?.points === points && cached.configKey === powerConfigKey) {
-        times[routeId] = cached.ridingTime;
+        metrics[routeId] = {
+          distanceMeters,
+          ascentMeters,
+          ridingTime: cached.ridingTime,
+          points,
+        };
         continue;
       }
 
       const ridingTime = computeRouteTotalETA(points, powerConfig);
       cache.set(routeId, { points, configKey: powerConfigKey, ridingTime });
-      times[routeId] = ridingTime;
+      metrics[routeId] = {
+        distanceMeters,
+        ascentMeters,
+        ridingTime,
+        points,
+      };
     }
 
     for (const routeId of cache.keys()) {
       if (!activeRouteIds.has(routeId)) cache.delete(routeId);
     }
 
-    return times;
-  }, [segmentsWithRoutes, pointsByRouteId, powerConfig, powerConfigKey]);
+    return metrics;
+  }, [segmentsWithRoutes, pointsByRouteId, resolvedPointsByRouteId, powerConfig, powerConfigKey]);
 
   useEffect(() => {
     setLocalGroups(serverGroups);
@@ -254,6 +440,26 @@ export default function SegmentList({
     ({ item: group, drag, isActive: isDragging }: RenderItemParams<PositionGroup>) => {
       const posIdx = localGroups.indexOf(group);
       const hasVariants = group.variants.length > 1;
+      const patchBaseVariant =
+        group.variants.find((sw) => sw.segment.variantKind === "full" && sw.segment.isSelected) ??
+        group.variants.find((sw) => sw.segment.variantKind === "full");
+      const referenceVariant =
+        patchBaseVariant ?? group.variants.find((sw) => sw.segment.isSelected) ?? group.variants[0];
+      const referenceMetrics = referenceVariant
+        ? metricsByRouteId[referenceVariant.route.id]
+        : undefined;
+      const getVariantDiff = (sw: CollectionSegmentWithRoute): VariantDiff | undefined => {
+        const metrics = metricsByRouteId[sw.route.id];
+        if (!referenceMetrics || !metrics) return undefined;
+        return {
+          distanceMeters: metrics.distanceMeters - referenceMetrics.distanceMeters,
+          ascentMeters: metrics.ascentMeters - referenceMetrics.ascentMeters,
+          ridingTime:
+            metrics.ridingTime != null && referenceMetrics.ridingTime != null
+              ? metrics.ridingTime - referenceMetrics.ridingTime
+              : null,
+        };
+      };
 
       return (
         <ScaleDecorator>
@@ -288,7 +494,13 @@ export default function SegmentList({
                         isSelected={isSelected}
                         hasVariants
                         posIdx={posIdx}
-                        ridingTime={ridingTimesByRouteId[sw.route.id] ?? null}
+                        ridingTime={metricsByRouteId[sw.route.id]?.ridingTime ?? null}
+                        stitchedInfo={isSelected ? stitchedInfoByRouteId[sw.route.id] : undefined}
+                        variantDiff={
+                          sw.route.id === referenceVariant?.route.id
+                            ? undefined
+                            : getVariantDiff(sw)
+                        }
                         onSelect={() => onSelectVariant(sw.route.id)}
                         onRemove={() => onRemove(sw.route.id)}
                       />
@@ -304,18 +516,43 @@ export default function SegmentList({
                   isSelected={sw.segment.isSelected}
                   hasVariants={false}
                   posIdx={posIdx}
-                  ridingTime={ridingTimesByRouteId[sw.route.id] ?? null}
+                  ridingTime={metricsByRouteId[sw.route.id]?.ridingTime ?? null}
+                  stitchedInfo={
+                    sw.segment.isSelected ? stitchedInfoByRouteId[sw.route.id] : undefined
+                  }
                   drag={drag}
                   onSelect={() => {}}
                   onRemove={() => onRemove(sw.route.id)}
                 />
               ))
             )}
+            {patchBaseVariant && (
+              <Button
+                variant="secondary"
+                className="mt-2 h-12 self-start px-3"
+                onPress={() =>
+                  onAddPatchVariant(patchBaseVariant.route.id, patchBaseVariant.segment.position)
+                }
+              >
+                <Plus size={16} color={colors.accent} />
+                <Text className="ml-2 text-[14px] font-barlow-semibold text-primary">
+                  Add Patch Variant
+                </Text>
+              </Button>
+            )}
           </View>
         </ScaleDecorator>
       );
     },
-    [localGroups, colors, ridingTimesByRouteId, onSelectVariant, onRemove],
+    [
+      localGroups,
+      colors,
+      metricsByRouteId,
+      stitchedInfoByRouteId,
+      onSelectVariant,
+      onAddPatchVariant,
+      onRemove,
+    ],
   );
 
   if (localGroups.length === 0) {

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -19,8 +19,10 @@ import RouteMarkerLayer from "./RouteMarkerLayer";
 import POILayer from "./POILayer";
 import ClimbHighlightLayer from "./ClimbHighlightLayer";
 import TemperatureRouteOverlay from "./TemperatureRouteOverlay";
+import VariantOverlayLayer, { type VariantOverlay } from "./VariantOverlayLayer";
 import TabbedBottomPanel from "./TabbedBottomPanel";
 import { displayPOIsForActiveRoute } from "@/services/activePOIs";
+import { computeRouteTotalETA } from "@/services/etaCalculator";
 import { resolveActiveClimb } from "@/utils/climbSelect";
 import { getClimbMapBounds, getZoomLevelToFitBounds } from "@/utils/climbGeometry";
 import { isClimbAtLeastDifficulty } from "@/constants/climbHelpers";
@@ -39,7 +41,10 @@ import { useEtaStore } from "@/store/etaStore";
 import { useWeatherStore } from "@/store/weatherStore";
 import { useOfflineStore } from "@/store/offlineStore";
 import { useSettingsStore } from "@/store/settingsStore";
-import type { RoutePoint, UserPosition } from "@/types";
+import { buildPatchVariantRoutePoints, routeEndDistance } from "@/services/stitchingService";
+import { computeSliceAscentFromDistance } from "@/utils/geo";
+import { formatDistance, formatDuration, formatElevation } from "@/utils/formatters";
+import type { CollectionSegmentWithRoute, RoutePoint, UnitSystem, UserPosition } from "@/types";
 
 const CLIMB_PAN_PADDING = {
   top: 72,
@@ -47,6 +52,117 @@ const CLIMB_PAN_PADDING = {
   bottom: 40,
   left: 32,
 };
+
+interface VariantMetric {
+  distanceMeters: number;
+  ascentMeters: number;
+  ridingTime: number | null;
+}
+
+function groupCollectionSegments(
+  segments: CollectionSegmentWithRoute[],
+): CollectionSegmentWithRoute[][] {
+  const grouped = new Map<number, CollectionSegmentWithRoute[]>();
+  for (const sw of segments) {
+    if (!grouped.has(sw.segment.position)) grouped.set(sw.segment.position, []);
+    grouped.get(sw.segment.position)!.push(sw);
+  }
+  return [...grouped.entries()].sort(([a], [b]) => a - b).map(([, variants]) => variants);
+}
+
+function effectiveVariantPoints(
+  sw: CollectionSegmentWithRoute,
+  pointsByRouteId: Record<string, RoutePoint[]>,
+): RoutePoint[] | null {
+  const routePoints = pointsByRouteId[sw.route.id];
+  if (sw.segment.variantKind !== "patch") return routePoints ?? null;
+
+  const { baseRouteId, replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
+  if (
+    !baseRouteId ||
+    replaceStartDistanceMeters == null ||
+    replaceEndDistanceMeters == null ||
+    !routePoints
+  ) {
+    return routePoints ?? null;
+  }
+
+  const basePoints = pointsByRouteId[baseRouteId];
+  if (!basePoints) return routePoints;
+  const stitched = buildPatchVariantRoutePoints(
+    basePoints,
+    routePoints,
+    replaceStartDistanceMeters,
+    replaceEndDistanceMeters,
+  );
+  return stitched.length >= 2 ? stitched : routePoints;
+}
+
+function effectiveVariantAscentMeters(
+  sw: CollectionSegmentWithRoute,
+  pointsByRouteId: Record<string, RoutePoint[]>,
+): number {
+  const { baseRouteId, replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
+  if (
+    sw.segment.variantKind === "patch" &&
+    baseRouteId &&
+    replaceStartDistanceMeters != null &&
+    replaceEndDistanceMeters != null
+  ) {
+    const basePoints = pointsByRouteId[baseRouteId];
+    if (basePoints?.length) {
+      const baseEnd = routeEndDistance(basePoints);
+      return (
+        computeSliceAscentFromDistance(basePoints, 0, replaceStartDistanceMeters) +
+        sw.route.totalAscentMeters +
+        computeSliceAscentFromDistance(basePoints, replaceEndDistanceMeters, baseEnd)
+      );
+    }
+  }
+  return sw.route.totalAscentMeters;
+}
+
+function variantMetric(
+  sw: CollectionSegmentWithRoute,
+  pointsByRouteId: Record<string, RoutePoint[]>,
+  powerConfig: ReturnType<typeof useEtaStore.getState>["powerConfig"],
+): VariantMetric | null {
+  const points = effectiveVariantPoints(sw, pointsByRouteId);
+  if (!points || points.length < 2) return null;
+  return {
+    distanceMeters: routeEndDistance(points),
+    ascentMeters: effectiveVariantAscentMeters(sw, pointsByRouteId),
+    ridingTime: computeRouteTotalETA(points, powerConfig),
+  };
+}
+
+function signedDistance(deltaMeters: number, units: UnitSystem): string {
+  if (Math.abs(deltaMeters) < 1) return "±0 m";
+  return `${deltaMeters > 0 ? "+" : "-"}${formatDistance(Math.abs(deltaMeters), units)}`;
+}
+
+function signedElevation(deltaMeters: number, units: UnitSystem): string {
+  if (Math.abs(deltaMeters) < 1) return "±0 m";
+  return `${deltaMeters > 0 ? "+" : "-"}${formatElevation(Math.abs(deltaMeters), units)}`;
+}
+
+function signedDuration(deltaSeconds: number | null): string {
+  if (deltaSeconds == null) return "ETA n/a";
+  if (Math.abs(deltaSeconds) < 30) return "ETA ±0m";
+  return `ETA ${deltaSeconds > 0 ? "+" : "-"}${formatDuration(Math.abs(deltaSeconds))}`;
+}
+
+function variantDiffLabel(metric: VariantMetric, reference: VariantMetric, units: UnitSystem) {
+  const timeDelta =
+    metric.ridingTime != null && reference.ridingTime != null
+      ? metric.ridingTime - reference.ridingTime
+      : null;
+  return [
+    signedDuration(timeDelta),
+    signedDistance(metric.distanceMeters - reference.distanceMeters, units),
+    `↑ ${signedElevation(metric.ascentMeters - reference.ascentMeters, units)}`,
+  ].join("\n");
+}
 
 // Initialize Mapbox with access token from app config
 try {
@@ -97,15 +213,26 @@ export default function MapScreen() {
   const recordSnapHistory = useRouteStore((s) => s.recordSnapHistory);
   const clearRouteProgress = useRouteStore((s) => s.clearRouteProgress);
   const loadCollections = useCollectionStore((s) => s.loadCollections);
+  const getCollectionSegmentsWithRoutes = useCollectionStore(
+    (s) => s.getCollectionSegmentsWithRoutes,
+  );
   const allPois = usePoiStore((s) => s.pois);
   const loadPOIs = usePoiStore((s) => s.loadPOIs);
   const computeETAForRoute = useEtaStore((s) => s.computeETAForRoute);
   const cumulativeTime = useEtaStore((s) => s.cumulativeTime);
+  const powerConfig = useEtaStore((s) => s.powerConfig);
   const fetchWeather = useWeatherStore((s) => s.fetchWeather);
   const weatherTimeline = useWeatherStore((s) => s.timeline);
   const weatherRouteId = useWeatherStore((s) => s.routeId);
   const weatherTemperatureMode = useSettingsStore((s) => s.weatherTemperatureDisplayMode);
+  const units = useSettingsStore((s) => s.units);
   const isConnected = useOfflineStore((s) => s.isConnected);
+  const [activeCollectionSegments, setActiveCollectionSegments] = useState<
+    CollectionSegmentWithRoute[]
+  >([]);
+  const [activeVariantPointsByRouteId, setActiveVariantPointsByRouteId] = useState<
+    Record<string, RoutePoint[]>
+  >({});
 
   // Unified active context — works for both standalone routes and collections
   const activeData = useActiveRouteData();
@@ -152,6 +279,47 @@ export default function MapScreen() {
     if (!activeStandaloneRouteId) return;
     loadRoutePoints([activeStandaloneRouteId], { prune: true });
   }, [activeStandaloneRouteId, loadRoutePoints]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadActiveCollectionVariants() {
+      if (activeData?.type !== "collection") {
+        setActiveCollectionSegments([]);
+        setActiveVariantPointsByRouteId({});
+        return;
+      }
+
+      const segments = await getCollectionSegmentsWithRoutes(activeData.id);
+      const routeIds = new Set<string>();
+      for (const sw of segments) {
+        routeIds.add(sw.route.id);
+        if (sw.segment.baseRouteId) routeIds.add(sw.segment.baseRouteId);
+      }
+
+      const { getRoutePoints } = await import("@/db/database");
+      const ids = [...routeIds];
+      const points = await Promise.all(ids.map((routeId) => getRoutePoints(routeId)));
+      if (cancelled) return;
+
+      const pointsByRouteId: Record<string, RoutePoint[]> = {};
+      for (let i = 0; i < ids.length; i++) {
+        pointsByRouteId[ids[i]] = points[i];
+      }
+      setActiveCollectionSegments(segments);
+      setActiveVariantPointsByRouteId(pointsByRouteId);
+    }
+
+    loadActiveCollectionVariants().catch((e) => {
+      if (cancelled) return;
+      console.warn("Failed to load active collection variants:", e);
+      setActiveCollectionSegments([]);
+      setActiveVariantPointsByRouteId({});
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeData?.id, activeData?.type, getCollectionSegmentsWithRoutes]);
 
   const loadClimbs = useClimbStore((s) => s.loadClimbs);
   const updateCurrentClimb = useClimbStore((s) => s.updateCurrentClimb);
@@ -440,6 +608,37 @@ export default function MapScreen() {
     };
   }, [activeData, activeRoutePoints?.length]);
 
+  const activeVariantOverlays = useMemo<VariantOverlay[]>(() => {
+    if (activeData?.type !== "collection" || activeCollectionSegments.length === 0) return [];
+    const overlays: VariantOverlay[] = [];
+    for (const variants of groupCollectionSegments(activeCollectionSegments)) {
+      if (variants.length <= 1) continue;
+      const reference = variants.find((sw) => sw.segment.isSelected) ?? variants[0];
+      const referenceMetric = variantMetric(reference, activeVariantPointsByRouteId, powerConfig);
+      if (!referenceMetric) continue;
+
+      for (const sw of variants) {
+        if (sw.segment.isSelected) continue;
+        const points = activeVariantPointsByRouteId[sw.route.id];
+        if (!points || points.length < 2) continue;
+        const metric = variantMetric(sw, activeVariantPointsByRouteId, powerConfig);
+        if (!metric) continue;
+        overlays.push({
+          id: sw.route.id,
+          points,
+          label: variantDiffLabel(metric, referenceMetric, units),
+        });
+      }
+    }
+    return overlays;
+  }, [
+    activeData?.type,
+    activeCollectionSegments,
+    activeVariantPointsByRouteId,
+    powerConfig,
+    units,
+  ]);
+
   // RNMapbox inserts native layers in mount order. Key upper overlay tiers so they remount
   // above lower tiers when route/climb/visibility state changes.
   const routeStackKey = useMemo(() => {
@@ -566,6 +765,12 @@ export default function MapScreen() {
             />
           );
         })}
+        {activeVariantOverlays.length > 0 && (
+          <VariantOverlayLayer
+            key={`collection-variants-${routeStackKey}`}
+            overlays={activeVariantOverlays}
+          />
+        )}
         {activeCollectionRoute && activeRoutePoints && activeRoutePoints.length > 1 && (
           <RouteLayer
             key={`${activeCollectionRoute.id}-${mapStyle.styleKey}`}

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -319,7 +319,7 @@ export default function MapScreen() {
     return () => {
       cancelled = true;
     };
-  }, [activeData?.id, activeData?.type, getCollectionSegmentsWithRoutes]);
+  }, [activeData?.id, activeData?.type, activeData?.segments, getCollectionSegmentsWithRoutes]);
 
   const loadClimbs = useClimbStore((s) => s.loadClimbs);
   const updateCurrentClimb = useClimbStore((s) => s.updateCurrentClimb);

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -41,7 +41,11 @@ import { useEtaStore } from "@/store/etaStore";
 import { useWeatherStore } from "@/store/weatherStore";
 import { useOfflineStore } from "@/store/offlineStore";
 import { useSettingsStore } from "@/store/settingsStore";
-import { buildPatchVariantRoutePoints, routeEndDistance } from "@/services/stitchingService";
+import {
+  buildPatchVariantRoutePoints,
+  routeEndDistance,
+  sliceRoutePointsByDistance,
+} from "@/services/stitchingService";
 import { computeSliceAscentFromDistance } from "@/utils/geo";
 import { formatDistance, formatDuration, formatElevation } from "@/utils/formatters";
 import type { CollectionSegmentWithRoute, RoutePoint, UnitSystem, UserPosition } from "@/types";
@@ -619,7 +623,20 @@ export default function MapScreen() {
 
       for (const sw of variants) {
         if (sw.segment.isSelected) continue;
-        const points = activeVariantPointsByRouteId[sw.route.id];
+        const rawPoints = activeVariantPointsByRouteId[sw.route.id];
+        const points =
+          rawPoints &&
+          sw.segment.variantKind === "full" &&
+          reference.segment.variantKind === "patch" &&
+          reference.segment.baseRouteId === sw.route.id &&
+          reference.segment.replaceStartDistanceMeters != null &&
+          reference.segment.replaceEndDistanceMeters != null
+            ? sliceRoutePointsByDistance(
+                rawPoints,
+                reference.segment.replaceStartDistanceMeters,
+                reference.segment.replaceEndDistanceMeters,
+              )
+            : rawPoints;
         if (!points || points.length < 2) continue;
         const metric = variantMetric(sw, activeVariantPointsByRouteId, powerConfig);
         if (!metric) continue;

--- a/components/map/VariantOverlayLayer.tsx
+++ b/components/map/VariantOverlayLayer.tsx
@@ -1,0 +1,101 @@
+import React, { useMemo } from "react";
+import { ShapeSource, LineLayer, SymbolLayer } from "@rnmapbox/maps";
+import { INACTIVE_ROUTE_COLOR } from "@/constants";
+import { useThemeColors } from "@/theme";
+import type { RoutePoint } from "@/types";
+
+export interface VariantOverlay {
+  id: string;
+  points: RoutePoint[];
+  label: string;
+}
+
+function labelCoordinate(points: RoutePoint[]): [number, number] | null {
+  if (points.length === 0) return null;
+  const targetDistance = (points[points.length - 1]?.distanceFromStartMeters ?? 0) / 2;
+  const point =
+    points.find((pt) => pt.distanceFromStartMeters >= targetDistance) ??
+    points[Math.floor(points.length / 2)];
+  return point ? [point.longitude, point.latitude] : null;
+}
+
+export default function VariantOverlayLayer({ overlays }: { overlays: VariantOverlay[] }) {
+  const colors = useThemeColors();
+
+  const { lineGeoJSON, labelGeoJSON } = useMemo(() => {
+    const visible = overlays.filter((overlay) => overlay.points.length >= 2);
+    const lines: GeoJSON.Feature<GeoJSON.LineString>[] = visible.map((overlay) => ({
+      type: "Feature",
+      properties: { id: overlay.id },
+      geometry: {
+        type: "LineString",
+        coordinates: overlay.points.map((point) => [point.longitude, point.latitude]),
+      },
+    }));
+    const labels: GeoJSON.Feature<GeoJSON.Point>[] = visible.flatMap((overlay) => {
+      const coordinates = labelCoordinate(overlay.points);
+      if (!coordinates) return [];
+      return [
+        {
+          type: "Feature",
+          properties: { id: overlay.id, label: overlay.label },
+          geometry: { type: "Point", coordinates },
+        },
+      ];
+    });
+
+    return {
+      lineGeoJSON: { type: "FeatureCollection", features: lines } as GeoJSON.FeatureCollection,
+      labelGeoJSON: { type: "FeatureCollection", features: labels } as GeoJSON.FeatureCollection,
+    };
+  }, [overlays]);
+
+  if (lineGeoJSON.features.length === 0) return null;
+
+  return (
+    <>
+      <ShapeSource id="collection-variant-overlay-source" shape={lineGeoJSON}>
+        <LineLayer
+          id="collection-variant-overlay-outline"
+          style={{
+            lineColor: colors.surface,
+            lineWidth: ["interpolate", ["linear"], ["zoom"], 8, 4.5, 13, 7],
+            lineOpacity: 0.45,
+            lineCap: "round",
+            lineJoin: "round",
+          }}
+        />
+        <LineLayer
+          id="collection-variant-overlay-line"
+          aboveLayerID="collection-variant-overlay-outline"
+          style={{
+            lineColor: INACTIVE_ROUTE_COLOR,
+            lineWidth: ["interpolate", ["linear"], ["zoom"], 8, 3, 13, 5],
+            lineOpacity: 0.65,
+            lineCap: "round",
+            lineJoin: "round",
+          }}
+        />
+      </ShapeSource>
+      {labelGeoJSON.features.length > 0 && (
+        <ShapeSource id="collection-variant-overlay-label-source" shape={labelGeoJSON}>
+          <SymbolLayer
+            id="collection-variant-overlay-labels"
+            style={{
+              textField: ["get", "label"],
+              textSize: ["interpolate", ["linear"], ["zoom"], 8, 0, 9, 10, 13, 11],
+              textOpacity: ["interpolate", ["linear"], ["zoom"], 8, 0, 9, 0.82],
+              textColor: colors.textSecondary,
+              textHaloColor: colors.surface,
+              textHaloWidth: 2,
+              textLineHeight: 1.12,
+              textAllowOverlap: false,
+              textIgnorePlacement: false,
+              textOffset: [0, -1],
+            }}
+          />
+        </ShapeSource>
+      )}
+    </>
+  );
+}

--- a/db/database.ts
+++ b/db/database.ts
@@ -23,6 +23,7 @@ import type {
   StarredItem,
   Collection,
   CollectionSegment,
+  CollectionSegmentVariantKind,
   Climb,
 } from "@/types";
 
@@ -38,6 +39,15 @@ export const db = drizzle(expoDb, {
 
 // Apply schema from drizzle/migrations.ts (generated from db/schema.ts via `npm run db:migrate`)
 migrate(db, migrations);
+
+function normalizeCollectionSegment(
+  row: typeof collectionSegments.$inferSelect,
+): CollectionSegment {
+  return {
+    ...row,
+    variantKind: row.variantKind as CollectionSegmentVariantKind,
+  };
+}
 
 // --- Route CRUD ---
 
@@ -475,6 +485,10 @@ export async function insertCollectionSegment(segment: CollectionSegment): Promi
       routeId: segment.routeId,
       position: segment.position,
       isSelected: segment.isSelected,
+      variantKind: segment.variantKind,
+      baseRouteId: segment.baseRouteId,
+      replaceStartDistanceMeters: segment.replaceStartDistanceMeters,
+      replaceEndDistanceMeters: segment.replaceEndDistanceMeters,
     })
     .run();
 }
@@ -493,6 +507,20 @@ export async function deleteCollectionSegment(
     .run();
 }
 
+export async function deletePatchVariantsForBaseRoute(
+  collectionId: string,
+  baseRouteId: string,
+): Promise<void> {
+  db.delete(collectionSegments)
+    .where(
+      and(
+        eq(collectionSegments.collectionId, collectionId),
+        eq(collectionSegments.baseRouteId, baseRouteId),
+      ),
+    )
+    .run();
+}
+
 export async function getCollectionSegments(collectionId: string): Promise<CollectionSegment[]> {
   const rows = db
     .select()
@@ -500,7 +528,7 @@ export async function getCollectionSegments(collectionId: string): Promise<Colle
     .where(eq(collectionSegments.collectionId, collectionId))
     .orderBy(asc(collectionSegments.position), desc(collectionSegments.isSelected))
     .all();
-  return rows;
+  return rows.map(normalizeCollectionSegment);
 }
 
 export async function selectVariant(collectionId: string, routeId: string): Promise<void> {

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -127,9 +127,14 @@ export const collectionSegments = sqliteTable(
       .references(() => routes.id, { onDelete: "cascade" }),
     position: integer("position").notNull(),
     isSelected: integer("isSelected", { mode: "boolean" }).notNull().default(true),
+    variantKind: text("variantKind").notNull().default("full"),
+    baseRouteId: text("baseRouteId").references(() => routes.id, { onDelete: "cascade" }),
+    replaceStartDistanceMeters: real("replaceStartDistanceMeters"),
+    replaceEndDistanceMeters: real("replaceEndDistanceMeters"),
   },
   (table) => [
     primaryKey({ columns: [table.collectionId, table.routeId] }),
     index("idx_collection_segments_col_pos").on(table.collectionId, table.position),
+    index("idx_collection_segments_base_route").on(table.collectionId, table.baseRouteId),
   ],
 );

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,6 +136,10 @@ OSM opening hours are often missing or wrong for gas stations and groceries — 
 
 Routes are stored individually. Collections reference routes via `collection_segments` table with position-based slots. At display time, selected segments are stitched (points concatenated with distance offsets). `RoutePoint[]` consumers (snapping, ETA cumulative time, weather, elevation rendering) receive the stitched array unchanged — their input is already in "stitched coords".
 
+Collection variants can be either full-route variants or patch variants. A patch variant uses a shorter route to replace a confirmed distance range on a base route in the same collection position. Stitching resolves that selected variant into base prefix + patch route + base suffix, then exposes the result as the same stitched `RoutePoint[]` used everywhere else.
+
+Patch-aware display data uses `StitchedSourceSpan` metadata. Each span records the source route, raw distance range, effective stitched range, and raw-to-stitched offset. POIs and climbs remain stored in raw per-route coordinates; collection display helpers include only items whose raw distances fall inside an active source span and apply that span's offset exactly once.
+
 ### Route Progress
 
 `SnappedPosition.distanceAlongRouteMeters` is the authoritative rider progress value. Route snapping computes it from segment projection, so it may fall between imported route points. `SnappedPosition.pointIndex` is still returned as the nearest route point for geometry anchoring and array-based helpers, but consumers should derive indexes from `distanceAlongRouteMeters` when they need an index for slicing, ETA, weather, or elevation rendering.

--- a/docs/features.md
+++ b/docs/features.md
@@ -23,6 +23,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 
 - Group route segments into collections with ordered positions
 - Variant auto-detection (alternative segments for the same position)
+- Patch-style variants for subset routes that replace a confirmed slice of a base segment
 - Stitching — selected segments concatenated into continuous view for all downstream features
 - Drag-to-reorder segments, radio-button variant selection
 

--- a/drizzle/0004_add_patch_route_variants.sql
+++ b/drizzle/0004_add_patch_route_variants.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `collection_segments` ADD `variantKind` text DEFAULT 'full' NOT NULL;--> statement-breakpoint
+ALTER TABLE `collection_segments` ADD `baseRouteId` text REFERENCES routes(id) ON DELETE cascade;--> statement-breakpoint
+ALTER TABLE `collection_segments` ADD `replaceStartDistanceMeters` real;--> statement-breakpoint
+ALTER TABLE `collection_segments` ADD `replaceEndDistanceMeters` real;--> statement-breakpoint
+CREATE INDEX `idx_collection_segments_base_route` ON `collection_segments` (`collectionId`,`baseRouteId`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777986757000,
       "tag": "0003_add_collection_planned_start",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1777986758000,
+      "tag": "0004_add_patch_route_variants",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations.ts
+++ b/drizzle/migrations.ts
@@ -8,6 +8,7 @@ export default {
       { idx: 1, when: 1774960400000, tag: "0001_add_climbs", breakpoints: true },
       { idx: 2, when: 1777986756000, tag: "0002_add_starred_items", breakpoints: true },
       { idx: 3, when: 1777986757000, tag: "0003_add_collection_planned_start", breakpoints: true },
+      { idx: 4, when: 1777986758000, tag: "0004_add_patch_route_variants", breakpoints: true },
     ],
   },
   migrations: {
@@ -99,6 +100,12 @@ CREATE INDEX \`idx_climbs_route_distance\` ON \`climbs\` (\`routeId\`,\`startDis
 );
 `,
     m0003: `ALTER TABLE \`collections\` ADD \`plannedStartMs\` integer;
+`,
+    m0004: `ALTER TABLE \`collection_segments\` ADD \`variantKind\` text DEFAULT 'full' NOT NULL;--> statement-breakpoint
+ALTER TABLE \`collection_segments\` ADD \`baseRouteId\` text REFERENCES routes(id) ON DELETE cascade;--> statement-breakpoint
+ALTER TABLE \`collection_segments\` ADD \`replaceStartDistanceMeters\` real;--> statement-breakpoint
+ALTER TABLE \`collection_segments\` ADD \`replaceEndDistanceMeters\` real;--> statement-breakpoint
+CREATE INDEX \`idx_collection_segments_base_route\` ON \`collection_segments\` (\`collectionId\`,\`baseRouteId\`);
 `,
   },
 };

--- a/hooks/useActiveRouteData.ts
+++ b/hooks/useActiveRouteData.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useRouteStore } from "@/store/routeStore";
 import { useCollectionStore } from "@/store/collectionStore";
+import { getStitchedSourceRouteIds } from "@/services/stitchingService";
 import type { ActiveRouteData, Collection, Route, RoutePoint, StitchedCollection } from "@/types";
 
 function buildActiveRouteData(
@@ -20,7 +21,7 @@ function buildActiveRouteData(
       totalAscentMeters: activeStitchedCollection.totalAscentMeters,
       totalDescentMeters: activeStitchedCollection.totalDescentMeters,
       segments: activeStitchedCollection.segments,
-      routeIds: activeStitchedCollection.segments.map((s) => s.routeId),
+      routeIds: getStitchedSourceRouteIds(activeStitchedCollection.segments),
       pointsByRouteId: activeStitchedCollection.pointsByRouteId,
     };
   }

--- a/services/displayDistance.ts
+++ b/services/displayDistance.ts
@@ -5,6 +5,7 @@ import type {
   DisplayPOI,
   POI,
   StitchedSegmentInfo,
+  StitchedSourceSpan,
 } from "@/types";
 
 export function toDisplayDistanceMeters(distanceMeters: number): DisplayDistanceMeters {
@@ -30,8 +31,12 @@ export function toDisplayPOIForSegments(
 ): DisplayPOI | null {
   if (!segments) return toDisplayPOI(poi);
 
-  const segment = segments.find((s) => s.routeId === poi.routeId);
-  return segment ? toDisplayPOI(poi, segment.distanceOffsetMeters) : null;
+  const span = findSourceSpanForDistance(
+    segments.flatMap((segment) => segment.sourceSpans),
+    poi.routeId,
+    poi.distanceAlongRouteMeters,
+  );
+  return span ? toDisplayPOI(poi, span.distanceOffsetMeters) : null;
 }
 
 export function toDisplayClimb(climb: Climb, distanceOffsetMeters = 0): DisplayClimb {
@@ -52,4 +57,47 @@ export function toDisplayClimb(climb: Climb, distanceOffsetMeters = 0): DisplayC
 
 export function toDisplayClimbs(climbs: Climb[], distanceOffsetMeters = 0): DisplayClimb[] {
   return climbs.map((climb) => toDisplayClimb(climb, distanceOffsetMeters));
+}
+
+export function findSourceSpanForDistance(
+  spans: StitchedSourceSpan[],
+  routeId: string,
+  distanceMeters: number,
+): StitchedSourceSpan | null {
+  return (
+    spans.find(
+      (span) =>
+        span.routeId === routeId &&
+        distanceMeters >= span.rawStartDistanceMeters &&
+        distanceMeters <= span.rawEndDistanceMeters,
+    ) ?? null
+  );
+}
+
+export function toDisplayClimbForSpan(climb: Climb, span: StitchedSourceSpan): DisplayClimb | null {
+  const clippedStart = Math.max(climb.startDistanceMeters, span.rawStartDistanceMeters);
+  const clippedEnd = Math.min(climb.endDistanceMeters, span.rawEndDistanceMeters);
+  if (clippedEnd <= clippedStart) return null;
+
+  const originalLength = Math.max(1, climb.endDistanceMeters - climb.startDistanceMeters);
+  const clippedLength = clippedEnd - clippedStart;
+  const lengthRatio = Math.min(1, clippedLength / originalLength);
+
+  const effectiveStartDistanceMeters = toDisplayDistanceMeters(
+    clippedStart + span.distanceOffsetMeters,
+  );
+  const effectiveEndDistanceMeters = toDisplayDistanceMeters(
+    clippedEnd + span.distanceOffsetMeters,
+  );
+
+  return {
+    ...climb,
+    startDistanceMeters: clippedStart,
+    endDistanceMeters: clippedEnd,
+    lengthMeters: clippedLength,
+    totalAscentMeters: climb.totalAscentMeters * lengthRatio,
+    effectiveDistanceMeters: effectiveStartDistanceMeters,
+    effectiveStartDistanceMeters,
+    effectiveEndDistanceMeters,
+  };
 }

--- a/services/displayDistance.ts
+++ b/services/displayDistance.ts
@@ -82,6 +82,9 @@ export function toDisplayClimbForSpan(climb: Climb, span: StitchedSourceSpan): D
   const originalLength = Math.max(1, climb.endDistanceMeters - climb.startDistanceMeters);
   const clippedLength = clippedEnd - clippedStart;
   const lengthRatio = Math.min(1, clippedLength / originalLength);
+  const clippedAscent = climb.totalAscentMeters * lengthRatio;
+  const clippedAverageGradient = (clippedAscent / clippedLength) * 100;
+  const clippedDifficultyScore = climb.difficultyScore * lengthRatio;
 
   const effectiveStartDistanceMeters = toDisplayDistanceMeters(
     clippedStart + span.distanceOffsetMeters,
@@ -95,7 +98,9 @@ export function toDisplayClimbForSpan(climb: Climb, span: StitchedSourceSpan): D
     startDistanceMeters: clippedStart,
     endDistanceMeters: clippedEnd,
     lengthMeters: clippedLength,
-    totalAscentMeters: climb.totalAscentMeters * lengthRatio,
+    totalAscentMeters: Math.round(clippedAscent * 10) / 10,
+    averageGradientPercent: Math.round(clippedAverageGradient * 10) / 10,
+    difficultyScore: Math.round(clippedDifficultyScore * 10) / 10,
     effectiveDistanceMeters: effectiveStartDistanceMeters,
     effectiveStartDistanceMeters,
     effectiveEndDistanceMeters,

--- a/services/stitchingService.ts
+++ b/services/stitchingService.ts
@@ -1,11 +1,241 @@
 import { getRouteWithPoints, getCollectionSegments } from "@/db/database";
-import { toDisplayPOI } from "@/services/displayDistance";
+import {
+  findSourceSpanForDistance,
+  toDisplayDistanceMeters,
+  toDisplayPOI,
+} from "@/services/displayDistance";
 import { isDistanceInWindow, type DistanceWindow } from "@/utils/ridingHorizon";
-import type { StitchedCollection, StitchedSegmentInfo, RoutePoint, POI, DisplayPOI } from "@/types";
+import {
+  computeSliceAscentFromDistance,
+  computeSliceDescentFromDistance,
+  findRouteSegmentCandidates,
+  interpolateRoutePointAtDistance,
+} from "@/utils/geo";
+import type {
+  StitchedCollection,
+  StitchedSegmentInfo,
+  StitchedSourceSpan,
+  StitchedSourceSpanKind,
+  RoutePoint,
+  RouteWithPoints,
+  POI,
+  DisplayPOI,
+  CollectionSegment,
+} from "@/types";
 
 interface StitchCollectionOptions {
   /** Keep raw per-segment point arrays in the returned view model. */
   includePointsByRouteId?: boolean;
+}
+
+export interface PatchVariantProposal {
+  baseRouteId: string;
+  patchRouteId: string;
+  replaceStartDistanceMeters: number;
+  replaceEndDistanceMeters: number;
+  startEndpointDistanceMeters: number;
+  endEndpointDistanceMeters: number;
+  isReversed: boolean;
+}
+
+const PATCH_ENDPOINT_WARNING_M = 5_000;
+
+export function routeEndDistance(points: RoutePoint[]): number {
+  return points[points.length - 1]?.distanceFromStartMeters ?? 0;
+}
+
+function clampDistance(points: RoutePoint[], distanceMeters: number): number {
+  return Math.max(0, Math.min(routeEndDistance(points), distanceMeters));
+}
+
+function pointFromInterpolated(
+  point: NonNullable<ReturnType<typeof interpolateRoutePointAtDistance>>,
+): RoutePoint {
+  return {
+    latitude: point.latitude,
+    longitude: point.longitude,
+    elevationMeters: point.elevationMeters,
+    distanceFromStartMeters: point.distanceFromStartMeters,
+    idx: point.nearestIndex,
+  };
+}
+
+export function sliceRoutePointsByDistance(
+  points: RoutePoint[],
+  startDistanceMeters: number,
+  endDistanceMeters: number,
+): RoutePoint[] {
+  if (points.length === 0) return [];
+  const start = clampDistance(points, startDistanceMeters);
+  const end = clampDistance(points, endDistanceMeters);
+  if (end < start) return [];
+
+  const startPoint = interpolateRoutePointAtDistance(points, start);
+  const endPoint = interpolateRoutePointAtDistance(points, end);
+  if (!startPoint || !endPoint) return [];
+
+  const out = [pointFromInterpolated(startPoint)];
+  for (const point of points) {
+    if (point.distanceFromStartMeters > start && point.distanceFromStartMeters < end) {
+      out.push(point);
+    }
+  }
+  if (end > start) out.push(pointFromInterpolated(endPoint));
+  return out;
+}
+
+function appendRebasedRoutePoints(
+  out: RoutePoint[],
+  points: RoutePoint[],
+  rawStartDistanceMeters: number,
+  effectiveStartDistanceMeters: number,
+) {
+  const offset = effectiveStartDistanceMeters - rawStartDistanceMeters;
+  for (const point of points) {
+    const effectiveDistance = point.distanceFromStartMeters + offset;
+    const prev = out[out.length - 1];
+    if (prev && Math.abs(prev.distanceFromStartMeters - effectiveDistance) < 0.001) continue;
+    out.push({
+      ...point,
+      idx: out.length,
+      distanceFromStartMeters: effectiveDistance,
+    });
+  }
+}
+
+export function buildPatchVariantRoutePoints(
+  basePoints: RoutePoint[],
+  patchPoints: RoutePoint[],
+  replaceStartDistanceMeters: number,
+  replaceEndDistanceMeters: number,
+): RoutePoint[] {
+  if (basePoints.length < 2 || patchPoints.length < 2) return [];
+
+  const out: RoutePoint[] = [];
+  const baseEnd = routeEndDistance(basePoints);
+  const patchEnd = routeEndDistance(patchPoints);
+  const basePrefix = sliceRoutePointsByDistance(basePoints, 0, replaceStartDistanceMeters);
+  const baseSuffix = sliceRoutePointsByDistance(basePoints, replaceEndDistanceMeters, baseEnd);
+
+  appendRebasedRoutePoints(out, basePrefix, 0, 0);
+  appendRebasedRoutePoints(out, patchPoints, 0, replaceStartDistanceMeters);
+  appendRebasedRoutePoints(
+    out,
+    baseSuffix,
+    replaceEndDistanceMeters,
+    replaceStartDistanceMeters + patchEnd,
+  );
+  return out;
+}
+
+interface AppendRouteSliceOptions {
+  route: RouteWithPoints;
+  position: number;
+  kind: StitchedSourceSpanKind;
+  rawStartDistanceMeters: number;
+  rawEndDistanceMeters: number;
+  effectiveStartDistanceMeters: number;
+  stitchedPoints: RoutePoint[];
+  globalIndex: number;
+}
+
+function appendRouteSlice({
+  route,
+  position,
+  kind,
+  rawStartDistanceMeters,
+  rawEndDistanceMeters,
+  effectiveStartDistanceMeters,
+  stitchedPoints,
+  globalIndex,
+}: AppendRouteSliceOptions): {
+  span: StitchedSourceSpan | null;
+  globalIndex: number;
+  distanceMeters: number;
+  ascentMeters: number;
+  descentMeters: number;
+} {
+  const rawStart = clampDistance(route.points, rawStartDistanceMeters);
+  const rawEnd = clampDistance(route.points, rawEndDistanceMeters);
+  if (rawEnd <= rawStart) {
+    return { span: null, globalIndex, distanceMeters: 0, ascentMeters: 0, descentMeters: 0 };
+  }
+
+  const rawSlice = sliceRoutePointsByDistance(route.points, rawStart, rawEnd);
+  if (rawSlice.length === 0) {
+    return { span: null, globalIndex, distanceMeters: 0, ascentMeters: 0, descentMeters: 0 };
+  }
+
+  const startPointIndex = globalIndex;
+  const offset = effectiveStartDistanceMeters - rawStart;
+  for (const pt of rawSlice) {
+    stitchedPoints.push({
+      latitude: pt.latitude,
+      longitude: pt.longitude,
+      elevationMeters: pt.elevationMeters,
+      distanceFromStartMeters: pt.distanceFromStartMeters + offset,
+      idx: globalIndex,
+    });
+    globalIndex++;
+  }
+
+  const effectiveEnd = rawEnd + offset;
+  const isWholeRoute = rawStart === 0 && rawEnd === route.totalDistanceMeters;
+  const ascentMeters = isWholeRoute
+    ? route.totalAscentMeters
+    : computeSliceAscentFromDistance(route.points, rawStart, rawEnd);
+  const descentMeters = isWholeRoute
+    ? route.totalDescentMeters
+    : computeSliceDescentFromDistance(route.points, rawStart, rawEnd);
+
+  return {
+    span: {
+      routeId: route.id,
+      routeName: route.name,
+      position,
+      kind,
+      startPointIndex,
+      endPointIndex: globalIndex - 1,
+      rawStartDistanceMeters: rawStart,
+      rawEndDistanceMeters: rawEnd,
+      effectiveStartDistanceMeters: toDisplayDistanceMeters(effectiveStartDistanceMeters),
+      effectiveEndDistanceMeters: toDisplayDistanceMeters(effectiveEnd),
+      distanceOffsetMeters: offset,
+    },
+    globalIndex,
+    distanceMeters: rawEnd - rawStart,
+    ascentMeters,
+    descentMeters,
+  };
+}
+
+function buildFallbackSegmentInfo(
+  segment: CollectionSegment,
+  route: RouteWithPoints,
+  startPointIndex: number,
+  endPointIndex: number,
+  distanceOffsetMeters: number,
+  sourceSpans: StitchedSourceSpan[],
+  segmentDistanceMeters: number,
+  segmentAscentMeters: number,
+  segmentDescentMeters: number,
+): StitchedSegmentInfo {
+  return {
+    routeId: route.id,
+    routeName: route.name,
+    position: segment.position,
+    variantKind: segment.variantKind,
+    baseRouteId: segment.baseRouteId,
+    replaceStartDistanceMeters: segment.replaceStartDistanceMeters,
+    replaceEndDistanceMeters: segment.replaceEndDistanceMeters,
+    startPointIndex,
+    endPointIndex,
+    distanceOffsetMeters,
+    segmentDistanceMeters,
+    segmentAscentMeters,
+    segmentDescentMeters,
+    sourceSpans,
+  };
 }
 
 export async function stitchCollection(
@@ -18,6 +248,7 @@ export async function stitchCollection(
 
   const stitchedPoints: RoutePoint[] = [];
   const segmentInfos: StitchedSegmentInfo[] = [];
+  const sourceSpans: StitchedSourceSpan[] = [];
   const pointsByRouteId: Record<string, RoutePoint[]> = {};
   let cumulativeDistance = 0;
   let globalIndex = 0;
@@ -25,43 +256,118 @@ export async function stitchCollection(
   let totalDescent = 0;
 
   for (let i = 0; i < selected.length; i++) {
-    const route = await getRouteWithPoints(selected[i].routeId);
+    const segment = selected[i];
+    const route = await getRouteWithPoints(segment.routeId);
     if (!route) continue;
 
-    const points = route.points;
     if (options.includePointsByRouteId ?? true) {
-      pointsByRouteId[route.id] = points;
+      pointsByRouteId[route.id] = route.points;
     }
     const startPointIndex = globalIndex;
+    const segmentOffset = cumulativeDistance;
+    const segmentSourceSpans: StitchedSourceSpan[] = [];
+    let segmentDistance = 0;
+    let segmentAscent = 0;
+    let segmentDescent = 0;
 
-    for (const pt of points) {
-      stitchedPoints.push({
-        latitude: pt.latitude,
-        longitude: pt.longitude,
-        elevationMeters: pt.elevationMeters,
-        distanceFromStartMeters: pt.distanceFromStartMeters + cumulativeDistance,
-        idx: globalIndex,
+    if (
+      segment.variantKind === "patch" &&
+      segment.baseRouteId &&
+      segment.replaceStartDistanceMeters != null &&
+      segment.replaceEndDistanceMeters != null
+    ) {
+      const baseRouteId = segment.baseRouteId;
+      const replaceStart = segment.replaceStartDistanceMeters;
+      const replaceEnd = segment.replaceEndDistanceMeters;
+      const baseRoute = await getRouteWithPoints(baseRouteId);
+      if (baseRoute) {
+        if (options.includePointsByRouteId ?? true) {
+          pointsByRouteId[baseRoute.id] = baseRoute.points;
+        }
+        const pieces = [
+          {
+            route: baseRoute,
+            kind: "base-prefix" as const,
+            rawStartDistanceMeters: 0,
+            rawEndDistanceMeters: replaceStart,
+            effectiveStartDistanceMeters: cumulativeDistance,
+          },
+          {
+            route,
+            kind: "patch" as const,
+            rawStartDistanceMeters: 0,
+            rawEndDistanceMeters: route.totalDistanceMeters,
+            effectiveStartDistanceMeters: cumulativeDistance + replaceStart,
+          },
+          {
+            route: baseRoute,
+            kind: "base-suffix" as const,
+            rawStartDistanceMeters: replaceEnd,
+            rawEndDistanceMeters: baseRoute.totalDistanceMeters,
+            effectiveStartDistanceMeters:
+              cumulativeDistance + replaceStart + route.totalDistanceMeters,
+          },
+        ];
+
+        for (const piece of pieces) {
+          const result = appendRouteSlice({
+            ...piece,
+            position: segment.position,
+            stitchedPoints,
+            globalIndex,
+          });
+          globalIndex = result.globalIndex;
+          if (result.span) {
+            segmentSourceSpans.push(result.span);
+            sourceSpans.push(result.span);
+          }
+          segmentDistance += result.distanceMeters;
+          segmentAscent += result.ascentMeters;
+          segmentDescent += result.descentMeters;
+        }
+      }
+    }
+
+    if (segmentSourceSpans.length === 0) {
+      const result = appendRouteSlice({
+        route,
+        position: segment.position,
+        kind: "full",
+        rawStartDistanceMeters: 0,
+        rawEndDistanceMeters: route.totalDistanceMeters,
+        effectiveStartDistanceMeters: cumulativeDistance,
+        stitchedPoints,
+        globalIndex,
       });
-      globalIndex++;
+      globalIndex = result.globalIndex;
+      if (result.span) {
+        segmentSourceSpans.push(result.span);
+        sourceSpans.push(result.span);
+      }
+      segmentDistance = result.distanceMeters;
+      segmentAscent = result.ascentMeters;
+      segmentDescent = result.descentMeters;
     }
 
     const endPointIndex = globalIndex - 1;
 
-    segmentInfos.push({
-      routeId: route.id,
-      routeName: route.name,
-      position: selected[i].position,
-      startPointIndex,
-      endPointIndex,
-      distanceOffsetMeters: cumulativeDistance,
-      segmentDistanceMeters: route.totalDistanceMeters,
-      segmentAscentMeters: route.totalAscentMeters,
-      segmentDescentMeters: route.totalDescentMeters,
-    });
+    segmentInfos.push(
+      buildFallbackSegmentInfo(
+        segment,
+        route,
+        startPointIndex,
+        endPointIndex,
+        segmentOffset,
+        segmentSourceSpans,
+        segmentDistance,
+        segmentAscent,
+        segmentDescent,
+      ),
+    );
 
-    cumulativeDistance += route.totalDistanceMeters;
-    totalAscent += route.totalAscentMeters;
-    totalDescent += route.totalDescentMeters;
+    cumulativeDistance += segmentDistance;
+    totalAscent += segmentAscent;
+    totalDescent += segmentDescent;
   }
 
   return {
@@ -72,6 +378,7 @@ export async function stitchCollection(
     totalAscentMeters: totalAscent,
     totalDescentMeters: totalDescent,
     pointsByRouteId,
+    sourceSpans,
   };
 }
 
@@ -81,18 +388,84 @@ export function stitchPOIs(
   window?: DistanceWindow,
 ): DisplayPOI[] {
   const combined: DisplayPOI[] = [];
+  const sourceSpans = segments.flatMap((seg) => seg.sourceSpans);
 
-  for (const seg of segments) {
-    const pois = poisByRoute[seg.routeId];
+  for (const span of sourceSpans) {
+    const pois = poisByRoute[span.routeId];
     if (!pois) continue;
 
     for (const poi of pois) {
-      const effectiveDistanceMeters = poi.distanceAlongRouteMeters + seg.distanceOffsetMeters;
+      const sourceSpan = findSourceSpanForDistance(
+        [span],
+        poi.routeId,
+        poi.distanceAlongRouteMeters,
+      );
+      if (!sourceSpan) continue;
+      const effectiveDistanceMeters =
+        poi.distanceAlongRouteMeters + sourceSpan.distanceOffsetMeters;
       if (!isDistanceInWindow(effectiveDistanceMeters, window)) continue;
-      combined.push(toDisplayPOI(poi, seg.distanceOffsetMeters));
+      combined.push(toDisplayPOI(poi, sourceSpan.distanceOffsetMeters));
     }
   }
 
   combined.sort((a, b) => a.effectiveDistanceMeters - b.effectiveDistanceMeters);
   return combined;
+}
+
+export function proposePatchVariantFromPoints(
+  baseRouteId: string,
+  patchRouteId: string,
+  basePoints: RoutePoint[],
+  patchPoints: RoutePoint[],
+): PatchVariantProposal | null {
+  if (basePoints.length < 2 || patchPoints.length < 2) return null;
+  const patchStart = patchPoints[0];
+  const patchEnd = patchPoints[patchPoints.length - 1];
+  const start = findRouteSegmentCandidates(patchStart.latitude, patchStart.longitude, basePoints, {
+    maxCandidates: 1,
+  })[0];
+  const end = findRouteSegmentCandidates(patchEnd.latitude, patchEnd.longitude, basePoints, {
+    maxCandidates: 1,
+  })[0];
+  if (!start || !end) return null;
+
+  const isReversed = start.distanceAlongRouteMeters > end.distanceAlongRouteMeters;
+  const replaceStartDistanceMeters = Math.min(
+    start.distanceAlongRouteMeters,
+    end.distanceAlongRouteMeters,
+  );
+  const replaceEndDistanceMeters = Math.max(
+    start.distanceAlongRouteMeters,
+    end.distanceAlongRouteMeters,
+  );
+
+  if (replaceEndDistanceMeters <= replaceStartDistanceMeters) return null;
+
+  return {
+    baseRouteId,
+    patchRouteId,
+    replaceStartDistanceMeters,
+    replaceEndDistanceMeters,
+    startEndpointDistanceMeters: start.distanceMeters,
+    endEndpointDistanceMeters: end.distanceMeters,
+    isReversed,
+  };
+}
+
+export function isPatchVariantProposalPoorMatch(proposal: PatchVariantProposal): boolean {
+  return (
+    proposal.isReversed ||
+    proposal.startEndpointDistanceMeters > PATCH_ENDPOINT_WARNING_M ||
+    proposal.endEndpointDistanceMeters > PATCH_ENDPOINT_WARNING_M
+  );
+}
+
+export function getStitchedSourceRouteIds(segments: StitchedSegmentInfo[]): string[] {
+  const ids = new Set<string>();
+  for (const segment of segments) {
+    for (const span of segment.sourceSpans) {
+      ids.add(span.routeId);
+    }
+  }
+  return [...ids];
 }

--- a/store/climbStore.ts
+++ b/store/climbStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import type { Climb, ClimbDifficulty, DisplayClimb, StitchedSegmentInfo } from "@/types";
 import { getClimbsForRoute, updateClimbName } from "@/db/database";
 import { MIN_GAIN_M } from "@/services/climbDetector";
-import { toDisplayClimb, toDisplayClimbs } from "@/services/displayDistance";
+import { toDisplayClimbForSpan, toDisplayClimbs } from "@/services/displayDistance";
 
 interface ClimbState {
   // Climb data per route
@@ -99,10 +99,13 @@ export const useClimbStore = create<ClimbState>((set, get) => ({
     if (segments && segments.length > 0) {
       const combined: DisplayClimb[] = [];
       for (const seg of segments) {
-        const routeClimbs = state.climbs[seg.routeId];
-        if (!routeClimbs) continue;
-        for (const c of routeClimbs) {
-          combined.push(toDisplayClimb(c, seg.distanceOffsetMeters));
+        for (const span of seg.sourceSpans) {
+          const routeClimbs = state.climbs[span.routeId];
+          if (!routeClimbs) continue;
+          for (const c of routeClimbs) {
+            const displayClimb = toDisplayClimbForSpan(c, span);
+            if (displayClimb) combined.push(displayClimb);
+          }
         }
       }
       combined.sort((a, b) => a.effectiveStartDistanceMeters - b.effectiveStartDistanceMeters);

--- a/store/collectionStore.ts
+++ b/store/collectionStore.ts
@@ -8,6 +8,7 @@ import {
   setActiveCollection as dbSetActiveCollection,
   insertCollectionSegment,
   deleteCollectionSegment as dbDeleteCollectionSegment,
+  deletePatchVariantsForBaseRoute,
   getCollectionSegments,
   selectVariant as dbSelectVariant,
   updateSegmentPositions as dbUpdateSegmentPositions,
@@ -47,6 +48,14 @@ interface CollectionState {
   updateCollectionPlannedStart: (id: string, plannedStartMs: number | null) => Promise<void>;
 
   addSegment: (collectionId: string, routeId: string) => Promise<void>;
+  addPatchVariant: (
+    collectionId: string,
+    routeId: string,
+    baseRouteId: string,
+    position: number,
+    replaceStartDistanceMeters: number,
+    replaceEndDistanceMeters: number,
+  ) => Promise<void>;
   removeSegment: (collectionId: string, routeId: string) => Promise<void>;
   selectVariant: (collectionId: string, routeId: string) => Promise<void>;
 
@@ -61,7 +70,12 @@ function fingerprintSegments(collectionId: string, segments: CollectionSegment[]
     .filter((s) => s.isSelected)
     .slice()
     .sort((a, b) => a.position - b.position)
-    .map((s) => `${s.position}:${s.routeId}`)
+    .map(
+      (s) =>
+        `${s.position}:${s.routeId}:${s.variantKind}:${s.baseRouteId ?? ""}:${
+          s.replaceStartDistanceMeters ?? ""
+        }:${s.replaceEndDistanceMeters ?? ""}`,
+    )
     .join(",");
   return `${collectionId}|${selected}`;
 }
@@ -182,6 +196,10 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
         routeId,
         position: matchedPosition,
         isSelected: false,
+        variantKind: "full",
+        baseRouteId: null,
+        replaceStartDistanceMeters: null,
+        replaceEndDistanceMeters: null,
       });
     } else {
       // Add as new position at the end
@@ -191,6 +209,10 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
         routeId,
         position: maxPos + 1,
         isSelected: true,
+        variantKind: "full",
+        baseRouteId: null,
+        replaceStartDistanceMeters: null,
+        replaceEndDistanceMeters: null,
       });
       if (get().activeStitchedCollection?.collectionId === collectionId) {
         await get().loadStitchedCollection(collectionId);
@@ -200,8 +222,33 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
     set({ assignedRouteIds: new Set([...get().assignedRouteIds, routeId]) });
   },
 
+  addPatchVariant: async (
+    collectionId,
+    routeId,
+    baseRouteId,
+    position,
+    replaceStartDistanceMeters,
+    replaceEndDistanceMeters,
+  ) => {
+    await insertCollectionSegment({
+      collectionId,
+      routeId,
+      position,
+      isSelected: false,
+      variantKind: "patch",
+      baseRouteId,
+      replaceStartDistanceMeters,
+      replaceEndDistanceMeters,
+    });
+    if (get().activeStitchedCollection?.collectionId === collectionId) {
+      await get().loadStitchedCollection(collectionId);
+    }
+    set({ assignedRouteIds: new Set([...get().assignedRouteIds, routeId, baseRouteId]) });
+  },
+
   removeSegment: async (collectionId, routeId) => {
     await dbDeleteCollectionSegment(collectionId, routeId);
+    await deletePatchVariantsForBaseRoute(collectionId, routeId);
     // Normalize positions: get remaining segments, re-number
     const segments = await getCollectionSegments(collectionId);
     const positions = [...new Set(segments.map((s) => s.position))].sort((a, b) => a - b);
@@ -246,8 +293,12 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
     await dbSetActiveCollection(id);
     // Make all selected segment routes visible in a single query
     const segments = await getCollectionSegments(id);
-    const selectedRouteIds = segments.filter((s) => s.isSelected).map((s) => s.routeId);
-    await setRoutesVisible(selectedRouteIds);
+    const selectedRouteIds = new Set<string>();
+    for (const segment of segments.filter((s) => s.isSelected)) {
+      selectedRouteIds.add(segment.routeId);
+      if (segment.baseRouteId) selectedRouteIds.add(segment.baseRouteId);
+    }
+    await setRoutesVisible([...selectedRouteIds]);
     // Reload route store to clear route isActive flags and pick up visibility changes
     const { useRouteStore } = await import("@/store/routeStore");
     const routeStore = useRouteStore.getState();
@@ -284,11 +335,14 @@ export const useCollectionStore = create<CollectionState>((set, get) => ({
   getCollectionSegmentsWithRoutes: async (id) => {
     const segments = await getCollectionSegments(id);
     const routes = await Promise.all(segments.map((s) => getRoute(s.routeId)));
+    const baseRoutes = await Promise.all(
+      segments.map((s) => (s.baseRouteId ? getRoute(s.baseRouteId) : Promise.resolve(null))),
+    );
     const results: CollectionSegmentWithRoute[] = [];
     for (let i = 0; i < segments.length; i++) {
       const route = routes[i];
       if (route) {
-        results.push({ segment: segments[i], route });
+        results.push({ segment: segments[i], route, baseRoute: baseRoutes[i] });
       }
     }
     return results;

--- a/tests/fixtures/collection.ts
+++ b/tests/fixtures/collection.ts
@@ -1,27 +1,68 @@
-import type { RoutePoint, StitchedCollection, StitchedSegmentInfo } from "@/types";
+import { toDisplayDistanceMeters } from "@/services/displayDistance";
+import type {
+  RoutePoint,
+  StitchedCollection,
+  StitchedSegmentInfo,
+  StitchedSourceSpan,
+} from "@/types";
+
+const sourceSpan = (
+  routeId: string,
+  routeName: string,
+  position: number,
+  startPointIndex: number,
+  endPointIndex: number,
+  rawStartDistanceMeters: number,
+  rawEndDistanceMeters: number,
+  distanceOffsetMeters: number,
+): StitchedSourceSpan => ({
+  routeId,
+  routeName,
+  position,
+  kind: "full",
+  startPointIndex,
+  endPointIndex,
+  rawStartDistanceMeters,
+  rawEndDistanceMeters,
+  effectiveStartDistanceMeters: toDisplayDistanceMeters(
+    rawStartDistanceMeters + distanceOffsetMeters,
+  ),
+  effectiveEndDistanceMeters: toDisplayDistanceMeters(rawEndDistanceMeters + distanceOffsetMeters),
+  distanceOffsetMeters,
+});
 
 export const stitchedSegmentsFixture: StitchedSegmentInfo[] = [
   {
     routeId: "r1",
     routeName: "r1",
     position: 0,
+    variantKind: "full",
+    baseRouteId: null,
+    replaceStartDistanceMeters: null,
+    replaceEndDistanceMeters: null,
     startPointIndex: 0,
     endPointIndex: 1,
     distanceOffsetMeters: 0,
     segmentDistanceMeters: 1_000,
     segmentAscentMeters: 100,
     segmentDescentMeters: 0,
+    sourceSpans: [sourceSpan("r1", "r1", 0, 0, 1, 0, 1_000, 0)],
   },
   {
     routeId: "r2",
     routeName: "r2",
     position: 1,
+    variantKind: "full",
+    baseRouteId: null,
+    replaceStartDistanceMeters: null,
+    replaceEndDistanceMeters: null,
     startPointIndex: 2,
     endPointIndex: 3,
     distanceOffsetMeters: 1_000,
     segmentDistanceMeters: 2_000,
     segmentAscentMeters: 200,
     segmentDescentMeters: 100,
+    sourceSpans: [sourceSpan("r2", "r2", 1, 2, 3, 0, 2_000, 1_000)],
   },
 ];
 
@@ -33,6 +74,7 @@ interface BuildStitchedCollectionOptions {
   totalAscentMeters?: number;
   totalDescentMeters?: number;
   pointsByRouteId?: Record<string, RoutePoint[]>;
+  sourceSpans?: StitchedSourceSpan[];
 }
 
 export function buildStitchedCollection({
@@ -43,6 +85,7 @@ export function buildStitchedCollection({
   totalAscentMeters = 300,
   totalDescentMeters = 100,
   pointsByRouteId = {},
+  sourceSpans = segments.flatMap((segment) => segment.sourceSpans),
 }: BuildStitchedCollectionOptions): StitchedCollection {
   return {
     collectionId,
@@ -52,5 +95,6 @@ export function buildStitchedCollection({
     totalAscentMeters,
     totalDescentMeters,
     pointsByRouteId,
+    sourceSpans,
   };
 }

--- a/tests/mocks/database.ts
+++ b/tests/mocks/database.ts
@@ -3,67 +3,112 @@ import type {
   deletePOIsBySource,
   deletePOI,
   deletePOIsForRoute,
+  deletePatchVariantsForBaseRoute,
   deleteRoute,
   getAllRoutes,
+  getAllCollections,
+  getAllAssignedRouteIds,
   getClimbsForRoute,
   getCollectionSegments,
   getPOICountsBySource,
   getPOIsForRoute,
   getStarredItems,
   getRoute,
+  getRouteEndpoints,
   getRoutePoints,
   getRouteWithPoints,
+  insertCollectionSegment,
+  insertCollection,
   insertPOIs,
   insertRoute,
   setActiveRoute,
+  setRoutesVisible,
+  setActiveCollection,
   setStarredItem,
   updateClimbName,
   updatePOITags,
   updateRouteVisibility,
+  updateSegmentPositions,
+  renameCollection,
+  deleteCollection,
+  updateCollectionPlannedStart,
+  getMaxSegmentPosition,
+  selectVariant,
+  deleteCollectionSegment,
 } from "@/db/database";
 
 export const databaseMocks = {
   deletePOI: vi.fn<typeof deletePOI>(),
   deletePOIsBySource: vi.fn<typeof deletePOIsBySource>(),
   deletePOIsForRoute: vi.fn<typeof deletePOIsForRoute>(),
+  deletePatchVariantsForBaseRoute: vi.fn<typeof deletePatchVariantsForBaseRoute>(),
   deleteRoute: vi.fn<typeof deleteRoute>(),
+  deleteCollection: vi.fn<typeof deleteCollection>(),
+  deleteCollectionSegment: vi.fn<typeof deleteCollectionSegment>(),
   getAllRoutes: vi.fn<typeof getAllRoutes>(),
+  getAllCollections: vi.fn<typeof getAllCollections>(),
+  getAllAssignedRouteIds: vi.fn<typeof getAllAssignedRouteIds>(),
   getClimbsForRoute: vi.fn<typeof getClimbsForRoute>(),
   getCollectionSegments: vi.fn<typeof getCollectionSegments>(),
   getPOICountsBySource: vi.fn<typeof getPOICountsBySource>(),
   getPOIsForRoute: vi.fn<typeof getPOIsForRoute>(),
   getStarredItems: vi.fn<typeof getStarredItems>(),
   getRoute: vi.fn<typeof getRoute>(),
+  getRouteEndpoints: vi.fn<typeof getRouteEndpoints>(),
   getRoutePoints: vi.fn<typeof getRoutePoints>(),
   getRouteWithPoints: vi.fn<typeof getRouteWithPoints>(),
+  getMaxSegmentPosition: vi.fn<typeof getMaxSegmentPosition>(),
+  insertCollection: vi.fn<typeof insertCollection>(),
+  insertCollectionSegment: vi.fn<typeof insertCollectionSegment>(),
   insertPOIs: vi.fn<typeof insertPOIs>(),
   insertRoute: vi.fn<typeof insertRoute>(),
   setActiveRoute: vi.fn<typeof setActiveRoute>(),
+  setActiveCollection: vi.fn<typeof setActiveCollection>(),
+  setRoutesVisible: vi.fn<typeof setRoutesVisible>(),
   setStarredItem: vi.fn<typeof setStarredItem>(),
   updateClimbName: vi.fn<typeof updateClimbName>(),
   updatePOITags: vi.fn<typeof updatePOITags>(),
   updateRouteVisibility: vi.fn<typeof updateRouteVisibility>(),
+  updateSegmentPositions: vi.fn<typeof updateSegmentPositions>(),
+  updateCollectionPlannedStart: vi.fn<typeof updateCollectionPlannedStart>(),
+  renameCollection: vi.fn<typeof renameCollection>(),
+  selectVariant: vi.fn<typeof selectVariant>(),
 };
 
 export function resetDatabaseMocks(): void {
   databaseMocks.deletePOI.mockResolvedValue(undefined);
   databaseMocks.deletePOIsBySource.mockResolvedValue(undefined);
   databaseMocks.deletePOIsForRoute.mockResolvedValue(undefined);
+  databaseMocks.deletePatchVariantsForBaseRoute.mockResolvedValue(undefined);
   databaseMocks.deleteRoute.mockResolvedValue(undefined);
+  databaseMocks.deleteCollection.mockResolvedValue(undefined);
+  databaseMocks.deleteCollectionSegment.mockResolvedValue(undefined);
   databaseMocks.getAllRoutes.mockResolvedValue([]);
+  databaseMocks.getAllCollections.mockResolvedValue([]);
+  databaseMocks.getAllAssignedRouteIds.mockResolvedValue(new Set());
   databaseMocks.getClimbsForRoute.mockResolvedValue([]);
   databaseMocks.getCollectionSegments.mockResolvedValue([]);
   databaseMocks.getPOICountsBySource.mockResolvedValue({ osm: 0, google: 0 });
   databaseMocks.getPOIsForRoute.mockResolvedValue([]);
   databaseMocks.getStarredItems.mockResolvedValue([]);
   databaseMocks.getRoute.mockResolvedValue(null);
+  databaseMocks.getRouteEndpoints.mockResolvedValue(null);
   databaseMocks.getRoutePoints.mockResolvedValue([]);
   databaseMocks.getRouteWithPoints.mockResolvedValue(null);
+  databaseMocks.getMaxSegmentPosition.mockResolvedValue(-1);
+  databaseMocks.insertCollection.mockResolvedValue(undefined);
+  databaseMocks.insertCollectionSegment.mockResolvedValue(undefined);
   databaseMocks.insertPOIs.mockResolvedValue(undefined);
   databaseMocks.insertRoute.mockResolvedValue(undefined);
   databaseMocks.setActiveRoute.mockResolvedValue(undefined);
+  databaseMocks.setActiveCollection.mockResolvedValue(undefined);
+  databaseMocks.setRoutesVisible.mockResolvedValue(undefined);
   databaseMocks.setStarredItem.mockResolvedValue(undefined);
   databaseMocks.updateClimbName.mockResolvedValue(undefined);
   databaseMocks.updatePOITags.mockResolvedValue(undefined);
   databaseMocks.updateRouteVisibility.mockResolvedValue(undefined);
+  databaseMocks.updateSegmentPositions.mockResolvedValue(undefined);
+  databaseMocks.updateCollectionPlannedStart.mockResolvedValue(undefined);
+  databaseMocks.renameCollection.mockResolvedValue(undefined);
+  databaseMocks.selectVariant.mockResolvedValue(undefined);
 }

--- a/tests/services/displayDistance.test.ts
+++ b/tests/services/displayDistance.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { toDisplayClimb, toDisplayPOI, toDisplayPOIForSegments } from "@/services/displayDistance";
+import {
+  toDisplayClimb,
+  toDisplayDistanceMeters,
+  toDisplayPOI,
+  toDisplayPOIForSegments,
+} from "@/services/displayDistance";
 import type { Climb, POI, StitchedSegmentInfo } from "@/types";
 
 const poi = (distanceAlongRouteMeters: number): POI => ({
@@ -35,12 +40,31 @@ const segment = (routeId: string, distanceOffsetMeters: number): StitchedSegment
   routeId,
   routeName: routeId,
   position: 0,
+  variantKind: "full",
+  baseRouteId: null,
+  replaceStartDistanceMeters: null,
+  replaceEndDistanceMeters: null,
   startPointIndex: 0,
   endPointIndex: 1,
   distanceOffsetMeters,
   segmentDistanceMeters: 1_000,
   segmentAscentMeters: 10,
   segmentDescentMeters: 10,
+  sourceSpans: [
+    {
+      routeId,
+      routeName: routeId,
+      position: 0,
+      kind: "full",
+      startPointIndex: 0,
+      endPointIndex: 1,
+      rawStartDistanceMeters: 0,
+      rawEndDistanceMeters: 1_000,
+      effectiveStartDistanceMeters: toDisplayDistanceMeters(distanceOffsetMeters),
+      effectiveEndDistanceMeters: toDisplayDistanceMeters(distanceOffsetMeters + 1_000),
+      distanceOffsetMeters,
+    },
+  ],
 });
 
 describe("displayDistance", () => {

--- a/tests/services/displayDistance.test.ts
+++ b/tests/services/displayDistance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   toDisplayClimb,
+  toDisplayClimbForSpan,
   toDisplayDistanceMeters,
   toDisplayPOI,
   toDisplayPOIForSegments,
@@ -97,5 +98,26 @@ describe("displayDistance", () => {
     const displayed = toDisplayPOIForSegments(poi(50), [segment("other-route", 1_000)]);
 
     expect(displayed).toBeNull();
+  });
+
+  it("recomputes clipped climb metrics for a source span", () => {
+    const displayed = toDisplayClimbForSpan(
+      {
+        ...climb(100, 1_100),
+        totalAscentMeters: 100,
+        averageGradientPercent: 10,
+        difficultyScore: 200,
+      },
+      segment("route-1", 2_000).sourceSpans[0],
+    );
+
+    expect(displayed?.startDistanceMeters).toBe(100);
+    expect(displayed?.endDistanceMeters).toBe(1_000);
+    expect(displayed?.lengthMeters).toBe(900);
+    expect(displayed?.totalAscentMeters).toBe(90);
+    expect(displayed?.averageGradientPercent).toBe(10);
+    expect(displayed?.difficultyScore).toBe(180);
+    expect(displayed?.effectiveStartDistanceMeters).toBe(2_100);
+    expect(displayed?.effectiveEndDistanceMeters).toBe(3_000);
   });
 });

--- a/tests/services/stitchingService.test.ts
+++ b/tests/services/stitchingService.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { stitchCollection, stitchPOIs } from "@/services/stitchingService";
+import {
+  proposePatchVariantFromPoints,
+  stitchCollection,
+  stitchPOIs,
+} from "@/services/stitchingService";
+import { toDisplayDistanceMeters } from "@/services/displayDistance";
 import { databaseMocks } from "@/tests/mocks/database";
-import type { POI, RouteWithPoints } from "@/types";
+import type {
+  CollectionSegment,
+  POI,
+  RoutePoint,
+  RouteWithPoints,
+  StitchedSegmentInfo,
+} from "@/types";
 
 const poi = (id: string, routeId: string, distanceAlongRouteMeters: number): POI => ({
   id,
@@ -47,12 +58,94 @@ const route = (id: string, distanceOffset = 0): RouteWithPoints => ({
   ],
 });
 
+const routeFromPoints = (id: string, points: RoutePoint[]): RouteWithPoints => ({
+  id,
+  name: id,
+  fileName: `${id}.gpx`,
+  color: "#fff",
+  isActive: false,
+  isVisible: true,
+  totalDistanceMeters: points[points.length - 1]?.distanceFromStartMeters ?? 0,
+  totalAscentMeters: 0,
+  totalDescentMeters: 0,
+  pointCount: points.length,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  points,
+});
+
+const routePoint = (
+  idx: number,
+  distanceFromStartMeters: number,
+  longitude: number,
+): RoutePoint => ({
+  latitude: 0,
+  longitude,
+  elevationMeters: 100,
+  distanceFromStartMeters,
+  idx,
+});
+
+const collectionSegment = (
+  routeId: string,
+  position: number,
+  isSelected = true,
+  patch?: {
+    baseRouteId: string;
+    replaceStartDistanceMeters: number;
+    replaceEndDistanceMeters: number;
+  },
+): CollectionSegment => ({
+  collectionId: "c1",
+  routeId,
+  position,
+  isSelected,
+  variantKind: patch ? "patch" : "full",
+  baseRouteId: patch?.baseRouteId ?? null,
+  replaceStartDistanceMeters: patch?.replaceStartDistanceMeters ?? null,
+  replaceEndDistanceMeters: patch?.replaceEndDistanceMeters ?? null,
+});
+
+const segmentInfo = (
+  routeId: string,
+  position: number,
+  distanceOffsetMeters: number,
+): StitchedSegmentInfo => ({
+  routeId,
+  routeName: routeId,
+  position,
+  variantKind: "full",
+  baseRouteId: null,
+  replaceStartDistanceMeters: null,
+  replaceEndDistanceMeters: null,
+  startPointIndex: position * 2,
+  endPointIndex: position * 2 + 1,
+  distanceOffsetMeters,
+  segmentDistanceMeters: 1_000,
+  segmentAscentMeters: 10,
+  segmentDescentMeters: 10,
+  sourceSpans: [
+    {
+      routeId,
+      routeName: routeId,
+      position,
+      kind: "full",
+      startPointIndex: position * 2,
+      endPointIndex: position * 2 + 1,
+      rawStartDistanceMeters: 0,
+      rawEndDistanceMeters: 1_000,
+      effectiveStartDistanceMeters: toDisplayDistanceMeters(distanceOffsetMeters),
+      effectiveEndDistanceMeters: toDisplayDistanceMeters(distanceOffsetMeters + 1_000),
+      distanceOffsetMeters,
+    },
+  ],
+});
+
 describe("stitchingService", () => {
   it("stitches selected segments in position order", async () => {
     databaseMocks.getCollectionSegments.mockResolvedValue([
-      { collectionId: "c1", routeId: "r2", position: 1, isSelected: true },
-      { collectionId: "c1", routeId: "r1", position: 0, isSelected: true },
-      { collectionId: "c1", routeId: "r3", position: 2, isSelected: false },
+      collectionSegment("r2", 1),
+      collectionSegment("r1", 0),
+      collectionSegment("r3", 2, false),
     ]);
     databaseMocks.getRouteWithPoints.mockImplementation(async (routeId: string) => {
       if (routeId === "r1") return route("r1");
@@ -75,9 +168,7 @@ describe("stitchingService", () => {
   });
 
   it("returns empty stitched collection when no selected routes exist", async () => {
-    databaseMocks.getCollectionSegments.mockResolvedValue([
-      { collectionId: "c1", routeId: "r1", position: 0, isSelected: false },
-    ]);
+    databaseMocks.getCollectionSegments.mockResolvedValue([collectionSegment("r1", 0, false)]);
 
     const stitched = await stitchCollection("c1");
 
@@ -90,9 +181,7 @@ describe("stitchingService", () => {
   });
 
   it("can omit raw per-segment point arrays for active collection view models", async () => {
-    databaseMocks.getCollectionSegments.mockResolvedValue([
-      { collectionId: "c1", routeId: "r1", position: 0, isSelected: true },
-    ]);
+    databaseMocks.getCollectionSegments.mockResolvedValue([collectionSegment("r1", 0)]);
     databaseMocks.getRouteWithPoints.mockResolvedValue(route("r1"));
 
     const stitched = await stitchCollection("c1", { includePointsByRouteId: false });
@@ -102,30 +191,7 @@ describe("stitchingService", () => {
   });
 
   it("stitchPOIs keeps raw distances and sorts by effective distances", () => {
-    const segments = [
-      {
-        routeId: "r1",
-        routeName: "r1",
-        position: 0,
-        startPointIndex: 0,
-        endPointIndex: 1,
-        distanceOffsetMeters: 0,
-        segmentDistanceMeters: 1_000,
-        segmentAscentMeters: 10,
-        segmentDescentMeters: 10,
-      },
-      {
-        routeId: "r2",
-        routeName: "r2",
-        position: 1,
-        startPointIndex: 2,
-        endPointIndex: 3,
-        distanceOffsetMeters: 1_000,
-        segmentDistanceMeters: 1_000,
-        segmentAscentMeters: 10,
-        segmentDescentMeters: 10,
-      },
-    ];
+    const segments = [segmentInfo("r1", 0, 0), segmentInfo("r2", 1, 1_000)];
 
     const combined = stitchPOIs(segments, {
       r1: [poi("a", "r1", 900)],
@@ -139,30 +205,7 @@ describe("stitchingService", () => {
   });
 
   it("stitchPOIs filters by stitched distance window before copying display POIs", () => {
-    const segments = [
-      {
-        routeId: "r1",
-        routeName: "r1",
-        position: 0,
-        startPointIndex: 0,
-        endPointIndex: 1,
-        distanceOffsetMeters: 0,
-        segmentDistanceMeters: 1_000,
-        segmentAscentMeters: 10,
-        segmentDescentMeters: 10,
-      },
-      {
-        routeId: "r2",
-        routeName: "r2",
-        position: 1,
-        startPointIndex: 2,
-        endPointIndex: 3,
-        distanceOffsetMeters: 1_000,
-        segmentDistanceMeters: 1_000,
-        segmentAscentMeters: 10,
-        segmentDescentMeters: 10,
-      },
-    ];
+    const segments = [segmentInfo("r1", 0, 0), segmentInfo("r2", 1, 1_000)];
 
     const combined = stitchPOIs(
       segments,
@@ -175,5 +218,133 @@ describe("stitchingService", () => {
 
     expect(combined.map((p) => p.id)).toEqual(["near", "ahead"]);
     expect(combined.map((p) => p.effectiveDistanceMeters)).toEqual([900, 1_100]);
+  });
+
+  it("snaps patch variant endpoints onto the base route", () => {
+    const basePoints = [
+      routePoint(0, 0, 0),
+      routePoint(1, 1_000, 0.01),
+      routePoint(2, 2_000, 0.02),
+    ];
+    const patchPoints = [routePoint(0, 0, 0.004), routePoint(1, 700, 0.016)];
+
+    const proposal = proposePatchVariantFromPoints("base", "patch", basePoints, patchPoints);
+
+    expect(proposal?.replaceStartDistanceMeters).toBeCloseTo(400, 0);
+    expect(proposal?.replaceEndDistanceMeters).toBeCloseTo(1_600, 0);
+    expect(proposal?.isReversed).toBe(false);
+  });
+
+  it("flags reversed patch endpoint matches", () => {
+    const basePoints = [
+      routePoint(0, 0, 0),
+      routePoint(1, 1_000, 0.01),
+      routePoint(2, 2_000, 0.02),
+    ];
+    const patchPoints = [routePoint(0, 0, 0.016), routePoint(1, 700, 0.004)];
+
+    const proposal = proposePatchVariantFromPoints("base", "patch", basePoints, patchPoints);
+
+    expect(proposal?.replaceStartDistanceMeters).toBeCloseTo(400, 0);
+    expect(proposal?.replaceEndDistanceMeters).toBeCloseTo(1_600, 0);
+    expect(proposal?.isReversed).toBe(true);
+  });
+
+  it("stitches patch variants as base prefix, patch route, and base suffix", async () => {
+    const base = routeFromPoints("base", [
+      routePoint(0, 0, 0),
+      routePoint(1, 500, 0.005),
+      routePoint(2, 1_500, 0.015),
+      routePoint(3, 2_000, 0.02),
+    ]);
+    const patch = routeFromPoints("patch", [routePoint(0, 0, 0.004), routePoint(1, 700, 0.016)]);
+
+    databaseMocks.getCollectionSegments.mockResolvedValue([
+      collectionSegment("base", 0, false),
+      collectionSegment("patch", 0, true, {
+        baseRouteId: "base",
+        replaceStartDistanceMeters: 500,
+        replaceEndDistanceMeters: 1_500,
+      }),
+    ]);
+    databaseMocks.getRouteWithPoints.mockImplementation(async (routeId: string) => {
+      if (routeId === "base") return base;
+      if (routeId === "patch") return patch;
+      return null;
+    });
+
+    const stitched = await stitchCollection("c1");
+
+    expect(stitched.totalDistanceMeters).toBe(1_700);
+    expect(stitched.segments[0].sourceSpans.map((span) => span.kind)).toEqual([
+      "base-prefix",
+      "patch",
+      "base-suffix",
+    ]);
+    expect(stitched.points.map((pt) => pt.distanceFromStartMeters)).toEqual([
+      0, 500, 500, 1_200, 1_200, 1_700,
+    ]);
+  });
+
+  it("stitchPOIs clips base POIs inside a replaced patch range", async () => {
+    const segment = segmentInfo("patch", 0, 0);
+    segment.variantKind = "patch";
+    segment.baseRouteId = "base";
+    segment.replaceStartDistanceMeters = 500;
+    segment.replaceEndDistanceMeters = 1_500;
+    segment.segmentDistanceMeters = 1_700;
+    segment.sourceSpans = [
+      {
+        routeId: "base",
+        routeName: "base",
+        position: 0,
+        kind: "base-prefix",
+        startPointIndex: 0,
+        endPointIndex: 1,
+        rawStartDistanceMeters: 0,
+        rawEndDistanceMeters: 500,
+        effectiveStartDistanceMeters: toDisplayDistanceMeters(0),
+        effectiveEndDistanceMeters: toDisplayDistanceMeters(500),
+        distanceOffsetMeters: 0,
+      },
+      {
+        routeId: "patch",
+        routeName: "patch",
+        position: 0,
+        kind: "patch",
+        startPointIndex: 2,
+        endPointIndex: 3,
+        rawStartDistanceMeters: 0,
+        rawEndDistanceMeters: 700,
+        effectiveStartDistanceMeters: toDisplayDistanceMeters(500),
+        effectiveEndDistanceMeters: toDisplayDistanceMeters(1_200),
+        distanceOffsetMeters: 500,
+      },
+      {
+        routeId: "base",
+        routeName: "base",
+        position: 0,
+        kind: "base-suffix",
+        startPointIndex: 4,
+        endPointIndex: 5,
+        rawStartDistanceMeters: 1_500,
+        rawEndDistanceMeters: 2_000,
+        effectiveStartDistanceMeters: toDisplayDistanceMeters(1_200),
+        effectiveEndDistanceMeters: toDisplayDistanceMeters(1_700),
+        distanceOffsetMeters: -300,
+      },
+    ];
+
+    const combined = stitchPOIs([segment], {
+      base: [
+        poi("before", "base", 200),
+        poi("replaced", "base", 1_000),
+        poi("after", "base", 1_800),
+      ],
+      patch: [poi("patch-poi", "patch", 100)],
+    });
+
+    expect(combined.map((p) => p.id)).toEqual(["before", "patch-poi", "after"]);
+    expect(combined.map((p) => p.effectiveDistanceMeters)).toEqual([200, 600, 1_500]);
   });
 });

--- a/tests/store/etaAndClimbCollectionBehavior.test.ts
+++ b/tests/store/etaAndClimbCollectionBehavior.test.ts
@@ -5,7 +5,8 @@ import { buildPoi } from "@/tests/fixtures/poi";
 import { buildRoutePoint } from "@/tests/fixtures/route";
 import { createStitchedCollectionHarness } from "@/tests/helpers/stitchedCollectionHarness";
 import { etaCalculatorMocks } from "@/tests/mocks/etaCalculator";
-import { toDisplayPOI } from "@/services/displayDistance";
+import { toDisplayDistanceMeters, toDisplayPOI } from "@/services/displayDistance";
+import type { StitchedSegmentInfo } from "@/types";
 
 const stitchedHarness = createStitchedCollectionHarness();
 
@@ -258,6 +259,90 @@ describe("stitched collection coordinate behavior", () => {
     ).toEqual([
       ["c1", 700, 900],
       ["c2", 1_100, 1_400],
+    ]);
+  });
+
+  it("clips climb display coordinates to active patch source spans", () => {
+    const patchSegment: StitchedSegmentInfo = {
+      routeId: "patch",
+      routeName: "patch",
+      position: 0,
+      variantKind: "patch",
+      baseRouteId: "base",
+      replaceStartDistanceMeters: 500,
+      replaceEndDistanceMeters: 1_500,
+      startPointIndex: 0,
+      endPointIndex: 5,
+      distanceOffsetMeters: 0,
+      segmentDistanceMeters: 1_700,
+      segmentAscentMeters: 100,
+      segmentDescentMeters: 0,
+      sourceSpans: [
+        {
+          routeId: "base",
+          routeName: "base",
+          position: 0,
+          kind: "base-prefix",
+          startPointIndex: 0,
+          endPointIndex: 1,
+          rawStartDistanceMeters: 0,
+          rawEndDistanceMeters: 500,
+          effectiveStartDistanceMeters: toDisplayDistanceMeters(0),
+          effectiveEndDistanceMeters: toDisplayDistanceMeters(500),
+          distanceOffsetMeters: 0,
+        },
+        {
+          routeId: "patch",
+          routeName: "patch",
+          position: 0,
+          kind: "patch",
+          startPointIndex: 2,
+          endPointIndex: 3,
+          rawStartDistanceMeters: 0,
+          rawEndDistanceMeters: 700,
+          effectiveStartDistanceMeters: toDisplayDistanceMeters(500),
+          effectiveEndDistanceMeters: toDisplayDistanceMeters(1_200),
+          distanceOffsetMeters: 500,
+        },
+        {
+          routeId: "base",
+          routeName: "base",
+          position: 0,
+          kind: "base-suffix",
+          startPointIndex: 4,
+          endPointIndex: 5,
+          rawStartDistanceMeters: 1_500,
+          rawEndDistanceMeters: 2_000,
+          effectiveStartDistanceMeters: toDisplayDistanceMeters(1_200),
+          effectiveEndDistanceMeters: toDisplayDistanceMeters(1_700),
+          distanceOffsetMeters: -300,
+        },
+      ],
+    };
+
+    useClimbStore.setState({
+      climbs: {
+        base: [
+          buildClimb("before", "base", 200, 400),
+          buildClimb("replaced", "base", 800, 1_000),
+          buildClimb("after", "base", 1_700, 1_900),
+        ],
+        patch: [buildClimb("patch-climb", "patch", 100, 300)],
+      },
+    });
+
+    const display = useClimbStore.getState().getClimbsForDisplay(["base", "patch"], [patchSegment]);
+
+    expect(
+      display.map((climb) => [
+        climb.id,
+        climb.effectiveStartDistanceMeters,
+        climb.effectiveEndDistanceMeters,
+      ]),
+    ).toEqual([
+      ["before", 200, 400],
+      ["patch-climb", 600, 800],
+      ["after", 1_400, 1_600],
     ]);
   });
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -307,28 +307,56 @@ export interface Collection {
   plannedStartMs: number | null;
 }
 
+export type CollectionSegmentVariantKind = "full" | "patch";
+
 export interface CollectionSegment {
   collectionId: string;
   routeId: string;
   position: number;
   isSelected: boolean;
+  variantKind: CollectionSegmentVariantKind;
+  baseRouteId: string | null;
+  replaceStartDistanceMeters: number | null;
+  replaceEndDistanceMeters: number | null;
 }
 
 export interface CollectionSegmentWithRoute {
   segment: CollectionSegment;
   route: Route;
+  baseRoute?: Route | null;
+}
+
+export type StitchedSourceSpanKind = "full" | "base-prefix" | "patch" | "base-suffix";
+
+export interface StitchedSourceSpan {
+  routeId: string;
+  routeName: string;
+  position: number;
+  kind: StitchedSourceSpanKind;
+  startPointIndex: number;
+  endPointIndex: number;
+  rawStartDistanceMeters: number;
+  rawEndDistanceMeters: number;
+  effectiveStartDistanceMeters: DisplayDistanceMeters;
+  effectiveEndDistanceMeters: DisplayDistanceMeters;
+  distanceOffsetMeters: number;
 }
 
 export interface StitchedSegmentInfo {
   routeId: string;
   routeName: string;
   position: number;
+  variantKind: CollectionSegmentVariantKind;
+  baseRouteId: string | null;
+  replaceStartDistanceMeters: number | null;
+  replaceEndDistanceMeters: number | null;
   startPointIndex: number;
   endPointIndex: number;
   distanceOffsetMeters: number;
   segmentDistanceMeters: number;
   segmentAscentMeters: number;
   segmentDescentMeters: number;
+  sourceSpans: StitchedSourceSpan[];
 }
 
 export interface StitchedCollection {
@@ -340,6 +368,7 @@ export interface StitchedCollection {
   totalDescentMeters: number;
   /** Per-segment raw points, keyed by routeId */
   pointsByRouteId: Record<string, RoutePoint[]>;
+  sourceSpans: StitchedSourceSpan[];
 }
 
 export interface ActiveRouteData {


### PR DESCRIPTION
## Summary

- Add patch-style collection variants that splice a subset route into a base collection segment.
- Store patch metadata, snap/confirm replacement ranges, and stitch prefix + patch + suffix for selected patch variants.
- Preserve POI/climb display correctness with source-span metadata and span-aware clipping.
- Update collection and main-map UI to show patch context, variant diffs, and quiet grey variant overlays.

Refs #14

## Impact

This lets a shorter imported route be manually attached as a variant for an existing collection segment, without requiring it to share the same start and finish as the original route. Full-route variants continue to work unchanged.

## Validation

- `npx tsc --noEmit`
- `npm run lint`
- `npm test` (152 tests)

Note: `./scripts/smoke-test.sh` could not run locally because no iOS simulator was booted; it failed while looking up the booted UDID.