### PR TITLE
Harden route import atomicity and retries

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,7 @@ import { useCollectionStore } from "@/store/collectionStore";
 import { usePoiStore } from "@/store/poiStore";
 import { useClimbStore } from "@/store/climbStore";
 import { COLORS } from "@/theme";
+import { IncomingUrlImportGate } from "@/utils/incomingUrlImport";
 
 export { ErrorBoundary } from "expo-router";
 
@@ -101,41 +102,44 @@ export default function RootLayout() {
   }, []);
 
   // Handle incoming GPX/KML and planner database files.
-  const handledUrls = useRef(new Set<string>());
+  const incomingUrlGate = useRef(new IncomingUrlImportGate());
 
   const handleIncomingUrl = useCallback(async (url: string) => {
-    if (handledUrls.current.has(url)) return;
-    handledUrls.current.add(url);
-
     const fileName = decodeURIComponent(url.split("/").pop() || "route");
     const ext = fileName.toLowerCase().split(".").pop();
     const isPlanningDb = fileName.toLowerCase().endsWith(".ultra-plan.db");
     if (!["gpx", "kml"].includes(ext || "") && !isPlanningDb) return;
 
     try {
-      if (isPlanningDb) {
-        const { importPlanningDatabaseFromUri } = await import("@/services/planningTransport");
-        const summary = await importPlanningDatabaseFromUri(url);
-        useRouteStore.setState({ visibleRoutePoints: {}, snappedPosition: null, snapHistory: [] });
-        usePoiStore.setState({ pois: {}, selectedPOI: null });
-        useClimbStore.getState().clearClimbCache();
-        await Promise.all([
-          useRouteStore.getState().loadRoutesAndPoints(),
-          useCollectionStore.getState().loadCollections(),
-          usePoiStore.getState().loadStarredItems(),
-        ]);
-        Alert.alert(
-          "Planner Import Complete",
-          `Merged ${summary.routes} routes, ${summary.collections} collections, and ${summary.pois} POIs.`,
-        );
-        router.replace("/settings");
-        return;
-      }
+      await incomingUrlGate.current.run(url, async () => {
+        if (isPlanningDb) {
+          const { importPlanningDatabaseFromUri } = await import("@/services/planningTransport");
+          const summary = await importPlanningDatabaseFromUri(url);
+          useRouteStore.setState({
+            visibleRoutePoints: {},
+            snappedPosition: null,
+            snapHistory: [],
+          });
+          usePoiStore.setState({ pois: {}, selectedPOI: null });
+          useClimbStore.getState().clearClimbCache();
+          await Promise.all([
+            useRouteStore.getState().loadRoutesAndPoints(),
+            useCollectionStore.getState().loadCollections(),
+            usePoiStore.getState().loadStarredItems(),
+          ]);
+          Alert.alert(
+            "Planner Import Complete",
+            `Merged ${summary.routes} routes, ${summary.collections} collections, and ${summary.pois} POIs.`,
+          );
+          router.replace("/settings");
+          return;
+        }
 
-      const route = await useRouteStore.getState().importFromUri(url, fileName);
-      // Replace (not push) so the +not-found screen Expo Router briefly lands on
-      // for the incoming file:// URL doesn't stay in the back stack.
-      router.replace(`/route/${route.id}`);
+        const route = await useRouteStore.getState().importFromUri(url, fileName);
+        // Replace (not push) so the +not-found screen Expo Router briefly lands on
+        // for the incoming file:// URL doesn't stay in the back stack.
+        router.replace(`/route/${route.id}`);
+      });
     } catch (e: any) {
       Alert.alert("Import Failed", e.message || "Could not import the file.");
     }

--- a/db/database.ts
+++ b/db/database.ts
@@ -206,7 +206,11 @@ export async function clearRelativeETACaches(scopeId?: string): Promise<void> {
 
 // --- Route CRUD ---
 
-export async function insertRoute(route: Route, points: RoutePoint[]): Promise<void> {
+export async function insertRoute(
+  route: Route,
+  points: RoutePoint[],
+  routeClimbs: Climb[] = [],
+): Promise<void> {
   db.transaction((tx) => {
     tx.insert(routes)
       .values({
@@ -236,6 +240,28 @@ export async function insertRoute(route: Route, points: RoutePoint[]): Promise<v
             longitude: p.longitude,
             elevationMeters: p.elevationMeters,
             distanceFromStartMeters: p.distanceFromStartMeters,
+          })),
+        )
+        .run();
+    }
+
+    for (let i = 0; i < routeClimbs.length; i += CHUNK) {
+      const chunk = routeClimbs.slice(i, i + CHUNK);
+      tx.insert(climbs)
+        .values(
+          chunk.map((climb) => ({
+            id: climb.id,
+            routeId: climb.routeId,
+            name: climb.name,
+            startDistanceMeters: climb.startDistanceMeters,
+            endDistanceMeters: climb.endDistanceMeters,
+            lengthMeters: climb.lengthMeters,
+            totalAscentMeters: climb.totalAscentMeters,
+            startElevationMeters: climb.startElevationMeters,
+            endElevationMeters: climb.endElevationMeters,
+            averageGradientPercent: climb.averageGradientPercent,
+            maxGradientPercent: climb.maxGradientPercent,
+            difficultyScore: climb.difficultyScore,
           })),
         )
         .run();

--- a/db/database.web.ts
+++ b/db/database.web.ts
@@ -386,7 +386,11 @@ export async function clearRelativeETACaches(scopeId?: string): Promise<void> {
 
 // --- Route CRUD ---
 
-export async function insertRoute(route: Route, points: RoutePoint[]): Promise<void> {
+export async function insertRoute(
+  route: Route,
+  points: RoutePoint[],
+  routeClimbs: Climb[] = [],
+): Promise<void> {
   const database = await getWebSQLiteDatabase();
   await database.withTransactionAsync(async () => {
     await database.runAsync(
@@ -421,6 +425,30 @@ export async function insertRoute(route: Route, points: RoutePoint[]): Promise<v
           point.longitude,
           point.elevationMeters,
           point.distanceFromStartMeters,
+        ],
+      );
+    }
+
+    for (const climb of routeClimbs) {
+      await database.runAsync(
+        `INSERT INTO climbs (
+          id, routeId, name, startDistanceMeters, endDistanceMeters, lengthMeters,
+          totalAscentMeters, startElevationMeters, endElevationMeters,
+          averageGradientPercent, maxGradientPercent, difficultyScore
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          climb.id,
+          climb.routeId,
+          climb.name,
+          climb.startDistanceMeters,
+          climb.endDistanceMeters,
+          climb.lengthMeters,
+          climb.totalAscentMeters,
+          climb.startElevationMeters,
+          climb.endElevationMeters,
+          climb.averageGradientPercent,
+          climb.maxGradientPercent,
+          climb.difficultyScore,
         ],
       );
     }

--- a/services/climbDetector.ts
+++ b/services/climbDetector.ts
@@ -314,15 +314,27 @@ export async function detectAndStoreClimbs(
   points: RoutePoint[],
 ): Promise<Climb[]> {
   const { insertClimbs } = await import("@/db/database");
+  const records = await detectClimbsForRoute(routeId, points);
+  await insertClimbs(records);
+  return records;
+}
+
+/**
+ * Detect climbs and create their database records without persisting them.
+ * This lets route imports include climbs in the same transaction as the route
+ * and its points.
+ */
+export async function detectClimbsForRoute(
+  routeId: string,
+  points: RoutePoint[],
+): Promise<Climb[]> {
   const { generateId } = await import("@/utils/generateId");
   const detected = detectClimbs(points);
-  const records: Climb[] = detected.map((c) => {
+  return detected.map((c) => {
     const out = Object.assign({}, c) as Climb;
     out.id = generateId();
     out.routeId = routeId;
     out.name = null;
     return out;
   });
-  await insertClimbs(records);
-  return records;
 }

--- a/store/routeStore.ts
+++ b/store/routeStore.ts
@@ -181,11 +181,12 @@ export const useRouteStore = create<RouteState>((set, get) => ({
       createdAt: options?.createdAt ?? new Date().toISOString(),
     };
 
-    await insertRoute(route, parsed.points);
-
-    // Detect and store climbs
-    const { detectAndStoreClimbs } = await import("@/services/climbDetector");
-    await detectAndStoreClimbs(route.id, parsed.points);
+    // Build climbs before changing the database, then persist the route, its
+    // geometry, and climbs in one transaction. A failed import therefore
+    // cannot leave a route that the UI reported as failed.
+    const { detectClimbsForRoute } = await import("@/services/climbDetector");
+    const climbs = await detectClimbsForRoute(route.id, parsed.points);
+    await insertRoute(route, parsed.points, climbs);
     scheduleRouteETAPrewarm(route, parsed.points);
 
     await get().loadRouteMetadata();

--- a/tests/store/routeStore.test.ts
+++ b/tests/store/routeStore.test.ts
@@ -3,16 +3,25 @@ import * as DocumentPicker from "expo-document-picker";
 import { databaseMocks } from "@/tests/mocks/database";
 import type { Route, RoutePoint } from "@/types";
 
+const { fileText, detectClimbsForRoute } = vi.hoisted(() => ({
+  fileText: vi.fn(),
+  detectClimbsForRoute: vi.fn(),
+}));
+
 vi.mock("expo-document-picker", () => ({
   getDocumentAsync: vi.fn(),
 }));
 
 vi.mock("expo-file-system", () => ({
   File: class {
-    text = vi.fn();
+    text = fileText;
     delete = vi.fn();
   },
   Paths: { cache: "" },
+}));
+
+vi.mock("@/services/climbDetector", () => ({
+  detectClimbsForRoute,
 }));
 
 import { useRouteStore } from "@/store/routeStore";
@@ -43,9 +52,17 @@ const point = (idx: number): RoutePoint => ({
   idx,
 });
 
+const validGpx = `<?xml version="1.0"?>
+<gpx><trk><name>Atomic route</name><trkseg>
+  <trkpt lat="48.1" lon="17.1"><ele>120</ele></trkpt>
+  <trkpt lat="48.2" lon="17.2"><ele>130</ele></trkpt>
+</trkseg></trk></gpx>`;
+
 describe("routeStore", () => {
   beforeEach(() => {
     vi.mocked(DocumentPicker.getDocumentAsync).mockReset();
+    fileText.mockReset();
+    detectClimbsForRoute.mockReset();
     useRouteStore.setState({
       routes: [],
       isLoading: false,
@@ -57,6 +74,55 @@ describe("routeStore", () => {
       importRoute: initialImportRoute,
       importFromUri: initialImportFromUri,
     });
+  });
+
+  it("commits the route, points, and detected climbs together", async () => {
+    const climbs = [
+      {
+        id: "climb-1",
+        routeId: "ignored",
+        name: null,
+        startDistanceMeters: 0,
+        endDistanceMeters: 1_000,
+        lengthMeters: 1_000,
+        totalAscentMeters: 100,
+        startElevationMeters: 100,
+        endElevationMeters: 200,
+        averageGradientPercent: 10,
+        maxGradientPercent: 12,
+        difficultyScore: 100,
+      },
+    ];
+    fileText.mockResolvedValue(validGpx);
+    detectClimbsForRoute.mockResolvedValue(climbs);
+
+    const imported = await useRouteStore.getState().importFromUri("file://route.gpx", "route.gpx");
+
+    expect(detectClimbsForRoute).toHaveBeenCalledWith(imported.id, expect.any(Array));
+    expect(databaseMocks.insertRoute).toHaveBeenCalledWith(imported, expect.any(Array), climbs);
+  });
+
+  it("does not persist a route when climb detection fails", async () => {
+    fileText.mockResolvedValue(validGpx);
+    detectClimbsForRoute.mockRejectedValue(new Error("Climb detection failed"));
+
+    await expect(
+      useRouteStore.getState().importFromUri("file://route.gpx", "route.gpx"),
+    ).rejects.toThrow("Climb detection failed");
+
+    expect(databaseMocks.insertRoute).not.toHaveBeenCalled();
+  });
+
+  it("reports a transactional persistence failure without treating the route as imported", async () => {
+    fileText.mockResolvedValue(validGpx);
+    detectClimbsForRoute.mockResolvedValue([]);
+    databaseMocks.insertRoute.mockRejectedValue(new Error("Route transaction failed"));
+
+    await expect(
+      useRouteStore.getState().importFromUri("file://route.gpx", "route.gpx"),
+    ).rejects.toThrow("Route transaction failed");
+
+    expect(databaseMocks.getAllRoutes).not.toHaveBeenCalled();
   });
 
   it("imports every selected route file and isolates per-file failures", async () => {

--- a/tests/utils/incomingUrlImport.test.ts
+++ b/tests/utils/incomingUrlImport.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { IncomingUrlImportGate } from "@/utils/incomingUrlImport";
+
+describe("IncomingUrlImportGate", () => {
+  it("retries the same URL after a failed import", async () => {
+    const gate = new IncomingUrlImportGate();
+    const importUrl = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("Temporary file access failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(gate.run("file://route.gpx", importUrl)).rejects.toThrow(
+      "Temporary file access failed",
+    );
+    await expect(gate.run("file://route.gpx", importUrl)).resolves.toBe(true);
+
+    expect(importUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not import a successful URL twice", async () => {
+    const gate = new IncomingUrlImportGate();
+    const importUrl = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+    await expect(gate.run("file://route.gpx", importUrl)).resolves.toBe(true);
+    await expect(gate.run("file://route.gpx", importUrl)).resolves.toBe(false);
+
+    expect(importUrl).toHaveBeenCalledOnce();
+  });
+
+  it("suppresses duplicate concurrent delivery", async () => {
+    const gate = new IncomingUrlImportGate();
+    let resolveImport: (() => void) | undefined;
+    const importUrl = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveImport = resolve;
+        }),
+    );
+
+    const firstImport = gate.run("file://route.gpx", importUrl);
+    await expect(gate.run("file://route.gpx", importUrl)).resolves.toBe(false);
+    resolveImport?.();
+    await expect(firstImport).resolves.toBe(true);
+
+    expect(importUrl).toHaveBeenCalledOnce();
+  });
+});

--- a/utils/incomingUrlImport.ts
+++ b/utils/incomingUrlImport.ts
@@ -1,0 +1,21 @@
+/**
+ * Deduplicates incoming file URLs without making a failed attempt permanent.
+ * URLs become handled only after their import operation completes successfully.
+ */
+export class IncomingUrlImportGate {
+  private readonly handledUrls = new Set<string>();
+  private readonly pendingUrls = new Set<string>();
+
+  async run(url: string, importUrl: () => Promise<void>): Promise<boolean> {
+    if (this.handledUrls.has(url) || this.pendingUrls.has(url)) return false;
+
+    this.pendingUrls.add(url);
+    try {
+      await importUrl();
+      this.handledUrls.add(url);
+      return true;
+    } finally {
+      this.pendingUrls.delete(url);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- persist each imported route, its points, and its detected climbs in one SQLite transaction
- prepare climb records before persistence so detection failures do not create partial routes
- retry failed incoming file URLs while preventing concurrent and successful duplicate imports
- add regression coverage for import failures and URL delivery behavior

## Root cause
Route persistence completed before climb detection and persistence, while incoming URLs were recorded as handled before their import result was known. This could leave a route behind after a reported failure and block a safe retry.

## Verification
- `npx tsc --noEmit`
- `npm run lint`
- `npm run format:check`
- `npm test` (229 tests)

Fixes #42