### PR TITLE
[codex] Improve bottom sheet navigation

### DIFF
--- a/components/map/ClimbTabContent.tsx
+++ b/components/map/ClimbTabContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback, useEffect } from "react";
+import React, { useMemo, useState, useCallback } from "react";
 import {
   View,
   TouchableOpacity,
@@ -87,10 +87,6 @@ export default function ClimbTabContent({ activeData }: ClimbTabContentProps) {
   const setSelectedPOI = usePoiStore((s) => s.setSelectedPOI);
   const isExpanded = usePanelStore((s) => s.isExpanded);
   const panelMode = usePanelStore((s) => s.panelMode);
-  // Reset to current/upcoming climb when tab mounts
-  useEffect(() => {
-    setSelectedClimb(null);
-  }, [setSelectedClimb]);
 
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState("");

--- a/components/map/POITabContent.tsx
+++ b/components/map/POITabContent.tsx
@@ -93,6 +93,7 @@ export default function POITabContent({ activeData }: POITabContentProps) {
   const cumulativeTime = useEtaStore((s) => s.cumulativeTime);
   const isExpanded = usePanelStore((s) => s.isExpanded);
   const panelMode = usePanelStore((s) => s.panelMode);
+  const consumeDetailReturnTab = usePanelStore((s) => s.consumeDetailReturnTab);
 
   const [searchQuery, setSearchQuery] = useState("");
   const [showAddPOI, setShowAddPOI] = useState(false);
@@ -234,6 +235,12 @@ export default function POITabContent({ activeData }: POITabContentProps) {
     [setSelectedPOI],
   );
 
+  const handleBackFromDetail = useCallback(() => {
+    const returnTab = consumeDetailReturnTab();
+    setSelectedPOI(null);
+    if (returnTab) usePanelStore.getState().setPanelTab(returnTab);
+  }, [consumeDetailReturnTab, setSelectedPOI]);
+
   const openAddPOISheet = useCallback(async () => {
     if (!activeData) {
       Alert.alert("No Active Route", "Set an active route or collection before saving a POI.");
@@ -302,7 +309,7 @@ export default function POITabContent({ activeData }: POITabContentProps) {
         poi={selectedPOI}
         segments={segments}
         currentDist={currentDist}
-        onBack={() => setSelectedPOI(null)}
+        onBack={handleBackFromDetail}
       />
     );
   }

--- a/components/map/TabbedBottomPanel.tsx
+++ b/components/map/TabbedBottomPanel.tsx
@@ -11,6 +11,7 @@ import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Text } from "@/components/ui/text";
 import { useThemeColors } from "@/theme";
+import { useClimbStore } from "@/store/climbStore";
 import { usePanelStore } from "@/store/panelStore";
 import { SHEET_COMPACT_RATIO, SHEET_EXPANDED_RATIO } from "@/constants";
 import ProfileTabContent from "./ProfileTabContent";
@@ -65,6 +66,15 @@ export default function TabbedBottomPanel({ activeData }: TabbedBottomPanelProps
   const panelTab = usePanelStore((s) => s.panelTab);
   const setPanelTab = usePanelStore((s) => s.setPanelTab);
   const setIsExpanded = usePanelStore((s) => s.setIsExpanded);
+  const setSelectedClimb = useClimbStore((s) => s.setSelectedClimb);
+
+  const handleTabPress = React.useCallback(
+    (tab: PanelTab) => {
+      if (tab === "climbs" && panelTab !== "climbs") setSelectedClimb(null);
+      setPanelTab(tab);
+    },
+    [panelTab, setPanelTab, setSelectedClimb],
+  );
 
   const panGesture = Gesture.Pan()
     .activeOffsetY([-10, 10])
@@ -157,7 +167,7 @@ export default function TabbedBottomPanel({ activeData }: TabbedBottomPanelProps
                     <TouchableOpacity
                       key={tab.key}
                       className="flex-1 items-center justify-center h-full"
-                      onPress={() => setPanelTab(tab.key)}
+                      onPress={() => handleTabPress(tab.key)}
                       accessibilityLabel={`${tab.label} tab`}
                       accessibilityRole="tab"
                       accessibilityState={{ selected: isActive }}

--- a/components/map/UpcomingTabContent.tsx
+++ b/components/map/UpcomingTabContent.tsx
@@ -1,5 +1,12 @@
-import React, { useCallback, useMemo } from "react";
-import { FlatList, TouchableOpacity, View, type ListRenderItem } from "react-native";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import {
+  FlatList,
+  TouchableOpacity,
+  View,
+  type ListRenderItem,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Clock3, Flag, GitBranch, MapPin, Mountain } from "lucide-react-native";
 import { Text } from "@/components/ui/text";
@@ -54,6 +61,9 @@ function eventKeyExtractor(event: UpcomingEvent): string {
 }
 
 export default function UpcomingTabContent({ activeData }: UpcomingTabContentProps) {
+  const listRef = useRef<FlatList<UpcomingEvent>>(null);
+  const initialScrollOffsetRef = useRef(usePanelStore.getState().upcomingScrollOffset);
+  const restoredScrollOffsetRef = useRef(false);
   const colors = useThemeColors();
   const { bottom: safeBottom } = useSafeAreaInsets();
   const units = useSettingsStore((s) => s.units);
@@ -67,6 +77,7 @@ export default function UpcomingTabContent({ activeData }: UpcomingTabContentPro
   const cumulativeTime = useEtaStore((s) => s.cumulativeTime);
   const panelMode = usePanelStore((s) => s.panelMode);
   const setPanelTab = usePanelStore((s) => s.setPanelTab);
+  const setUpcomingScrollOffset = usePanelStore((s) => s.setUpcomingScrollOffset);
   const timing = useActiveRouteTiming(activeData);
 
   const routeIds = useMemo(() => activeData?.routeIds ?? [], [activeData?.routeIds]);
@@ -154,6 +165,23 @@ export default function UpcomingTabContent({ activeData }: UpcomingTabContentPro
     ],
   );
 
+  useEffect(() => {
+    const offset = initialScrollOffsetRef.current;
+    if (restoredScrollOffsetRef.current || offset <= 0 || events.length === 0) return;
+
+    restoredScrollOffsetRef.current = true;
+    requestAnimationFrame(() => {
+      listRef.current?.scrollToOffset({ offset, animated: false });
+    });
+  }, [events.length]);
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      setUpcomingScrollOffset(Math.max(0, event.nativeEvent.contentOffset.y));
+    },
+    [setUpcomingScrollOffset],
+  );
+
   const handleEventPress = useCallback(
     (event: UpcomingEvent) => {
       if (event.kind === "poi") {
@@ -193,10 +221,13 @@ export default function UpcomingTabContent({ activeData }: UpcomingTabContentPro
       />
 
       <FlatList
+        ref={listRef}
         data={events}
         keyExtractor={eventKeyExtractor}
         renderItem={renderEvent}
         showsVerticalScrollIndicator={false}
+        onScroll={handleScroll}
+        scrollEventThrottle={250}
         initialNumToRender={INITIAL_RENDER_COUNT}
         maxToRenderPerBatch={LIST_MAX_BATCH}
         updateCellsBatchingPeriod={LIST_BATCHING_PERIOD_MS}

--- a/store/panelStore.ts
+++ b/store/panelStore.ts
@@ -32,6 +32,15 @@ interface PanelState {
   /** Whether the bottom sheet is in expanded mode */
   isExpanded: boolean;
   setIsExpanded: (isExpanded: boolean) => void;
+
+  /** Tab to return to when closing a detail view opened from another tab */
+  detailReturnTab: PanelTab | null;
+  setDetailReturnTab: (tab: PanelTab | null) => void;
+  consumeDetailReturnTab: () => PanelTab | null;
+
+  /** Last visible Upcoming list offset, used when returning from detail views */
+  upcomingScrollOffset: number;
+  setUpcomingScrollOffset: (offset: number) => void;
 }
 
 const DEFAULT_PANEL_MODE: PanelMode = "upcoming-50";
@@ -89,5 +98,22 @@ export const usePanelStore = create<PanelState>((set, get) => ({
   setIsExpanded: (isExpanded) => {
     if (get().isExpanded === isExpanded) return;
     set({ isExpanded });
+  },
+
+  detailReturnTab: null,
+  setDetailReturnTab: (detailReturnTab) => {
+    if (get().detailReturnTab === detailReturnTab) return;
+    set({ detailReturnTab });
+  },
+  consumeDetailReturnTab: () => {
+    const tab = get().detailReturnTab;
+    if (tab) set({ detailReturnTab: null });
+    return tab;
+  },
+
+  upcomingScrollOffset: 0,
+  setUpcomingScrollOffset: (upcomingScrollOffset) => {
+    if (Math.abs(get().upcomingScrollOffset - upcomingScrollOffset) < 1) return;
+    set({ upcomingScrollOffset });
   },
 }));

--- a/store/poiStore.ts
+++ b/store/poiStore.ts
@@ -640,8 +640,11 @@ export const usePoiStore = create<POIState>((set, get) => ({
   },
 
   setSelectedPOI: (poi) => {
+    const panel = usePanelStore.getState();
+    const sourceTab = panel.panelTab;
+    panel.setDetailReturnTab(poi && sourceTab !== "pois" ? sourceTab : null);
     set({ selectedPOI: poi });
-    if (poi) usePanelStore.getState().setPanelTab("pois");
+    if (poi) panel.setPanelTab("pois");
   },
   getVisiblePOIs: (routeId) => {
     const state = get();


### PR DESCRIPTION
## Summary
- Return from POI detail to the originating bottom-sheet tab when POIs are opened from Upcoming.
- Preserve the Upcoming list scroll offset when returning from detail views.
- Keep Upcoming-selected climbs selected when switching into Climbs, while manual Climbs tab taps still show the next/current climb.

## Root cause
POI selection always forced the POI tab without retaining the source tab, and the Climbs tab cleared selected climb state on mount, which discarded selections made from Upcoming.

## Validation
- `git diff --check`
- `npx tsc --noEmit --pretty false`
- `npm run lint`
- `npm run format:check`
- `npm test`

Note: `./scripts/smoke-test.sh` could not run because no iOS simulator was booted in this environment.