### PR TITLE
Restore long-route memory guarantees

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -8,11 +8,9 @@ import { useThemeColors } from "@/theme";
 import { useSettingsStore } from "@/store/settingsStore";
 import { useEtaStore } from "@/store/etaStore";
 import { usePoiStore } from "@/store/poiStore";
-import { useRouteStore } from "@/store/routeStore";
-import { useCollectionStore } from "@/store/collectionStore";
-import { useClimbStore } from "@/store/climbStore";
 import { solveVelocity } from "@/services/powerModel";
 import { pickAndImportPlanningDatabase, sharePlanningDatabase } from "@/services/planningTransport";
+import { refreshPlanningDataAfterImport } from "@/services/planningDataRefresh";
 import { POI_DISCOVERY_GROUPS } from "@/constants";
 import type { UnitSystem } from "@/types";
 import StorageSection from "@/components/offline/StorageSection";
@@ -174,14 +172,7 @@ export default function SettingsScreen() {
   }, [powerConfig]);
 
   const refreshPlanningData = useCallback(async () => {
-    useRouteStore.setState({ visibleRoutePoints: {}, snappedPosition: null, snapHistory: [] });
-    usePoiStore.setState({ pois: {}, selectedPOI: null });
-    useClimbStore.getState().clearClimbCache();
-    await Promise.all([
-      useRouteStore.getState().loadRoutesAndPoints(),
-      useCollectionStore.getState().loadCollections(),
-      usePoiStore.getState().loadStarredItems(),
-    ]);
+    await refreshPlanningDataAfterImport();
   }, []);
 
   const handleExportPlanningDatabase = useCallback(async () => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,9 +14,9 @@ import { useOfflineStore } from "@/store/offlineStore";
 import { useRouteStore } from "@/store/routeStore";
 import { useCollectionStore } from "@/store/collectionStore";
 import { usePoiStore } from "@/store/poiStore";
-import { useClimbStore } from "@/store/climbStore";
 import { COLORS } from "@/theme";
 import { IncomingUrlImportGate } from "@/utils/incomingUrlImport";
+import { refreshPlanningDataAfterImport } from "@/services/planningDataRefresh";
 
 export { ErrorBoundary } from "expo-router";
 
@@ -115,18 +115,7 @@ export default function RootLayout() {
         if (isPlanningDb) {
           const { importPlanningDatabaseFromUri } = await import("@/services/planningTransport");
           const summary = await importPlanningDatabaseFromUri(url);
-          useRouteStore.setState({
-            visibleRoutePoints: {},
-            snappedPosition: null,
-            snapHistory: [],
-          });
-          usePoiStore.setState({ pois: {}, selectedPOI: null });
-          useClimbStore.getState().clearClimbCache();
-          await Promise.all([
-            useRouteStore.getState().loadRoutesAndPoints(),
-            useCollectionStore.getState().loadCollections(),
-            usePoiStore.getState().loadStarredItems(),
-          ]);
+          await refreshPlanningDataAfterImport();
           Alert.alert(
             "Planner Import Complete",
             `Merged ${summary.routes} routes, ${summary.collections} collections, and ${summary.pois} POIs.`,

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -22,7 +22,6 @@ import type { VariantOverlay } from "./VariantOverlayLayer";
 import TabbedBottomPanel from "./TabbedBottomPanel";
 import { getWebMapCameraPadding } from "./webPanelLayout";
 import { displayPOIsForActiveRoute } from "@/services/activePOIs";
-import { computeCachedRouteTotalETA } from "@/services/etaCalculator";
 import { stitchedSegmentsCacheSignature } from "@/services/relativeEtaCache";
 import { resolveActiveRouteProgress } from "@/utils/routeProgress";
 import { plannedStopsFromPOIs } from "@/services/plannedStops";
@@ -36,12 +35,12 @@ import { useWeatherStore } from "@/store/weatherStore";
 import { useOfflineStore } from "@/store/offlineStore";
 import { useSettingsStore } from "@/store/settingsStore";
 import {
-  buildPatchVariantRoutePoints,
-  routeEndDistance,
-  sliceRoutePointsByDistance,
-} from "@/services/stitchingService";
+  collectionVariantKey,
+  loadCollectionVariantDisplayData,
+  type CollectionVariantMetric,
+} from "@/services/collectionVariantGeometry";
+import { routeEndDistance } from "@/services/stitchingService";
 import {
-  computeSliceAscentFromDistance,
   estimateMapVisibleSpanMeters,
   findFirstPointAtOrAfterDistance,
   haversineDistance,
@@ -61,12 +60,6 @@ import {
 import { measureSync } from "@/utils/perfMarks";
 import { pickRouteRecords } from "@/utils/routeScopedRecords";
 import type { CollectionSegmentWithRoute, RoutePoint, UnitSystem, UserPosition } from "@/types";
-
-interface VariantMetric {
-  distanceMeters: number;
-  ascentMeters: number;
-  ridingTime: number | null;
-}
 
 interface MapCameraHandle {
   setCamera(options: {
@@ -298,73 +291,6 @@ function groupCollectionSegments(
   return [...grouped.entries()].sort(([a], [b]) => a - b).map(([, variants]) => variants);
 }
 
-function effectiveVariantPoints(
-  sw: CollectionSegmentWithRoute,
-  pointsByRouteId: Record<string, RoutePoint[]>,
-): RoutePoint[] | null {
-  const routePoints = pointsByRouteId[sw.route.id];
-  if (sw.segment.variantKind !== "patch") return routePoints ?? null;
-
-  const { baseRouteId, replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
-  if (
-    !baseRouteId ||
-    replaceStartDistanceMeters == null ||
-    replaceEndDistanceMeters == null ||
-    !routePoints
-  ) {
-    return routePoints ?? null;
-  }
-
-  const basePoints = pointsByRouteId[baseRouteId];
-  if (!basePoints) return routePoints;
-  const stitched = buildPatchVariantRoutePoints(
-    basePoints,
-    routePoints,
-    replaceStartDistanceMeters,
-    replaceEndDistanceMeters,
-  );
-  return stitched.length >= 2 ? stitched : routePoints;
-}
-
-function effectiveVariantAscentMeters(
-  sw: CollectionSegmentWithRoute,
-  pointsByRouteId: Record<string, RoutePoint[]>,
-): number {
-  const { baseRouteId, replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
-  if (
-    sw.segment.variantKind === "patch" &&
-    baseRouteId &&
-    replaceStartDistanceMeters != null &&
-    replaceEndDistanceMeters != null
-  ) {
-    const basePoints = pointsByRouteId[baseRouteId];
-    if (basePoints?.length) {
-      const baseEnd = routeEndDistance(basePoints);
-      return (
-        computeSliceAscentFromDistance(basePoints, 0, replaceStartDistanceMeters) +
-        sw.route.totalAscentMeters +
-        computeSliceAscentFromDistance(basePoints, replaceEndDistanceMeters, baseEnd)
-      );
-    }
-  }
-  return sw.route.totalAscentMeters;
-}
-
-function variantMetric(
-  sw: CollectionSegmentWithRoute,
-  pointsByRouteId: Record<string, RoutePoint[]>,
-  powerConfig: ReturnType<typeof useEtaStore.getState>["powerConfig"],
-  metricKey: string,
-): VariantMetric | null {
-  const points = effectiveVariantPoints(sw, pointsByRouteId);
-  if (!points || points.length < 2) return null;
-  return {
-    distanceMeters: routeEndDistance(points),
-    ascentMeters: effectiveVariantAscentMeters(sw, pointsByRouteId),
-    ridingTime: computeCachedRouteTotalETA(metricKey, points, powerConfig),
-  };
-}
-
 function signedDistance(deltaMeters: number, units: UnitSystem): string {
   if (Math.abs(deltaMeters) < 1) return "±0 m";
   return `${deltaMeters > 0 ? "+" : "-"}${formatDistance(Math.abs(deltaMeters), units)}`;
@@ -381,7 +307,11 @@ function signedDuration(deltaSeconds: number | null): string {
   return `ETA ${deltaSeconds > 0 ? "+" : "-"}${formatDuration(Math.abs(deltaSeconds))}`;
 }
 
-function variantDiffLabel(metric: VariantMetric, reference: VariantMetric, units: UnitSystem) {
+function variantDiffLabel(
+  metric: CollectionVariantMetric,
+  reference: CollectionVariantMetric,
+  units: UnitSystem,
+) {
   const timeDelta =
     metric.ridingTime != null && reference.ridingTime != null
       ? metric.ridingTime - reference.ridingTime
@@ -391,10 +321,6 @@ function variantDiffLabel(metric: VariantMetric, reference: VariantMetric, units
     signedDistance(metric.distanceMeters - reference.distanceMeters, units),
     `↑ ${signedElevation(metric.ascentMeters - reference.ascentMeters, units)}`,
   ].join("\n");
-}
-
-function variantMetricKey(sw: CollectionSegmentWithRoute): string {
-  return `${sw.segment.collectionId}:${sw.segment.position}:${sw.route.id}:${sw.segment.variantKind}`;
 }
 
 function plannedStopsSignature(
@@ -471,11 +397,11 @@ export default function MapScreen() {
   const [activeCollectionSegments, setActiveCollectionSegments] = useState<
     CollectionSegmentWithRoute[]
   >([]);
-  const [activeVariantPointsByRouteId, setActiveVariantPointsByRouteId] = useState<
+  const [activeVariantOverlayPointsByKey, setActiveVariantOverlayPointsByKey] = useState<
     Record<string, RoutePoint[]>
   >({});
   const [activeVariantMetricsByKey, setActiveVariantMetricsByKey] = useState<
-    Record<string, VariantMetric>
+    Record<string, CollectionVariantMetric>
   >({});
 
   // Unified active context — works for both standalone routes and collections
@@ -610,42 +536,43 @@ export default function MapScreen() {
     async function loadActiveCollectionVariants() {
       if (activeData?.type !== "collection") {
         setActiveCollectionSegments([]);
-        setActiveVariantPointsByRouteId({});
+        setActiveVariantOverlayPointsByKey({});
         setActiveVariantMetricsByKey({});
         return;
       }
 
       const segments = await getCollectionSegmentsWithRoutes(activeData.id);
-      const routeIds = new Set<string>();
-      for (const sw of segments) {
-        routeIds.add(sw.route.id);
-        if (sw.segment.baseRouteId) routeIds.add(sw.segment.baseRouteId);
-      }
-
       const { getRoutePoints } = await import("@/db/database");
-      const ids = [...routeIds];
-      const points = await Promise.all(ids.map((routeId) => getRoutePoints(routeId)));
+      const displayData = await loadCollectionVariantDisplayData(
+        segments,
+        powerConfig,
+        getRoutePoints,
+      );
       if (cancelled) return;
 
-      const pointsByRouteId: Record<string, RoutePoint[]> = {};
-      for (let i = 0; i < ids.length; i++) {
-        pointsByRouteId[ids[i]] = points[i];
-      }
       setActiveCollectionSegments(segments);
-      setActiveVariantPointsByRouteId(pointsByRouteId);
+      setActiveVariantOverlayPointsByKey(displayData.overlayPointsByKey);
+      setActiveVariantMetricsByKey(displayData.metricsByKey);
     }
 
     loadActiveCollectionVariants().catch((e) => {
       if (cancelled) return;
       console.warn("Failed to load active collection variants:", e);
       setActiveCollectionSegments([]);
-      setActiveVariantPointsByRouteId({});
+      setActiveVariantOverlayPointsByKey({});
+      setActiveVariantMetricsByKey({});
     });
 
     return () => {
       cancelled = true;
     };
-  }, [activeData?.id, activeData?.type, activeSegmentsKey, getCollectionSegmentsWithRoutes]);
+  }, [
+    activeData?.id,
+    activeData?.type,
+    activeSegmentsKey,
+    getCollectionSegmentsWithRoutes,
+    powerConfig,
+  ]);
 
   const loadClimbs = useClimbStore((s) => s.loadClimbs);
   const updateCurrentClimb = useClimbStore((s) => s.updateCurrentClimb);
@@ -985,55 +912,20 @@ export default function MapScreen() {
     return layers;
   }, [renderedRoutes, preparedRouteGeometries, activeCollectionRouteId, mapStyle.styleKey]);
 
-  useEffect(() => {
-    if (activeData?.type !== "collection" || activeCollectionSegments.length === 0) {
-      setActiveVariantMetricsByKey({});
-      return;
-    }
-    const metrics: Record<string, VariantMetric> = {};
-    measureSync("map.variantMetrics", () => {
-      for (const variants of groupCollectionSegments(activeCollectionSegments)) {
-        for (const sw of variants) {
-          const metric = variantMetric(
-            sw,
-            activeVariantPointsByRouteId,
-            powerConfig,
-            variantMetricKey(sw),
-          );
-          if (metric) metrics[variantMetricKey(sw)] = metric;
-        }
-      }
-    });
-    setActiveVariantMetricsByKey(metrics);
-  }, [activeData?.type, activeCollectionSegments, activeVariantPointsByRouteId, powerConfig]);
-
   const activeVariantOverlays = useMemo<VariantOverlay[]>(() => {
     if (activeData?.type !== "collection" || activeCollectionSegments.length === 0) return [];
     const overlays: VariantOverlay[] = [];
     for (const variants of groupCollectionSegments(activeCollectionSegments)) {
       if (variants.length <= 1) continue;
       const reference = variants.find((sw) => sw.segment.isSelected) ?? variants[0];
-      const referenceMetric = activeVariantMetricsByKey[variantMetricKey(reference)];
+      const referenceMetric = activeVariantMetricsByKey[collectionVariantKey(reference)];
       if (!referenceMetric) continue;
 
       for (const sw of variants) {
         if (sw.segment.isSelected) continue;
-        const rawPoints = activeVariantPointsByRouteId[sw.route.id];
-        const points =
-          rawPoints &&
-          sw.segment.variantKind === "full" &&
-          reference.segment.variantKind === "patch" &&
-          reference.segment.baseRouteId === sw.route.id &&
-          reference.segment.replaceStartDistanceMeters != null &&
-          reference.segment.replaceEndDistanceMeters != null
-            ? sliceRoutePointsByDistance(
-                rawPoints,
-                reference.segment.replaceStartDistanceMeters,
-                reference.segment.replaceEndDistanceMeters,
-              )
-            : rawPoints;
+        const points = activeVariantOverlayPointsByKey[collectionVariantKey(sw)];
         if (!points || points.length < 2) continue;
-        const metric = activeVariantMetricsByKey[variantMetricKey(sw)];
+        const metric = activeVariantMetricsByKey[collectionVariantKey(sw)];
         if (!metric) continue;
         overlays.push({
           id: sw.route.id,
@@ -1046,7 +938,7 @@ export default function MapScreen() {
   }, [
     activeData?.type,
     activeCollectionSegments,
-    activeVariantPointsByRouteId,
+    activeVariantOverlayPointsByKey,
     activeVariantMetricsByKey,
     units,
   ]);

--- a/docs/performance-notes.md
+++ b/docs/performance-notes.md
@@ -1,6 +1,6 @@
 # Performance Notes
 
-Issue 18 focused on long ultra-distance routes and active collections. This document describes the intended memory model and calls out current regressions explicitly.
+Issue 18 focused on long ultra-distance routes and active collections. This document describes the implemented memory ownership and loading contract.
 
 ## Route Point Loading
 
@@ -8,7 +8,7 @@ Before: app startup and the map tab called `loadRoutesAndPoints()`, which loaded
 
 After: normal startup loads route metadata only. The map tab lazy-loads full points only for the active standalone route, while active collections are loaded through the collection stitching path. Route and collection detail screens still load full geometry when opened explicitly.
 
-Current exception: importing a planner database refreshes through `loadRoutesAndPoints()`, temporarily loading points for every visible route. This is a regression from the intended metadata-first startup model and is tracked in [#43](https://github.com/conqeror/ultra-companion/issues/43).
+Planner import follows the same contract: it clears stale view state, reloads route metadata, and loads points only for an active standalone route. An active collection loads its selected stitched geometry through the collection store; no unrelated visible route points are populated.
 
 Representative memory shape:
 
@@ -22,7 +22,7 @@ Before: collection activation stored both a stitched full-resolution point array
 
 After: active collection stitching omits `pointsByRouteId`, loads selected segments sequentially, and keeps only the stitched points plus segment offsets in the active collection view model. Collection detail still requests raw per-segment points because the planning screen needs mini-map routes and per-segment ETA rows.
 
-Current exception: the active map also loads raw geometry for collection positions that have variants so it can draw base and alternative overlays. The implementation currently fetches more raw routes than the overlay requires; this long-route memory regression is tracked in [#43](https://github.com/conqeror/ultra-companion/issues/43).
+The active map queries geometry only for collection positions that have alternatives, plus a patch variant's base route when it is needed to calculate its effective metric. It loads those routes sequentially, computes metric labels, and retains only the alternative line geometry that Mapbox renders. Raw selected/base arrays are released after preparation; positions without variants issue no route-point queries.
 
 Representative 3 × 100k-point collection:
 

--- a/services/collectionVariantGeometry.ts
+++ b/services/collectionVariantGeometry.ts
@@ -1,0 +1,152 @@
+import { computeCachedRouteTotalETA } from "@/services/etaCalculator";
+import {
+  buildPatchVariantRoutePoints,
+  routeEndDistance,
+  sliceRoutePointsByDistance,
+} from "@/services/stitchingService";
+import { computeSliceAscentFromDistance } from "@/utils/geo";
+import type { CollectionSegmentWithRoute, PowerModelConfig, RoutePoint } from "@/types";
+
+export interface CollectionVariantMetric {
+  distanceMeters: number;
+  ascentMeters: number;
+  ridingTime: number | null;
+}
+
+export interface CollectionVariantDisplayData {
+  metricsByKey: Record<string, CollectionVariantMetric>;
+  overlayPointsByKey: Record<string, RoutePoint[]>;
+}
+
+export type LoadRoutePoints = (routeId: string) => Promise<RoutePoint[]>;
+
+export function collectionVariantKey(sw: CollectionSegmentWithRoute): string {
+  return `${sw.segment.collectionId}:${sw.segment.position}:${sw.route.id}:${sw.segment.variantKind}`;
+}
+
+function groupCollectionSegments(
+  segments: CollectionSegmentWithRoute[],
+): CollectionSegmentWithRoute[][] {
+  const grouped = new Map<number, CollectionSegmentWithRoute[]>();
+  for (const sw of segments) {
+    if (!grouped.has(sw.segment.position)) grouped.set(sw.segment.position, []);
+    grouped.get(sw.segment.position)!.push(sw);
+  }
+  return [...grouped.entries()].sort(([a], [b]) => a - b).map(([, variants]) => variants);
+}
+
+function effectiveVariantPoints(
+  sw: CollectionSegmentWithRoute,
+  pointsByRouteId: Record<string, RoutePoint[]>,
+): RoutePoint[] | null {
+  const routePoints = pointsByRouteId[sw.route.id];
+  if (sw.segment.variantKind !== "patch") return routePoints ?? null;
+
+  const { baseRouteId, replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
+  if (
+    !baseRouteId ||
+    replaceStartDistanceMeters == null ||
+    replaceEndDistanceMeters == null ||
+    !routePoints
+  ) {
+    return routePoints ?? null;
+  }
+
+  const basePoints = pointsByRouteId[baseRouteId];
+  if (!basePoints) return routePoints;
+  const stitched = buildPatchVariantRoutePoints(
+    basePoints,
+    routePoints,
+    replaceStartDistanceMeters,
+    replaceEndDistanceMeters,
+  );
+  return stitched.length >= 2 ? stitched : routePoints;
+}
+
+function effectiveVariantAscentMeters(
+  sw: CollectionSegmentWithRoute,
+  pointsByRouteId: Record<string, RoutePoint[]>,
+): number {
+  const { baseRouteId, replaceStartDistanceMeters, replaceEndDistanceMeters } = sw.segment;
+  if (
+    sw.segment.variantKind === "patch" &&
+    baseRouteId &&
+    replaceStartDistanceMeters != null &&
+    replaceEndDistanceMeters != null
+  ) {
+    const basePoints = pointsByRouteId[baseRouteId];
+    if (basePoints?.length) {
+      const baseEnd = routeEndDistance(basePoints);
+      return (
+        computeSliceAscentFromDistance(basePoints, 0, replaceStartDistanceMeters) +
+        sw.route.totalAscentMeters +
+        computeSliceAscentFromDistance(basePoints, replaceEndDistanceMeters, baseEnd)
+      );
+    }
+  }
+  return sw.route.totalAscentMeters;
+}
+
+/**
+ * Fetch only variant positions. Raw arrays exist only while their metrics are
+ * calculated; returned arrays are the exact geometry the overlay draws.
+ */
+export async function loadCollectionVariantDisplayData(
+  segments: CollectionSegmentWithRoute[],
+  powerConfig: PowerModelConfig,
+  loadRoutePoints: LoadRoutePoints,
+): Promise<CollectionVariantDisplayData> {
+  const metricsByKey: Record<string, CollectionVariantMetric> = {};
+  const overlayPointsByKey: Record<string, RoutePoint[]> = {};
+
+  for (const variants of groupCollectionSegments(segments)) {
+    if (variants.length <= 1) continue;
+
+    const routeIds = new Set<string>();
+    for (const sw of variants) {
+      routeIds.add(sw.route.id);
+      if (sw.segment.variantKind === "patch" && sw.segment.baseRouteId) {
+        routeIds.add(sw.segment.baseRouteId);
+      }
+    }
+
+    // Sequential loading bounds the temporary raw geometry held while a
+    // large collection's variants are being prepared.
+    const pointsByRouteId: Record<string, RoutePoint[]> = {};
+    for (const routeId of routeIds) {
+      pointsByRouteId[routeId] = await loadRoutePoints(routeId);
+    }
+
+    for (const sw of variants) {
+      const points = effectiveVariantPoints(sw, pointsByRouteId);
+      if (!points || points.length < 2) continue;
+      metricsByKey[collectionVariantKey(sw)] = {
+        distanceMeters: routeEndDistance(points),
+        ascentMeters: effectiveVariantAscentMeters(sw, pointsByRouteId),
+        ridingTime: computeCachedRouteTotalETA(collectionVariantKey(sw), points, powerConfig),
+      };
+    }
+
+    const reference = variants.find((sw) => sw.segment.isSelected) ?? variants[0];
+    for (const sw of variants) {
+      if (sw.segment.isSelected) continue;
+      const rawPoints = pointsByRouteId[sw.route.id];
+      const points =
+        rawPoints &&
+        sw.segment.variantKind === "full" &&
+        reference.segment.variantKind === "patch" &&
+        reference.segment.baseRouteId === sw.route.id &&
+        reference.segment.replaceStartDistanceMeters != null &&
+        reference.segment.replaceEndDistanceMeters != null
+          ? sliceRoutePointsByDistance(
+              rawPoints,
+              reference.segment.replaceStartDistanceMeters,
+              reference.segment.replaceEndDistanceMeters,
+            )
+          : rawPoints;
+      if (points?.length >= 2) overlayPointsByKey[collectionVariantKey(sw)] = points;
+    }
+  }
+
+  return { metricsByKey, overlayPointsByKey };
+}

--- a/services/planningDataRefresh.ts
+++ b/services/planningDataRefresh.ts
@@ -1,0 +1,60 @@
+export interface PlanningDataRefreshDependencies {
+  clearRouteViewState: () => void;
+  clearPoiViewState: () => void;
+  clearClimbCache: () => void;
+  loadRouteMetadata: () => Promise<void>;
+  activeStandaloneRouteId: () => string | null;
+  loadRoutePoints: (routeIds: string[], options: { prune: true }) => Promise<void>;
+  loadCollections: () => Promise<void>;
+  loadStarredItems: () => Promise<void>;
+}
+
+export async function refreshPlanningData(
+  dependencies: PlanningDataRefreshDependencies,
+): Promise<void> {
+  dependencies.clearRouteViewState();
+  dependencies.clearPoiViewState();
+  dependencies.clearClimbCache();
+
+  await dependencies.loadRouteMetadata();
+  const activeStandaloneRouteId = dependencies.activeStandaloneRouteId();
+
+  await Promise.all([
+    dependencies.loadRoutePoints(activeStandaloneRouteId ? [activeStandaloneRouteId] : [], {
+      prune: true,
+    }),
+    dependencies.loadCollections(),
+    dependencies.loadStarredItems(),
+  ]);
+}
+
+/**
+ * Reconcile in-memory state after importing a planner database without
+ * recreating the old "every visible route has points" memory shape.
+ *
+ * Collections own their selected stitched geometry. A standalone active route
+ * is the only route allowed into the route point cache during this refresh.
+ */
+export async function refreshPlanningDataAfterImport(): Promise<void> {
+  const [{ useClimbStore }, { useCollectionStore }, { usePoiStore }, { useRouteStore }] =
+    await Promise.all([
+      import("@/store/climbStore"),
+      import("@/store/collectionStore"),
+      import("@/store/poiStore"),
+      import("@/store/routeStore"),
+    ]);
+
+  await refreshPlanningData({
+    clearRouteViewState: () =>
+      useRouteStore.setState({ visibleRoutePoints: {}, snappedPosition: null, snapHistory: [] }),
+    clearPoiViewState: () => usePoiStore.setState({ pois: {}, selectedPOI: null }),
+    clearClimbCache: () => useClimbStore.getState().clearClimbCache(),
+    loadRouteMetadata: () => useRouteStore.getState().loadRouteMetadata(),
+    activeStandaloneRouteId: () =>
+      useRouteStore.getState().routes.find((route) => route.isActive)?.id ?? null,
+    loadRoutePoints: (routeIds, options) =>
+      useRouteStore.getState().loadRoutePoints(routeIds, options),
+    loadCollections: () => useCollectionStore.getState().loadCollections(),
+    loadStarredItems: () => usePoiStore.getState().loadStarredItems(),
+  });
+}

--- a/tests/services/collectionVariantGeometry.test.ts
+++ b/tests/services/collectionVariantGeometry.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_POWER_CONFIG } from "@/constants";
+import {
+  collectionVariantKey,
+  loadCollectionVariantDisplayData,
+} from "@/services/collectionVariantGeometry";
+import type { CollectionSegmentWithRoute, Route, RoutePoint } from "@/types";
+
+const points = (id: number, length = 1_000): RoutePoint[] => [
+  { latitude: id, longitude: 0, elevationMeters: 100, distanceFromStartMeters: 0, idx: 0 },
+  {
+    latitude: id + 0.01,
+    longitude: 0.01,
+    elevationMeters: 120,
+    distanceFromStartMeters: length,
+    idx: 1,
+  },
+];
+
+const route = (id: string, length = 1_000): Route => ({
+  id,
+  name: id,
+  fileName: `${id}.gpx`,
+  color: "#fff",
+  isActive: false,
+  isVisible: true,
+  totalDistanceMeters: length,
+  totalAscentMeters: 20,
+  totalDescentMeters: 0,
+  pointCount: 2,
+  createdAt: "2026-01-01T00:00:00.000Z",
+});
+
+const segment = (
+  routeId: string,
+  position: number,
+  options: Partial<CollectionSegmentWithRoute["segment"]> = {},
+): CollectionSegmentWithRoute => ({
+  route: route(routeId),
+  segment: {
+    collectionId: "c1",
+    routeId,
+    position,
+    isSelected: false,
+    variantKind: "full",
+    baseRouteId: null,
+    replaceStartDistanceMeters: null,
+    replaceEndDistanceMeters: null,
+    ...options,
+  },
+});
+
+describe("loadCollectionVariantDisplayData", () => {
+  it("does not query any geometry for collection positions without variants", async () => {
+    const loadRoutePoints = vi.fn<(routeId: string) => Promise<RoutePoint[]>>();
+
+    const result = await loadCollectionVariantDisplayData(
+      [segment("r1", 0, { isSelected: true }), segment("r2", 1, { isSelected: true })],
+      DEFAULT_POWER_CONFIG,
+      loadRoutePoints,
+    );
+
+    expect(loadRoutePoints).not.toHaveBeenCalled();
+    expect(result).toEqual({ metricsByKey: {}, overlayPointsByKey: {} });
+  });
+
+  it("loads only a variant position and retains only its alternative overlay", async () => {
+    const selected = segment("r1", 0, { isSelected: true });
+    const alternative = segment("r1-alt", 0);
+    const unrelated = segment("r2", 1, { isSelected: true });
+    const geometry = { r1: points(1), "r1-alt": points(2), r2: points(3) };
+    const loadRoutePoints = vi.fn(
+      async (routeId: string) => geometry[routeId as keyof typeof geometry],
+    );
+
+    const result = await loadCollectionVariantDisplayData(
+      [selected, alternative, unrelated],
+      DEFAULT_POWER_CONFIG,
+      loadRoutePoints,
+    );
+
+    expect(loadRoutePoints.mock.calls.map(([routeId]) => routeId)).toEqual(["r1", "r1-alt"]);
+    expect(result.metricsByKey).toEqual(
+      expect.objectContaining({
+        [collectionVariantKey(selected)]: expect.any(Object),
+        [collectionVariantKey(alternative)]: expect.any(Object),
+      }),
+    );
+    expect(result.overlayPointsByKey).toEqual({
+      [collectionVariantKey(alternative)]: geometry["r1-alt"],
+    });
+  });
+
+  it("loads a patch base only when that variant needs it and slices the full-route overlay", async () => {
+    const base = segment("base", 0);
+    const patch = segment("patch", 0, {
+      isSelected: true,
+      variantKind: "patch",
+      baseRouteId: "base",
+      replaceStartDistanceMeters: 250,
+      replaceEndDistanceMeters: 750,
+    });
+    const basePoints = [
+      { latitude: 0, longitude: 0, elevationMeters: 100, distanceFromStartMeters: 0, idx: 0 },
+      { latitude: 0, longitude: 0.01, elevationMeters: 120, distanceFromStartMeters: 500, idx: 1 },
+      {
+        latitude: 0,
+        longitude: 0.02,
+        elevationMeters: 140,
+        distanceFromStartMeters: 1_000,
+        idx: 2,
+      },
+    ];
+    const loadRoutePoints = vi.fn(async (routeId: string) =>
+      routeId === "base" ? basePoints : points(1, 500),
+    );
+
+    const result = await loadCollectionVariantDisplayData(
+      [base, patch],
+      DEFAULT_POWER_CONFIG,
+      loadRoutePoints,
+    );
+
+    expect(loadRoutePoints.mock.calls.map(([routeId]) => routeId)).toEqual(["base", "patch"]);
+    expect(
+      result.overlayPointsByKey[collectionVariantKey(base)]?.map(
+        (point) => point.distanceFromStartMeters,
+      ),
+    ).toEqual([250, 500, 750]);
+  });
+});

--- a/tests/services/planningDataRefresh.test.ts
+++ b/tests/services/planningDataRefresh.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { databaseMocks } from "@/tests/mocks/database";
+import { refreshPlanningData } from "@/services/planningDataRefresh";
+import type { Route } from "@/types";
+
+const route = (id: string, isActive = false): Route => ({
+  id,
+  name: id,
+  fileName: `${id}.gpx`,
+  color: "#fff",
+  isActive,
+  isVisible: true,
+  totalDistanceMeters: 1_000,
+  totalAscentMeters: 100,
+  totalDescentMeters: 50,
+  pointCount: 2,
+  createdAt: "2026-01-01T00:00:00.000Z",
+});
+
+describe("refreshPlanningData", () => {
+  it("loads metadata and only the active standalone route's points", async () => {
+    let routes: Route[] = [];
+    const loadRouteMetadata = vi.fn(async () => {
+      routes = [route("active", true), route("visible-a"), route("visible-b")];
+    });
+    const loadRoutePoints = vi.fn(async (routeIds: string[]) => {
+      await Promise.all(routeIds.map((routeId) => databaseMocks.getRoutePoints(routeId)));
+    });
+
+    await refreshPlanningData({
+      clearRouteViewState: vi.fn(),
+      clearPoiViewState: vi.fn(),
+      clearClimbCache: vi.fn(),
+      loadRouteMetadata,
+      activeStandaloneRouteId: () => routes.find((item) => item.isActive)?.id ?? null,
+      loadRoutePoints,
+      loadCollections: vi.fn().mockResolvedValue(undefined),
+      loadStarredItems: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(loadRouteMetadata).toHaveBeenCalledTimes(1);
+    expect(loadRoutePoints).toHaveBeenCalledWith(["active"], { prune: true });
+    expect(databaseMocks.getRoutePoints).toHaveBeenCalledTimes(1);
+    expect(databaseMocks.getRoutePoints).toHaveBeenCalledWith("active");
+  });
+
+  it("does not populate visible route points when collection activation owns the geometry", async () => {
+    const loadRoutePoints = vi.fn().mockResolvedValue(undefined);
+
+    await refreshPlanningData({
+      clearRouteViewState: vi.fn(),
+      clearPoiViewState: vi.fn(),
+      clearClimbCache: vi.fn(),
+      loadRouteMetadata: vi.fn().mockResolvedValue(undefined),
+      activeStandaloneRouteId: () => null,
+      loadRoutePoints,
+      loadCollections: vi.fn().mockResolvedValue(undefined),
+      loadStarredItems: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(loadRoutePoints).toHaveBeenCalledWith([], { prune: true });
+    expect(databaseMocks.getRoutePoints).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- keep planner database imports metadata-first and load only the active standalone route’s geometry
- load collection variant geometry only for positions with alternatives, retaining just the overlay lines after metric calculation
- document the memory ownership contract and add planner-refresh and collection-activation regression coverage

## Root cause
Planner imports called `loadRoutesAndPoints()`, which repopulated every visible route’s full geometry. The map fetched and retained raw points for every collection segment even when no variant overlay needed them.

## Verification
- `npx tsc --noEmit`
- `npm test` (228 tests)
- `npm run format:check`
- targeted `oxlint` for changed files
- simulator smoke script attempted but no simulator was available in this environment

Fixes #43