### PR TITLE
[codex] Simplify upcoming climb rows

### DIFF
--- a/components/map/UpcomingTabContent.tsx
+++ b/components/map/UpcomingTabContent.tsx
@@ -299,7 +299,7 @@ const UpcomingEventRow = React.memo(function UpcomingEventRow({
   const departureTime =
     event.kind === "poi" ? departureTimeAfterPlannedStop(eta, plannedStopMinutes) : null;
   const hasStopInterval = plannedStopMinutes > 0 && eta != null && departureTime != null;
-  const hasClimbInterval = event.kind === "climb-span" && event.endEta != null;
+  const hasClimbInterval = event.kind === "climb-span" && !event.isActive && event.endEta != null;
   const clockLabel = eta ? formatETA(eta.eta) : "--:--";
   const departureLabel = departureTime ? formatETA(departureTime) : null;
   const climbEndLabel =

--- a/components/map/UpcomingTabContent.tsx
+++ b/components/map/UpcomingTabContent.tsx
@@ -12,11 +12,7 @@ import { Clock3, Flag, GitBranch, MapPin, Mountain } from "lucide-react-native";
 import { Text } from "@/components/ui/text";
 import { POI_ICON_MAP } from "@/constants/poiIcons";
 import { getCategoryMeta, ohStatusColorKey } from "@/constants/poiHelpers";
-import {
-  CLIMB_DIFFICULTY_LABELS,
-  climbDifficultyColor,
-  getClimbDifficulty,
-} from "@/constants/climbHelpers";
+import { climbDifficultyColor } from "@/constants/climbHelpers";
 import { useThemeColors } from "@/theme";
 import { useClimbStore } from "@/store/climbStore";
 import { useEtaStore } from "@/store/etaStore";
@@ -186,11 +182,7 @@ export default function UpcomingTabContent({ activeData }: UpcomingTabContentPro
     (event: UpcomingEvent) => {
       if (event.kind === "poi") {
         setSelectedPOI(event.poi);
-      } else if (
-        event.kind === "climb-span" ||
-        event.kind === "climb-start" ||
-        event.kind === "climb-top"
-      ) {
+      } else if (event.kind === "climb-span") {
         setSelectedClimb(event.climb);
         setPanelTab("climbs");
       }
@@ -307,21 +299,24 @@ const UpcomingEventRow = React.memo(function UpcomingEventRow({
   const departureTime =
     event.kind === "poi" ? departureTimeAfterPlannedStop(eta, plannedStopMinutes) : null;
   const hasStopInterval = plannedStopMinutes > 0 && eta != null && departureTime != null;
+  const hasClimbInterval = event.kind === "climb-span" && event.endEta != null;
   const clockLabel = eta ? formatETA(eta.eta) : "--:--";
   const departureLabel = departureTime ? formatETA(departureTime) : null;
+  const climbEndLabel =
+    event.kind === "climb-span" && event.endEta ? formatETA(event.endEta.eta) : null;
+  const primaryRidingTime = eta ?? (event.kind === "climb-span" ? event.endEta : null);
   const ridingTimeLabel =
-    eta && eta.ridingTimeSeconds > 0 ? `~${formatDuration(eta.ridingTimeSeconds)}` : "no ETA";
-  const isPressable =
-    event.kind === "poi" ||
-    event.kind === "climb-span" ||
-    event.kind === "climb-start" ||
-    event.kind === "climb-top";
+    primaryRidingTime && primaryRidingTime.ridingTimeSeconds > 0
+      ? `~${formatDuration(primaryRidingTime.ridingTimeSeconds)}`
+      : "no ETA";
+  const isPressable = event.kind === "poi" || event.kind === "climb-span";
   const content = eventContent(event, units, colors);
   const accessibilityLabel = [
     content.title,
     content.subtitle,
     eta ? `ETA ${clockLabel}` : null,
     hasStopInterval && departureLabel ? `depart ${departureLabel}` : null,
+    hasClimbInterval && climbEndLabel ? `end ${climbEndLabel}` : null,
     `${distanceLabel} ahead`,
   ]
     .filter(Boolean)
@@ -342,6 +337,11 @@ const UpcomingEventRow = React.memo(function UpcomingEventRow({
         {hasStopInterval && departureLabel && (
           <Text className="text-[20px] font-barlow-sc-semibold text-foreground" numberOfLines={1}>
             {departureLabel}
+          </Text>
+        )}
+        {hasClimbInterval && climbEndLabel && (
+          <Text className="text-[20px] font-barlow-sc-semibold text-foreground" numberOfLines={1}>
+            {climbEndLabel}
           </Text>
         )}
         <Text className="text-[12px] font-barlow-sc-medium text-muted-foreground" numberOfLines={1}>
@@ -415,19 +415,14 @@ function eventContent(
         icon: <IconComp size={20} color={meta?.color ?? colors.textPrimary} />,
       };
     }
-    case "climb-span":
-    case "climb-start":
-    case "climb-top": {
-      const difficulty = getClimbDifficulty(event.climb.difficultyScore);
+    case "climb-span": {
       const color = climbDifficultyColor(event.climb.difficultyScore);
-      const titlePrefix =
-        event.kind === "climb-start" ? "START" : event.kind === "climb-top" ? "END" : "Climb";
       return {
-        title: `${titlePrefix}: ${event.climb.name ?? "Climb"}`,
-        subtitle: `${CLIMB_DIFFICULTY_LABELS[difficulty]} · ${formatDistance(
-          event.climb.lengthMeters,
+        title: event.climb.name ?? "Climb",
+        subtitle: `${formatDistance(event.climb.lengthMeters, units)} · +${formatElevation(
+          event.climb.totalAscentMeters,
           units,
-        )} · +${formatElevation(event.climb.totalAscentMeters, units)}`,
+        )} · ${event.climb.averageGradientPercent}% avg`,
         subtitleColor: color,
         color,
         icon: <Mountain size={20} color={color} />,

--- a/docs/features.md
+++ b/docs/features.md
@@ -43,7 +43,7 @@ What's implemented. For the "why" behind these, see `usage-context.md`.
 - Uses the same 10km / 25km / 50km / 100km / 200km / FULL horizon as the ride view
 - Displays clock ETA and riding time when available, with distance-first fallback when ETA is unavailable
 - Includes POIs with planned stop durations even when unstarred, so downstream ETA shifts are visible
-- Models climbs as spans, splitting moderate/hard climbs or climbs with important POIs into start/top context
+- Models climbs as one span row with start and end ETA when available
 
 ## Climb Detection
 

--- a/services/upcomingTimeline.ts
+++ b/services/upcomingTimeline.ts
@@ -37,6 +37,7 @@ export interface UpcomingClimbSpanEvent extends UpcomingEventBase {
   kind: "climb-span";
   climb: DisplayClimb;
   endEta: ETAResult | null;
+  isActive: boolean;
 }
 
 export interface UpcomingSegmentTransitionEvent extends UpcomingEventBase {
@@ -123,27 +124,37 @@ export function buildUpcomingTimeline({
       continue;
     }
 
+    const isActive =
+      climb.effectiveStartDistanceMeters < anchorDistanceMeters &&
+      climb.effectiveEndDistanceMeters >= anchorDistanceMeters;
+    const endEta = resolveETA(
+      cumulativeTime,
+      routePoints,
+      anchorDistanceMeters,
+      climb.effectiveEndDistanceMeters,
+      etaStartTimeMs,
+      plannedStops,
+    );
+
     events.push({
       id: `climb-span:${climb.id}`,
       kind: "climb-span",
-      distanceMeters: climb.effectiveStartDistanceMeters,
-      eta: resolveETA(
-        cumulativeTime,
-        routePoints,
-        anchorDistanceMeters,
-        climb.effectiveStartDistanceMeters,
-        etaStartTimeMs,
-        plannedStops,
-      ),
+      distanceMeters: (isActive
+        ? anchorDistanceMeters
+        : climb.effectiveStartDistanceMeters) as DisplayDistanceMeters,
+      eta: isActive
+        ? endEta
+        : resolveETA(
+            cumulativeTime,
+            routePoints,
+            anchorDistanceMeters,
+            climb.effectiveStartDistanceMeters,
+            etaStartTimeMs,
+            plannedStops,
+          ),
       climb,
-      endEta: resolveETA(
-        cumulativeTime,
-        routePoints,
-        anchorDistanceMeters,
-        climb.effectiveEndDistanceMeters,
-        etaStartTimeMs,
-        plannedStops,
-      ),
+      endEta,
+      isActive,
     });
   }
 

--- a/services/upcomingTimeline.ts
+++ b/services/upcomingTimeline.ts
@@ -1,4 +1,3 @@
-import { getClimbDifficulty } from "@/constants/climbHelpers";
 import { getETAToDistanceFromDistance } from "@/services/etaCalculator";
 import {
   applyPlannedStopOffsetToETA,
@@ -20,13 +19,7 @@ import type {
   StitchedSegmentInfo,
 } from "@/types";
 
-export type UpcomingEventKind =
-  | "poi"
-  | "climb-span"
-  | "climb-start"
-  | "climb-top"
-  | "segment-transition"
-  | "finish";
+export type UpcomingEventKind = "poi" | "climb-span" | "segment-transition" | "finish";
 
 interface UpcomingEventBase {
   id: string;
@@ -43,11 +36,7 @@ export interface UpcomingPOIEvent extends UpcomingEventBase {
 export interface UpcomingClimbSpanEvent extends UpcomingEventBase {
   kind: "climb-span";
   climb: DisplayClimb;
-}
-
-export interface UpcomingClimbPointEvent extends UpcomingEventBase {
-  kind: "climb-start" | "climb-top";
-  climb: DisplayClimb;
+  endEta: ETAResult | null;
 }
 
 export interface UpcomingSegmentTransitionEvent extends UpcomingEventBase {
@@ -64,7 +53,6 @@ export interface UpcomingFinishEvent extends UpcomingEventBase {
 export type UpcomingEvent =
   | UpcomingPOIEvent
   | UpcomingClimbSpanEvent
-  | UpcomingClimbPointEvent
   | UpcomingSegmentTransitionEvent
   | UpcomingFinishEvent;
 
@@ -83,11 +71,9 @@ export interface BuildUpcomingTimelineInput {
 }
 
 const EVENT_ORDER: Record<UpcomingEventKind, number> = {
-  "climb-start": 0,
-  "segment-transition": 1,
-  poi: 2,
-  "climb-span": 3,
-  "climb-top": 4,
+  "segment-transition": 0,
+  poi: 1,
+  "climb-span": 2,
   finish: 5,
 };
 
@@ -137,62 +123,6 @@ export function buildUpcomingTimeline({
       continue;
     }
 
-    const hasImportantPOIInside = importantPOIs.some(
-      (poi) =>
-        poi.effectiveDistanceMeters >= climb.effectiveStartDistanceMeters &&
-        poi.effectiveDistanceMeters <= climb.effectiveEndDistanceMeters,
-    );
-    const shouldSplit =
-      getClimbDifficulty(climb.difficultyScore) !== "low" || hasImportantPOIInside;
-
-    if (shouldSplit) {
-      if (
-        isPointInUpcomingWindow(
-          climb.effectiveStartDistanceMeters,
-          horizonWindow,
-          anchorDistanceMeters,
-        )
-      ) {
-        events.push({
-          id: `climb-start:${climb.id}`,
-          kind: "climb-start",
-          distanceMeters: climb.effectiveStartDistanceMeters,
-          eta: resolveETA(
-            cumulativeTime,
-            routePoints,
-            anchorDistanceMeters,
-            climb.effectiveStartDistanceMeters,
-            etaStartTimeMs,
-            plannedStops,
-          ),
-          climb,
-        });
-      }
-      if (
-        isPointInUpcomingWindow(
-          climb.effectiveEndDistanceMeters,
-          horizonWindow,
-          anchorDistanceMeters,
-        )
-      ) {
-        events.push({
-          id: `climb-top:${climb.id}`,
-          kind: "climb-top",
-          distanceMeters: climb.effectiveEndDistanceMeters,
-          eta: resolveETA(
-            cumulativeTime,
-            routePoints,
-            anchorDistanceMeters,
-            climb.effectiveEndDistanceMeters,
-            etaStartTimeMs,
-            plannedStops,
-          ),
-          climb,
-        });
-      }
-      continue;
-    }
-
     events.push({
       id: `climb-span:${climb.id}`,
       kind: "climb-span",
@@ -206,6 +136,14 @@ export function buildUpcomingTimeline({
         plannedStops,
       ),
       climb,
+      endEta: resolveETA(
+        cumulativeTime,
+        routePoints,
+        anchorDistanceMeters,
+        climb.effectiveEndDistanceMeters,
+        etaStartTimeMs,
+        plannedStops,
+      ),
     });
   }
 

--- a/tests/services/upcomingTimeline.test.ts
+++ b/tests/services/upcomingTimeline.test.ts
@@ -171,6 +171,37 @@ describe("upcomingTimeline", () => {
     vi.useRealTimers();
   });
 
+  it("anchors an active climb to current progress and uses the top ETA", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+
+    const routePoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+    ];
+    const events = buildUpcomingTimeline({
+      pois: [],
+      starredPOIIds: new Set(),
+      climbs: [toDisplayClimb(buildClimb("active", "r1", 1_000, 2_000))],
+      segments: null,
+      totalDistanceMeters: 3_000,
+      currentDistanceMeters: 1_500,
+      routePoints,
+      cumulativeTime: [0, 100, 200],
+    });
+
+    const climb = events.find((event) => event.id === "climb-span:active");
+    expect(climb).toMatchObject({
+      distanceMeters: 1_500,
+      eta: { ridingTimeSeconds: 50 },
+      endEta: { ridingTimeSeconds: 50 },
+      isActive: true,
+    });
+
+    vi.useRealTimers();
+  });
+
   it("keeps rows visible without ETA data", () => {
     const events = buildUpcomingTimeline({
       pois: [toDisplayPOI(buildPoi("water", "r1", 1_000))],

--- a/tests/services/upcomingTimeline.test.ts
+++ b/tests/services/upcomingTimeline.test.ts
@@ -119,7 +119,7 @@ describe("upcomingTimeline", () => {
     expect(events.map((event) => event.id)).toEqual(["poi:ahead"]);
   });
 
-  it("splits moderate climbs and easy climbs with important POIs, but collapses isolated easy climbs", () => {
+  it("keeps each climb as one span event even when difficult or containing important POIs", () => {
     const events = buildUpcomingTimeline({
       pois: [toDisplayPOI(buildPoi("inside-easy", "r1", 2_200))],
       starredPOIIds: new Set(["inside-easy"]),
@@ -135,13 +135,40 @@ describe("upcomingTimeline", () => {
 
     expect(events.map((event) => event.id)).toEqual([
       "climb-span:easy",
-      "climb-start:easy-poi",
+      "climb-span:easy-poi",
       "poi:inside-easy",
-      "climb-top:easy-poi",
-      "climb-start:medium",
-      "climb-top:medium",
+      "climb-span:medium",
       "finish",
     ]);
+  });
+
+  it("attaches start and end ETA to climb spans", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T12:00:00.000Z"));
+
+    const routePoints = [
+      buildRoutePoint(0, 0),
+      buildRoutePoint(1_000, 1),
+      buildRoutePoint(2_000, 2),
+    ];
+    const events = buildUpcomingTimeline({
+      pois: [],
+      starredPOIIds: new Set(),
+      climbs: [toDisplayClimb(buildClimb("climb", "r1", 1_000, 2_000))],
+      segments: null,
+      totalDistanceMeters: 3_000,
+      currentDistanceMeters: 0,
+      routePoints,
+      cumulativeTime: [0, 100, 200],
+    });
+
+    const climb = events.find((event) => event.id === "climb-span:climb");
+    expect(climb).toMatchObject({
+      eta: { ridingTimeSeconds: 100 },
+      endEta: { ridingTimeSeconds: 200 },
+    });
+
+    vi.useRealTimers();
   });
 
   it("keeps rows visible without ETA data", () => {


### PR DESCRIPTION
## Summary

- Collapse upcoming timeline climbs into a single span event instead of separate start/top rows.
- Show climb start and end ETAs in the same row, matching planned POI stop timing treatment.
- Remove explicit climb difficulty labels from the upcoming row copy and rely on the existing difficulty color.
- Update timeline tests and feature docs for the new climb row behavior.

## Why

The previous upcoming list split harder climbs into separate start and top entries, which made climbs feel different from POI stops and added extra scan cost. A single row keeps the upcoming list quieter while still preserving both relevant time points.

## Validation

- `npm test -- tests/services/upcomingTimeline.test.ts`
- `npm run lint`
- `npx tsc --noEmit`
- Commit hook reran `oxfmt`, `oxlint --fix`, and `tsc --noEmit`.